### PR TITLE
Add SQLite inbox and cron jobs pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ode",
-  "version": "0.1.22",
+  "version": "0.1.23",
   "description": "Coding anywhere with your coding agents connected",
   "module": "packages/core/index.ts",
   "type": "module",

--- a/packages/config/local/cron-jobs.ts
+++ b/packages/config/local/cron-jobs.ts
@@ -1,0 +1,413 @@
+import { Database } from "bun:sqlite";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { loadOdeConfig } from "./ode-store";
+import { validateCronExpression } from "@/core/cron/expression";
+
+export type CronJobPlatform = "slack" | "discord" | "lark";
+export type CronJobRunStatus = "idle" | "running" | "success" | "failed";
+
+export type CronJobRecord = {
+  id: string;
+  title: string;
+  cronExpression: string;
+  platform: CronJobPlatform;
+  workspaceId: string | null;
+  workspaceName: string | null;
+  channelId: string;
+  channelName: string | null;
+  messageText: string;
+  enabled: boolean;
+  lastTriggeredAt: number | null;
+  lastCompletedAt: number | null;
+  lastRunStatus: CronJobRunStatus;
+  lastError: string | null;
+  createdAt: number;
+  updatedAt: number;
+};
+
+export type CronJobChannelOption = {
+  value: string;
+  platform: CronJobPlatform;
+  workspaceId: string;
+  workspaceName: string;
+  channelId: string;
+  channelName: string;
+  label: string;
+};
+
+export type CreateCronJobParams = {
+  title: string;
+  cronExpression: string;
+  channelId: string;
+  messageText: string;
+  enabled?: boolean;
+};
+
+type CronJobRow = {
+  id: string;
+  title: string;
+  cron_expression: string;
+  platform: CronJobPlatform;
+  workspace_id: string | null;
+  workspace_name: string | null;
+  channel_id: string;
+  channel_name: string | null;
+  message_text: string;
+  enabled: number;
+  last_triggered_at: number | null;
+  last_completed_at: number | null;
+  last_run_status: CronJobRunStatus;
+  last_error: string | null;
+  created_at: number;
+  updated_at: number;
+};
+
+const existsSync = fs.existsSync;
+const mkdirSync = fs.mkdirSync;
+const join = typeof path.join === "function" ? path.join : (...parts: string[]) => parts.join("/");
+const homedir = typeof os.homedir === "function" ? os.homedir : () => "";
+
+const ODE_CONFIG_DIR = join(homedir(), ".config", "ode");
+const DEFAULT_DB_FILE = join(ODE_CONFIG_DIR, "inbox.db");
+
+let cachedDatabase: { path: string; db: Database } | null = null;
+
+function resolveDbFile(): string {
+  const override = process.env.ODE_INBOX_DB_FILE?.trim();
+  return override && override.length > 0 ? override : DEFAULT_DB_FILE;
+}
+
+function ensureParentDir(filePath: string): void {
+  const dir = path.dirname(filePath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+}
+
+function initializeDatabase(db: Database): void {
+  db.exec("PRAGMA journal_mode = WAL;");
+  db.exec("PRAGMA busy_timeout = 5000;");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS cron_jobs (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      cron_expression TEXT NOT NULL,
+      platform TEXT NOT NULL,
+      workspace_id TEXT,
+      workspace_name TEXT,
+      channel_id TEXT NOT NULL,
+      channel_name TEXT,
+      message_text TEXT NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      last_triggered_at INTEGER,
+      last_completed_at INTEGER,
+      last_run_status TEXT NOT NULL DEFAULT 'idle',
+      last_error TEXT,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    );
+  `);
+  db.exec("CREATE INDEX IF NOT EXISTS idx_cron_jobs_enabled ON cron_jobs(enabled, updated_at DESC);");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_cron_jobs_channel_id ON cron_jobs(channel_id, updated_at DESC);");
+}
+
+function getDatabase(): Database {
+  const filePath = resolveDbFile();
+  if (cachedDatabase?.path === filePath) {
+    return cachedDatabase.db;
+  }
+
+  if (cachedDatabase) {
+    try {
+      cachedDatabase.db.close();
+    } catch {
+      // Ignore close errors on path switch.
+    }
+  }
+
+  ensureParentDir(filePath);
+  const db = new Database(filePath);
+  initializeDatabase(db);
+  cachedDatabase = { path: filePath, db };
+  return db;
+}
+
+function mapRow(row: CronJobRow): CronJobRecord {
+  return {
+    id: row.id,
+    title: row.title,
+    cronExpression: row.cron_expression,
+    platform: row.platform,
+    workspaceId: row.workspace_id,
+    workspaceName: row.workspace_name,
+    channelId: row.channel_id,
+    channelName: row.channel_name,
+    messageText: row.message_text,
+    enabled: row.enabled === 1,
+    lastTriggeredAt: row.last_triggered_at,
+    lastCompletedAt: row.last_completed_at,
+    lastRunStatus: row.last_run_status,
+    lastError: row.last_error,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+function resolveConfigChannelId(channelId: string): string {
+  const trimmed = channelId.trim();
+  if (!trimmed) return trimmed;
+  const delimiter = "::";
+  const index = trimmed.lastIndexOf(delimiter);
+  if (index < 0) return trimmed;
+  const raw = trimmed.slice(index + delimiter.length).trim();
+  return raw || trimmed;
+}
+
+function getChannelSnapshot(channelId: string): {
+  platform: CronJobPlatform;
+  workspaceId: string;
+  workspaceName: string;
+  channelId: string;
+  channelName: string;
+} {
+  const resolvedChannelId = resolveConfigChannelId(channelId);
+  const config = loadOdeConfig();
+  for (const workspace of config.workspaces) {
+    const channel = workspace.channelDetails.find((item) => item.id === resolvedChannelId);
+    if (!channel) continue;
+    return {
+      platform: workspace.type,
+      workspaceId: workspace.id,
+      workspaceName: workspace.name || workspace.id,
+      channelId: channel.id,
+      channelName: channel.name || channel.id,
+    };
+  }
+  throw new Error("Channel not found in configured workspaces");
+}
+
+function normalizeTitle(value: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error("Cron job title is required");
+  }
+  return normalized;
+}
+
+function normalizeCronExpression(value: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error("Cron expression is required");
+  }
+  validateCronExpression(normalized);
+  return normalized;
+}
+
+function normalizeMessageText(value: string): string {
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error("Cron job message is required");
+  }
+  return normalized;
+}
+
+function normalizeEnabled(value: boolean | undefined): boolean {
+  return value !== false;
+}
+
+export function listCronJobChannelOptions(): CronJobChannelOption[] {
+  const config = loadOdeConfig();
+  return config.workspaces.flatMap((workspace) =>
+    workspace.channelDetails.map((channel) => ({
+      value: `${workspace.id}::${channel.id}`,
+      platform: workspace.type,
+      workspaceId: workspace.id,
+      workspaceName: workspace.name || workspace.id,
+      channelId: channel.id,
+      channelName: channel.name || channel.id,
+      label: `${workspace.name || workspace.id} / ${channel.name || channel.id}`,
+    }))
+  );
+}
+
+export function listCronJobs(): CronJobRecord[] {
+  const db = getDatabase();
+  const rows = db.query(`
+    SELECT *
+    FROM cron_jobs
+    ORDER BY created_at DESC
+  `).all() as CronJobRow[];
+  return rows.map(mapRow);
+}
+
+export function listEnabledCronJobs(): CronJobRecord[] {
+  const db = getDatabase();
+  const rows = db.query(`
+    SELECT *
+    FROM cron_jobs
+    WHERE enabled = 1
+    ORDER BY created_at ASC
+  `).all() as CronJobRow[];
+  return rows.map(mapRow);
+}
+
+export function getCronJobById(id: string): CronJobRecord | null {
+  const db = getDatabase();
+  const row = db.query("SELECT * FROM cron_jobs WHERE id = ?").get(id) as CronJobRow | null;
+  return row ? mapRow(row) : null;
+}
+
+export function createCronJob(params: CreateCronJobParams): CronJobRecord {
+  const db = getDatabase();
+  const channel = getChannelSnapshot(params.channelId);
+  const now = Date.now();
+  const id = crypto.randomUUID();
+  const title = normalizeTitle(params.title);
+  const cronExpression = normalizeCronExpression(params.cronExpression);
+  const messageText = normalizeMessageText(params.messageText);
+  const enabled = normalizeEnabled(params.enabled);
+
+  db.query(`
+    INSERT INTO cron_jobs (
+      id,
+      title,
+      cron_expression,
+      platform,
+      workspace_id,
+      workspace_name,
+      channel_id,
+      channel_name,
+      message_text,
+      enabled,
+      last_run_status,
+      created_at,
+      updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'idle', ?, ?)
+  `).run(
+    id,
+    title,
+    cronExpression,
+    channel.platform,
+    channel.workspaceId,
+    channel.workspaceName,
+    channel.channelId,
+    channel.channelName,
+    messageText,
+    enabled ? 1 : 0,
+    now,
+    now
+  );
+
+  return getCronJobById(id)!;
+}
+
+export function updateCronJob(id: string, params: CreateCronJobParams): CronJobRecord {
+  const existing = getCronJobById(id);
+  if (!existing) {
+    throw new Error("Cron job not found");
+  }
+
+  const db = getDatabase();
+  const channel = getChannelSnapshot(params.channelId);
+  const title = normalizeTitle(params.title);
+  const cronExpression = normalizeCronExpression(params.cronExpression);
+  const messageText = normalizeMessageText(params.messageText);
+  const enabled = normalizeEnabled(params.enabled);
+  const now = Date.now();
+
+  db.query(`
+    UPDATE cron_jobs
+    SET
+      title = ?,
+      cron_expression = ?,
+      platform = ?,
+      workspace_id = ?,
+      workspace_name = ?,
+      channel_id = ?,
+      channel_name = ?,
+      message_text = ?,
+      enabled = ?,
+      updated_at = ?
+    WHERE id = ?
+  `).run(
+    title,
+    cronExpression,
+    channel.platform,
+    channel.workspaceId,
+    channel.workspaceName,
+    channel.channelId,
+    channel.channelName,
+    messageText,
+    enabled ? 1 : 0,
+    now,
+    id
+  );
+
+  return getCronJobById(id)!;
+}
+
+export function deleteCronJob(id: string): void {
+  const db = getDatabase();
+  db.query("DELETE FROM cron_jobs WHERE id = ?").run(id);
+}
+
+export function markCronJobTriggered(id: string, minuteStartMs: number): boolean {
+  const db = getDatabase();
+  const result = db.query(`
+    UPDATE cron_jobs
+    SET
+      last_triggered_at = ?,
+      last_run_status = 'running',
+      last_error = NULL,
+      updated_at = ?
+    WHERE id = ?
+      AND enabled = 1
+      AND (last_triggered_at IS NULL OR last_triggered_at < ?)
+  `).run(minuteStartMs, Date.now(), id, minuteStartMs);
+  return result.changes > 0;
+}
+
+export function markCronJobCompleted(id: string): void {
+  const db = getDatabase();
+  const now = Date.now();
+  db.query(`
+    UPDATE cron_jobs
+    SET
+      last_completed_at = ?,
+      last_run_status = 'success',
+      last_error = NULL,
+      updated_at = ?
+    WHERE id = ?
+  `).run(now, now, id);
+}
+
+export function markCronJobFailed(id: string, errorMessage: string): void {
+  const db = getDatabase();
+  const now = Date.now();
+  db.query(`
+    UPDATE cron_jobs
+    SET
+      last_run_status = 'failed',
+      last_error = ?,
+      updated_at = ?
+    WHERE id = ?
+  `).run(errorMessage, now, id);
+}
+
+export function clearCronJobsForTests(): void {
+  const db = getDatabase();
+  db.exec("DELETE FROM cron_jobs;");
+}
+
+export function closeCronJobDatabaseForTests(): void {
+  if (!cachedDatabase) return;
+  try {
+    cachedDatabase.db.close();
+  } catch {
+    // Ignore close errors in tests.
+  } finally {
+    cachedDatabase = null;
+  }
+}

--- a/packages/config/local/inbox.test.ts
+++ b/packages/config/local/inbox.test.ts
@@ -71,6 +71,8 @@ describe("local inbox store", () => {
     expect(page.items).toHaveLength(1);
     expect(page.items[0]?.id).toBe(id);
     expect(page.items[0]?.status).toBe("completed");
+    expect(page.items[0]?.sourceKind).toBe("user");
+    expect(page.items[0]?.cronJobId).toBeNull();
     expect(page.items[0]?.providerId).toBe("codex");
     expect(page.items[0]?.model).toBe("openai/gpt-5.4");
     expect(page.items[0]?.resultSummary?.includes("feature A shipped")).toBe(true);
@@ -80,5 +82,27 @@ describe("local inbox store", () => {
     expect(detail?.promptText).toContain("release notes");
     expect(detail?.resultText).toContain("feature C was removed");
     expect(detail?.context?.isFirstMessageInThread).toBe(true);
+  });
+
+  it("stores cron job source metadata", () => {
+    const id = "cron:job-1:123";
+
+    recordInboxRequest({
+      id,
+      platform: "slack",
+      sourceKind: "cron_job",
+      cronJobId: "job-1",
+      cronJobTitle: "Morning Sync",
+      channelId: "C-cron",
+      threadId: "cron-job:job-1",
+      replyThreadId: "cron-job:job-1",
+      promptText: "summarize overnight alerts",
+    });
+
+    const detail = getInboxRecordById(id);
+    expect(detail).not.toBeNull();
+    expect(detail?.sourceKind).toBe("cron_job");
+    expect(detail?.cronJobId).toBe("job-1");
+    expect(detail?.cronJobTitle).toBe("Morning Sync");
   });
 });

--- a/packages/config/local/inbox.ts
+++ b/packages/config/local/inbox.ts
@@ -5,10 +5,14 @@ import * as path from "path";
 import { loadOdeConfig } from "./ode-store";
 
 export type InboxRecordStatus = "pending" | "completed" | "failed";
+export type InboxRecordSourceKind = "user" | "cron_job";
 
 export type InboxRecordSummary = {
   id: string;
   status: InboxRecordStatus;
+  sourceKind: InboxRecordSourceKind;
+  cronJobId: string | null;
+  cronJobTitle: string | null;
   platform: "slack" | "discord" | "lark";
   workspaceId: string | null;
   workspaceName: string | null;
@@ -50,6 +54,9 @@ export type InboxPage = {
 export type CreateInboxRecordParams = {
   id: string;
   platform: "slack" | "discord" | "lark";
+  sourceKind?: InboxRecordSourceKind;
+  cronJobId?: string | null;
+  cronJobTitle?: string | null;
   channelId: string;
   rawChannelId?: string;
   threadId: string;
@@ -67,6 +74,9 @@ export type CreateInboxRecordParams = {
 type InboxRow = {
   id: string;
   status: InboxRecordStatus;
+  source_kind: InboxRecordSourceKind;
+  cron_job_id: string | null;
+  cron_job_title: string | null;
   platform: "slack" | "discord" | "lark";
   workspace_id: string | null;
   workspace_name: string | null;
@@ -115,6 +125,14 @@ function ensureParentDir(filePath: string): void {
   }
 }
 
+function ensureColumn(db: Database, tableName: string, columnName: string, definition: string): void {
+  const columns = db.query(`PRAGMA table_info(${tableName})`).all() as Array<{ name?: string }>;
+  if (columns.some((column) => column.name === columnName)) {
+    return;
+  }
+  db.exec(`ALTER TABLE ${tableName} ADD COLUMN ${columnName} ${definition};`);
+}
+
 function initializeDatabase(db: Database): void {
   db.exec("PRAGMA journal_mode = WAL;");
   db.exec("PRAGMA busy_timeout = 5000;");
@@ -122,6 +140,9 @@ function initializeDatabase(db: Database): void {
     CREATE TABLE IF NOT EXISTS inbox_records (
       id TEXT PRIMARY KEY,
       status TEXT NOT NULL,
+      source_kind TEXT NOT NULL DEFAULT 'user',
+      cron_job_id TEXT,
+      cron_job_title TEXT,
       platform TEXT NOT NULL,
       workspace_id TEXT,
       workspace_name TEXT,
@@ -147,10 +168,14 @@ function initializeDatabase(db: Database): void {
       completed_at INTEGER
     );
   `);
+  ensureColumn(db, "inbox_records", "source_kind", "TEXT NOT NULL DEFAULT 'user'");
+  ensureColumn(db, "inbox_records", "cron_job_id", "TEXT");
+  ensureColumn(db, "inbox_records", "cron_job_title", "TEXT");
   db.exec("CREATE INDEX IF NOT EXISTS idx_inbox_records_created_at ON inbox_records(created_at DESC);");
   db.exec("CREATE INDEX IF NOT EXISTS idx_inbox_records_channel_id ON inbox_records(channel_id, created_at DESC);");
   db.exec("CREATE INDEX IF NOT EXISTS idx_inbox_records_thread_id ON inbox_records(thread_id, created_at DESC);");
   db.exec("CREATE INDEX IF NOT EXISTS idx_inbox_records_status ON inbox_records(status, created_at DESC);");
+  db.exec("CREATE INDEX IF NOT EXISTS idx_inbox_records_source_kind ON inbox_records(source_kind, created_at DESC);");
 }
 
 function getDatabase(): Database {
@@ -243,6 +268,9 @@ function mapSummaryRow(row: InboxRow): InboxRecordSummary {
   return {
     id: row.id,
     status: row.status,
+    sourceKind: row.source_kind,
+    cronJobId: row.cron_job_id,
+    cronJobTitle: row.cron_job_title,
     platform: row.platform,
     workspaceId: row.workspace_id,
     workspaceName: row.workspace_name,
@@ -290,11 +318,15 @@ export function recordInboxRequest(params: CreateInboxRecordParams): string {
   const now = Date.now();
   const workspace = getWorkspaceChannelSnapshot(params.rawChannelId ?? params.channelId);
   const promptSummary = createSummary(params.promptText);
+  const sourceKind = params.sourceKind ?? "user";
 
   db.query(`
     INSERT INTO inbox_records (
       id,
       status,
+      source_kind,
+      cron_job_id,
+      cron_job_title,
       platform,
       workspace_id,
       workspace_name,
@@ -314,8 +346,11 @@ export function recordInboxRequest(params: CreateInboxRecordParams): string {
       context_json,
       created_at,
       updated_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ON CONFLICT(id) DO UPDATE SET
+      source_kind = excluded.source_kind,
+      cron_job_id = excluded.cron_job_id,
+      cron_job_title = excluded.cron_job_title,
       platform = excluded.platform,
       workspace_id = excluded.workspace_id,
       workspace_name = excluded.workspace_name,
@@ -337,6 +372,9 @@ export function recordInboxRequest(params: CreateInboxRecordParams): string {
   `).run(
     params.id,
     "pending",
+    sourceKind,
+    params.cronJobId ?? null,
+    params.cronJobTitle ?? null,
     params.platform,
     workspace.workspaceId,
     workspace.workspaceName,

--- a/packages/core/cron/expression.test.ts
+++ b/packages/core/cron/expression.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import { matchesCronExpression, validateCronExpression } from "@/core/cron/expression";
+
+describe("cron expression utilities", () => {
+  it("validates a standard five-field cron expression", () => {
+    expect(() => validateCronExpression("0 9 * * 1-5")).not.toThrow();
+  });
+
+  it("rejects invalid field counts", () => {
+    expect(() => validateCronExpression("0 9 * *")).toThrow("exactly 5 fields");
+  });
+
+  it("matches stepped and ranged expressions", () => {
+    const matchingDate = new Date(2026, 3, 20, 9, 0, 0, 0);
+    const nonMatchingDate = new Date(2026, 3, 20, 9, 5, 0, 0);
+
+    expect(matchesCronExpression("0-30/15 9 * * 1-5", matchingDate)).toBe(true);
+    expect(matchesCronExpression("0-30/15 9 * * 1-5", nonMatchingDate)).toBe(false);
+  });
+
+  it("treats 7 as sunday in day-of-week expressions", () => {
+    const sunday = new Date(2026, 3, 19, 10, 0, 0, 0);
+    expect(matchesCronExpression("0 10 * * 7", sunday)).toBe(true);
+  });
+});

--- a/packages/core/cron/expression.ts
+++ b/packages/core/cron/expression.ts
@@ -1,0 +1,125 @@
+export type CronFieldName = "minute" | "hour" | "dayOfMonth" | "month" | "dayOfWeek";
+
+type CronFieldSpec = {
+  name: CronFieldName;
+  min: number;
+  max: number;
+  allowSevenAsSunday?: boolean;
+};
+
+const CRON_FIELD_SPECS: CronFieldSpec[] = [
+  { name: "minute", min: 0, max: 59 },
+  { name: "hour", min: 0, max: 23 },
+  { name: "dayOfMonth", min: 1, max: 31 },
+  { name: "month", min: 1, max: 12 },
+  { name: "dayOfWeek", min: 0, max: 6, allowSevenAsSunday: true },
+];
+
+function normalizeWeekdayValue(value: number, spec: CronFieldSpec): number {
+  if (spec.allowSevenAsSunday && value === 7) {
+    return 0;
+  }
+  return value;
+}
+
+function parseSingleValue(rawValue: string, spec: CronFieldSpec): number {
+  const parsed = Number(rawValue);
+  if (!Number.isInteger(parsed)) {
+    throw new Error(`Invalid ${spec.name} value '${rawValue}'`);
+  }
+  const normalized = normalizeWeekdayValue(parsed, spec);
+  if (normalized < spec.min || normalized > spec.max) {
+    throw new Error(`Invalid ${spec.name} value '${rawValue}'`);
+  }
+  return normalized;
+}
+
+function addRangeValues(set: Set<number>, start: number, end: number, step: number, spec: CronFieldSpec): void {
+  if (!Number.isInteger(step) || step <= 0) {
+    throw new Error(`Invalid ${spec.name} step '${step}'`);
+  }
+  if (start > end) {
+    throw new Error(`Invalid ${spec.name} range '${start}-${end}'`);
+  }
+  for (let value = start; value <= end; value += step) {
+    set.add(normalizeWeekdayValue(value, spec));
+  }
+}
+
+function parseSegment(rawSegment: string, spec: CronFieldSpec, set: Set<number>): void {
+  const segment = rawSegment.trim();
+  if (!segment) {
+    throw new Error(`Invalid ${spec.name} segment`);
+  }
+
+  const [baseRaw = "", stepRaw] = segment.split("/");
+  const base = baseRaw.trim();
+  const step = stepRaw === undefined ? 1 : Number(stepRaw);
+
+  if (base === "*") {
+    addRangeValues(set, spec.min, spec.max, step, spec);
+    return;
+  }
+
+  if (base.includes("-")) {
+    const [startRaw, endRaw] = base.split("-");
+    if (!startRaw || !endRaw) {
+      throw new Error(`Invalid ${spec.name} range '${segment}'`);
+    }
+    const start = parseSingleValue(startRaw, spec);
+    const end = parseSingleValue(endRaw, spec);
+    addRangeValues(set, start, end, step, spec);
+    return;
+  }
+
+  const value = parseSingleValue(base, spec);
+  if (stepRaw !== undefined) {
+    addRangeValues(set, value, spec.max, step, spec);
+    return;
+  }
+  set.add(value);
+}
+
+function parseField(rawField: string, spec: CronFieldSpec): Set<number> {
+  const field = rawField.trim();
+  if (!field) {
+    throw new Error(`Missing ${spec.name} field`);
+  }
+
+  const allowedValues = new Set<number>();
+  const segments = field.split(",");
+  for (const segment of segments) {
+    parseSegment(segment, spec, allowedValues);
+  }
+
+  if (allowedValues.size === 0) {
+    throw new Error(`Invalid ${spec.name} field '${rawField}'`);
+  }
+  return allowedValues;
+}
+
+export function validateCronExpression(expression: string): void {
+  const normalized = expression.trim();
+  const fields = normalized.split(/\s+/);
+  if (fields.length !== 5) {
+    throw new Error("Cron expression must have exactly 5 fields");
+  }
+
+  fields.forEach((field, index) => {
+    parseField(field, CRON_FIELD_SPECS[index]!);
+  });
+}
+
+export function matchesCronExpression(expression: string, date = new Date()): boolean {
+  validateCronExpression(expression);
+  const fields = expression.trim().split(/\s+/);
+  const dateValues = [
+    date.getMinutes(),
+    date.getHours(),
+    date.getDate(),
+    date.getMonth() + 1,
+    date.getDay(),
+  ];
+
+  return fields.every((field, index) => parseField(field, CRON_FIELD_SPECS[index]!).has(dateValues[index]!));
+}

--- a/packages/core/cron/scheduler.ts
+++ b/packages/core/cron/scheduler.ts
@@ -1,0 +1,278 @@
+import { createAgentAdapter } from "@/agents/adapter";
+import type { OpenCodeMessageContext } from "@/agents";
+import {
+  getChannelBaseBranch,
+  getChannelModel,
+  getChannelSystemMessage,
+  getUserGeneralSettings,
+  resolveChannelCwd,
+} from "@/config";
+import {
+  type CronJobRecord,
+  listEnabledCronJobs,
+  markCronJobCompleted,
+  markCronJobFailed,
+  markCronJobTriggered,
+} from "@/config/local/cron-jobs";
+import {
+  completeInboxRecord,
+  failInboxRecord,
+  recordInboxRequest,
+} from "@/config/local/inbox";
+import {
+  loadSession,
+  saveSession,
+  type PersistedSession,
+} from "@/config/local/sessions";
+import { matchesCronExpression } from "@/core/cron/expression";
+import { buildMessageOptions } from "@/core/runtime/message-options";
+import { buildFinalResponseText, categorizeRuntimeError } from "@/core/runtime/helpers";
+import { buildSessionEnvironment, prepareSessionWorkspace } from "@/core/session";
+import { sendChannelMessage as sendDiscordChannelMessage } from "@/ims/discord/client";
+import { sendChannelMessage as sendLarkChannelMessage } from "@/ims/lark/client";
+import { sendChannelMessage as sendSlackChannelMessage } from "@/ims/slack/client";
+import { log } from "@/utils";
+
+const CRON_POLL_INTERVAL_MS = 15_000;
+
+let cronSchedulerTimer: ReturnType<typeof setInterval> | null = null;
+const runningJobIds = new Set<string>();
+
+function getCronThreadId(jobId: string): string {
+  return `cron-job:${jobId}`;
+}
+
+function getCronUserId(jobId: string): string {
+  return `cron-job:${jobId}`;
+}
+
+function buildInboxRecordId(jobId: string, minuteStartMs: number): string {
+  return `cron:${jobId}:${minuteStartMs}`;
+}
+
+function resolveInboxModelForCron(job: CronJobRecord, options: ReturnType<typeof buildMessageOptions>): string | null {
+  const explicitModel = options?.model;
+  if (explicitModel?.providerID && explicitModel.modelID) {
+    return `${explicitModel.providerID}/${explicitModel.modelID}`;
+  }
+  const fallbackModel = getChannelModel(job.channelId)?.trim();
+  return fallbackModel && fallbackModel.length > 0 ? fallbackModel : null;
+}
+
+async function sendResultToChannel(job: CronJobRecord, text: string): Promise<void> {
+  if (job.platform === "slack") {
+    await sendSlackChannelMessage(job.channelId, text);
+    return;
+  }
+  if (job.platform === "discord") {
+    await sendDiscordChannelMessage(job.channelId, text);
+    return;
+  }
+  await sendLarkChannelMessage(job.channelId, text);
+}
+
+function buildCronAgentContext(job: CronJobRecord): OpenCodeMessageContext {
+  const userId = getCronUserId(job.id);
+  const threadId = getCronThreadId(job.id);
+  return {
+    slack: {
+      platform: job.platform,
+      channelId: job.channelId,
+      threadId,
+      userId,
+      hasGitHubToken: false,
+      channelSystemMessage: getChannelSystemMessage(job.channelId) ?? undefined,
+    },
+  };
+}
+
+async function prepareCronSession(job: CronJobRecord): Promise<{
+  session: PersistedSession;
+  sessionId: string;
+  cwd: string;
+  created: boolean;
+}> {
+  const threadId = getCronThreadId(job.id);
+  const userId = getCronUserId(job.id);
+  const agent = createAgentAdapter();
+
+  let cwd = resolveChannelCwd(job.channelId).cwd;
+  let session = loadSession(job.channelId, threadId);
+  if (session?.workingDirectory) {
+    cwd = session.workingDirectory;
+  }
+
+  const { env: sessionEnv, gitIdentity } = buildSessionEnvironment({
+    threadOwnerUserId: userId,
+  });
+
+  const { sessionId } = await agent.getOrCreateSession(job.channelId, threadId, cwd, sessionEnv);
+  const created = !session;
+
+  if (created && getUserGeneralSettings().gitStrategy === "worktree") {
+    const baseBranch = getChannelBaseBranch(job.channelId);
+    const prepared = await prepareSessionWorkspace({
+      channelId: job.channelId,
+      threadId,
+      cwd,
+      worktreeId: `ode_cron_${job.id.replace(/[^a-zA-Z0-9_-]/g, "_")}`,
+      baseBranch,
+      sessionEnv,
+      gitIdentity,
+    });
+    cwd = prepared.cwd;
+  }
+
+  if (!session) {
+    session = {
+      sessionId,
+      providerId: agent.getProviderForSession(sessionId),
+      platform: job.platform,
+      channelId: job.channelId,
+      threadId,
+      workingDirectory: cwd,
+      threadOwnerUserId: userId,
+      participantBotIds: ["cron-job"],
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+      lastActivityBotId: "cron-job",
+    };
+  } else {
+    session.sessionId = sessionId;
+    session.providerId = agent.getProviderForSession(sessionId);
+    session.platform = job.platform;
+    session.workingDirectory = cwd;
+    session.lastActivityBotId = "cron-job";
+  }
+
+  saveSession(session);
+  return { session, sessionId, cwd, created };
+}
+
+async function runCronJob(job: CronJobRecord, minuteStartMs: number): Promise<void> {
+  const agent = createAgentAdapter();
+  const inboxRecordId = buildInboxRecordId(job.id, minuteStartMs);
+
+  try {
+    const { session, sessionId, cwd } = await prepareCronSession(job);
+    const providerId = agent.getProviderForSession(sessionId);
+    const options = buildMessageOptions({
+      text: job.messageText,
+      channelId: job.channelId,
+      providerId,
+    });
+
+    recordInboxRequest({
+      id: inboxRecordId,
+      platform: job.platform,
+      sourceKind: "cron_job",
+      cronJobId: job.id,
+      cronJobTitle: job.title,
+      channelId: job.channelId,
+      threadId: getCronThreadId(job.id),
+      replyThreadId: getCronThreadId(job.id),
+      sessionId,
+      userId: getCronUserId(job.id),
+      messageId: String(minuteStartMs),
+      providerId,
+      model: resolveInboxModelForCron(job, options),
+      workingDirectory: cwd,
+      promptText: job.messageText,
+      context: {
+        sourceKind: "cron_job",
+        cronJobId: job.id,
+        cronJobTitle: job.title,
+        scheduledMinuteStartMs: minuteStartMs,
+        isFirstMessageInThread: false,
+      },
+    });
+
+    const responses = await agent.sendMessage(
+      job.channelId,
+      sessionId,
+      job.messageText,
+      cwd,
+      options,
+      buildCronAgentContext(job)
+    );
+    const finalText = buildFinalResponseText(responses) ?? "_Done_";
+
+    await sendResultToChannel(job, finalText);
+    completeInboxRecord({
+      id: inboxRecordId,
+      resultText: finalText,
+      sessionId,
+      providerId,
+      model: resolveInboxModelForCron(job, options),
+      workingDirectory: cwd,
+    });
+    markCronJobCompleted(job.id);
+  } catch (error) {
+    const { message } = categorizeRuntimeError(error);
+    failInboxRecord({
+      id: inboxRecordId,
+      errorText: message,
+    });
+    markCronJobFailed(job.id, message);
+    log.warn("Cron job execution failed", {
+      cronJobId: job.id,
+      title: job.title,
+      channelId: job.channelId,
+      error: String(error),
+    });
+  }
+}
+
+async function tickCronJobs(): Promise<void> {
+  const now = new Date();
+  const minuteStartMs = new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    now.getDate(),
+    now.getHours(),
+    now.getMinutes(),
+    0,
+    0
+  ).getTime();
+
+  const jobs = listEnabledCronJobs();
+  for (const job of jobs) {
+    if (runningJobIds.has(job.id)) continue;
+    try {
+      if (!matchesCronExpression(job.cronExpression, now)) continue;
+    } catch (error) {
+      markCronJobFailed(job.id, error instanceof Error ? error.message : String(error));
+      log.warn("Skipping cron job with invalid cron expression", {
+        cronJobId: job.id,
+        cronExpression: job.cronExpression,
+        error: String(error),
+      });
+      continue;
+    }
+
+    const claimed = markCronJobTriggered(job.id, minuteStartMs);
+    if (!claimed) continue;
+
+    runningJobIds.add(job.id);
+    void runCronJob(job, minuteStartMs).finally(() => {
+      runningJobIds.delete(job.id);
+    });
+  }
+}
+
+export function startCronJobScheduler(): void {
+  if (cronSchedulerTimer) return;
+  void tickCronJobs();
+  cronSchedulerTimer = setInterval(() => {
+    void tickCronJobs();
+  }, CRON_POLL_INTERVAL_MS);
+  log.debug("Cron job scheduler started", { intervalMs: CRON_POLL_INTERVAL_MS });
+}
+
+export function stopCronJobScheduler(): void {
+  if (!cronSchedulerTimer) return;
+  clearInterval(cronSchedulerTimer);
+  cronSchedulerTimer = null;
+  runningJobIds.clear();
+  log.debug("Cron job scheduler stopped");
+}

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -31,6 +31,7 @@ import { hasWebUiBuild, startLocalWebServer, stopLocalWebServer } from "./web/se
 import { markRuntimeReady, scheduleUpgradeRestart } from "@/core/daemon/control";
 import { checkForUpdate, isInstalledBinary, performUpgrade } from "./upgrade";
 import { runOnboardingIfNeeded } from "./onboarding";
+import { startCronJobScheduler, stopCronJobScheduler } from "@/core/cron/scheduler";
 import packageJson from "../../package.json" with { type: "json" };
 
 const CONFIG_WATCH_INTERVAL_MS = 1000;
@@ -277,6 +278,7 @@ async function main(): Promise<void> {
   await startSlackRuntime("startup");
   await startDiscordRuntime("startup");
   await startLarkRuntime("startup");
+  startCronJobScheduler();
 
   if (slackApps.length > 0) {
     log.debug("Slack app created");
@@ -289,6 +291,7 @@ async function main(): Promise<void> {
     log.debug("Shutting down...", { signal });
 
     try {
+      stopCronJobScheduler();
       stopOAuthServer();
       await stopSlackRuntime("shutdown");
       await stopDiscordRuntime("shutdown");

--- a/packages/core/test/runtime-resilience-e2e.test.ts
+++ b/packages/core/test/runtime-resilience-e2e.test.ts
@@ -1,6 +1,10 @@
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "bun:test";
 import { createCoreRuntime } from "@/core/runtime";
 import { loadOdeConfig, updateOdeConfig } from "@/config";
+import {
+  clearInboxRecordsForTests,
+  closeInboxDatabaseForTests,
+} from "@/config/local/inbox";
 import {
   createActiveRequest,
   deleteSession,
@@ -9,12 +13,17 @@ import {
 } from "@/config/local/sessions";
 import type { AgentAdapter, IMAdapter } from "@/core/types";
 import type { RawInboundEvent } from "@/core/model/raw-inbound-event";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 let sequence = 0;
+const tempInboxDir = fs.mkdtempSync(path.join(os.tmpdir(), "ode-runtime-resilience-inbox-test-"));
+const tempInboxDbFile = path.join(tempInboxDir, "inbox.db");
 
 function uniqueId(prefix: string): string {
   sequence += 1;
@@ -164,12 +173,25 @@ function toInboundEvent(params: {
 
 describe("core runtime resilience e2e", () => {
   const previousCi = process.env.CI;
+  const previousInboxDbFile = process.env.ODE_INBOX_DB_FILE;
 
   beforeAll(() => {
     process.env.CI = "1";
+    process.env.ODE_INBOX_DB_FILE = tempInboxDbFile;
+  });
+
+  beforeEach(() => {
+    clearInboxRecordsForTests();
   });
 
   afterAll(() => {
+    closeInboxDatabaseForTests();
+    if (previousInboxDbFile === undefined) {
+      delete process.env.ODE_INBOX_DB_FILE;
+    } else {
+      process.env.ODE_INBOX_DB_FILE = previousInboxDbFile;
+    }
+    fs.rmSync(tempInboxDir, { recursive: true, force: true });
     if (previousCi === undefined) {
       delete process.env.CI;
       return;
@@ -179,26 +201,26 @@ describe("core runtime resilience e2e", () => {
 
   it("falls back to sending final message when status updates are rate-limited", async () => {
     await withFastMessageUpdates(async () => {
-    const logs = { sends: [], updates: [] } as {
-      sends: Array<{ channelId: string; threadId: string; text: string; messageTs: string }>;
-      updates: Array<{ channelId: string; messageTs: string; text: string }>;
-    };
-    const im = createFakeIm(logs, { failUpdateWith429: true });
-    const { agent } = createFakeAgent({
-      delayMs: 5200,
-      responseText: "final from agent",
-    });
-    const runtime = createCoreRuntime({ platform: "slack", im, agent });
-    const channelId = uniqueId("CE2E-RES-429");
-    const threadId = uniqueId("TE2E-RES-429");
+      const logs = { sends: [], updates: [] } as {
+        sends: Array<{ channelId: string; threadId: string; text: string; messageTs: string }>;
+        updates: Array<{ channelId: string; messageTs: string; text: string }>;
+      };
+      const im = createFakeIm(logs, { failUpdateWith429: true });
+      const { agent } = createFakeAgent({
+        delayMs: 5200,
+        responseText: "final from agent",
+      });
+      const runtime = createCoreRuntime({ platform: "slack", im, agent });
+      const channelId = uniqueId("CE2E-RES-429");
+      const threadId = uniqueId("TE2E-RES-429");
 
-    const context = {
-      channelId,
-      replyThreadId: threadId,
-      threadId,
-      userId: "UE2E-429",
-      messageId: uniqueId("ME2E-429"),
-    };
+      const context = {
+        channelId,
+        replyThreadId: threadId,
+        threadId,
+        userId: "UE2E-429",
+        messageId: uniqueId("ME2E-429"),
+      };
 
       await runtime.handleInboundEvent(toInboundEvent({
         channelId: context.channelId,

--- a/packages/core/test/web-routes.test.ts
+++ b/packages/core/test/web-routes.test.ts
@@ -1,6 +1,10 @@
 import { afterAll, describe, expect, it } from "bun:test";
 import type { SessionEvent } from "@/config/local/redis";
 import {
+  clearCronJobsForTests,
+  closeCronJobDatabaseForTests,
+} from "@/config/local/cron-jobs";
+import {
   clearInboxRecordsForTests,
   closeInboxDatabaseForTests,
   createInboxRecordId,
@@ -100,6 +104,23 @@ describe("web app routing", () => {
     expect(detailPayload.result?.id).toBe(inboxId);
     expect(detailPayload.result?.promptText).toBe("show me the latest build failures");
   });
+
+  it("returns cron job list payload", async () => {
+    clearCronJobsForTests();
+    const app = createWebApp();
+    const response = await app.handle(new Request("http://localhost/api/cron-jobs"));
+    expect(response.status).toBe(200);
+    const payload = await response.json() as {
+      ok: boolean;
+      result?: {
+        jobs: unknown[];
+        channels: unknown[];
+      };
+    };
+    expect(payload.ok).toBe(true);
+    expect(Array.isArray(payload.result?.jobs)).toBe(true);
+    expect(Array.isArray(payload.result?.channels)).toBe(true);
+  });
 });
 
 describe("collapseTextDeltas", () => {
@@ -146,6 +167,7 @@ describe("collapseTextDeltas", () => {
 });
 
 afterAll(() => {
+  closeCronJobDatabaseForTests();
   closeInboxDatabaseForTests();
   delete process.env.ODE_INBOX_DB_FILE;
   fs.rmSync(tempDir, { recursive: true, force: true });

--- a/packages/core/web/app.ts
+++ b/packages/core/web/app.ts
@@ -7,6 +7,7 @@ import { registerAgentCheckRoutes } from "./routes/agent-check";
 import { registerSessionRoutes } from "./routes/sessions";
 import { registerActionRoutes } from "./routes/action";
 import { registerInboxRoutes } from "./routes/inbox";
+import { registerCronJobRoutes } from "./routes/cron-jobs";
 
 export function createWebApp(): Elysia {
   const app = new Elysia();
@@ -32,6 +33,7 @@ export function createWebApp(): Elysia {
   registerSessionRoutes(app);
   registerActionRoutes(app);
   registerInboxRoutes(app);
+  registerCronJobRoutes(app);
 
   app.all("*", async ({ request }: { request: Request }) => {
     return serveStaticAsset(request);

--- a/packages/core/web/routes/cron-jobs.ts
+++ b/packages/core/web/routes/cron-jobs.ts
@@ -1,0 +1,106 @@
+import type { Elysia } from "elysia";
+import {
+  createCronJob,
+  deleteCronJob,
+  listCronJobChannelOptions,
+  listCronJobs,
+  updateCronJob,
+} from "@/config/local/cron-jobs";
+import { jsonResponse, readJsonBody, runRoute } from "../http";
+
+function getString(payload: Record<string, unknown>, key: string): string {
+  const value = payload[key];
+  return typeof value === "string" ? value : "";
+}
+
+function getBoolean(payload: Record<string, unknown>, key: string): boolean | undefined {
+  const value = payload[key];
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function parseCronJobPayload(payload: Record<string, unknown>) {
+  return {
+    title: getString(payload, "title"),
+    cronExpression: getString(payload, "cronExpression"),
+    channelId: getString(payload, "channelId"),
+    messageText: getString(payload, "messageText"),
+    enabled: getBoolean(payload, "enabled"),
+  };
+}
+
+export function registerCronJobRoutes(app: Elysia): void {
+  app.get("/api/cron-jobs", async () => {
+    return runRoute(
+      async () => ({
+        jobs: listCronJobs(),
+        channels: listCronJobChannelOptions(),
+      }),
+      (result) => jsonResponse(200, { ok: true, result }),
+      { fallbackMessage: "Internal server error", status: 500 }
+    );
+  });
+
+  app.post("/api/cron-jobs", async ({ request }: { request: Request }) => {
+    return runRoute(
+      async () => {
+        const payload = parseCronJobPayload(await readJsonBody(request));
+        const job = createCronJob(payload);
+        return {
+          job,
+          jobs: listCronJobs(),
+          channels: listCronJobChannelOptions(),
+        };
+      },
+      (result) => jsonResponse(200, { ok: true, result }),
+      { fallbackMessage: "Invalid cron job payload", status: 400 }
+    );
+  });
+
+  app.put("/api/cron-jobs/:id", async ({ params, request }: { params: { id?: string }; request: Request }) => {
+    return runRoute(
+      async () => {
+        const id = params.id?.trim();
+        if (!id) {
+          throw new Error("Missing cron job id");
+        }
+        const payload = parseCronJobPayload(await readJsonBody(request));
+        const job = updateCronJob(id, payload);
+        return {
+          job,
+          jobs: listCronJobs(),
+          channels: listCronJobChannelOptions(),
+        };
+      },
+      (result) => jsonResponse(200, { ok: true, result }),
+      {
+        fallbackMessage: "Invalid cron job payload",
+        resolveStatus: (message) => {
+          if (message === "Missing cron job id") return 400;
+          if (message === "Cron job not found") return 404;
+          return 400;
+        },
+      }
+    );
+  });
+
+  app.delete("/api/cron-jobs/:id", async ({ params }: { params: { id?: string } }) => {
+    return runRoute(
+      async () => {
+        const id = params.id?.trim();
+        if (!id) {
+          throw new Error("Missing cron job id");
+        }
+        deleteCronJob(id);
+        return {
+          jobs: listCronJobs(),
+          channels: listCronJobChannelOptions(),
+        };
+      },
+      (result) => jsonResponse(200, { ok: true, result }),
+      {
+        fallbackMessage: "Failed to delete cron job",
+        resolveStatus: (message) => (message === "Missing cron job id" ? 400 : 400),
+      }
+    );
+  });
+}

--- a/packages/ims/discord/client.ts
+++ b/packages/ims/discord/client.ts
@@ -215,6 +215,32 @@ async function sendMessage(
   }
 }
 
+export async function sendChannelMessage(
+  channelId: string,
+  text: string,
+  processorId?: string
+): Promise<string | undefined> {
+  try {
+    const channel = await resolveTextChannel(channelId, processorId);
+    const chunks = splitForDiscord(text, DISCORD_MESSAGE_LIMIT);
+    let firstId: string | undefined;
+    for (let index = 0; index < chunks.length; index += 1) {
+      const chunk = chunks[index] ?? "";
+      const sent = await channel.send(chunk);
+      firstId = firstId || sent.id;
+      statusMessageIndex.setThreadId(sent.id, channelId);
+    }
+    return firstId;
+  } catch (error) {
+    log.warn("Failed to send Discord top-level channel message", {
+      channelId,
+      textLength: text.length,
+      error: String(error),
+    });
+    throw error;
+  }
+}
+
 async function updateMessage(
   channelId: string,
   messageId: string,

--- a/packages/ims/lark/client.ts
+++ b/packages/ims/lark/client.ts
@@ -374,6 +374,22 @@ async function sendMessage(
   });
 }
 
+export async function sendChannelMessage(
+  channelId: string,
+  text: string,
+  processorId?: string
+): Promise<string | undefined> {
+  const creds = getLarkCredentialsForProcessor(processorId, channelId);
+  if (!creds) return undefined;
+  return sendLarkMessage({
+    channelId,
+    threadId: "",
+    msgType: "post",
+    content: buildLarkPostContent(text),
+    creds,
+  });
+}
+
 async function sendSettingsCard(channelId: string, threadId: string, userId = ""): Promise<string | undefined> {
   const routeThreadId = threadId || "";
   return sendLarkSettingsCard({

--- a/packages/ims/slack/client.ts
+++ b/packages/ims/slack/client.ts
@@ -6,6 +6,7 @@ import {
   invalidateOdeConfigCache,
   getGitHubInfoForUser,
   getChannelSystemMessage,
+  getWorkspaces,
 } from "@/config";
 import { markdownToSlack, splitForSlack, truncateForSlack } from "./formatter";
 import {
@@ -338,6 +339,49 @@ export async function sendMessage(
     lastTs = result.ts;
     if (botToken && result.ts) {
       slackAuthRegistry.setThreadBotToken(rawChannelId, threadId, botToken);
+      slackAuthRegistry.setMessageBotToken(rawChannelId, result.ts, botToken);
+    }
+  }
+  return lastTs;
+}
+
+function getWorkspaceBotTokenForChannel(channelId: string): string | undefined {
+  const resolvedChannelId = channelId.trim();
+  for (const workspace of getWorkspaces()) {
+    if (workspace.type !== "slack") continue;
+    if (!workspace.channelDetails.some((channel) => channel.id === resolvedChannelId)) continue;
+    const botToken = workspace.slackBotToken?.trim();
+    if (botToken) return botToken;
+  }
+  return undefined;
+}
+
+export async function sendChannelMessage(
+  channelId: string,
+  text: string,
+  processorId?: string
+): Promise<string | undefined> {
+  const rawChannelId = channelId;
+  const slackApp = getApp();
+  const formattedText = markdownToSlack(text);
+  const chunks = splitForSlack(formattedText);
+  const botToken = getSlackBotTokenForProcessor(processorId)
+    ?? getWorkspaceBotTokenForChannel(channelId)
+    ?? getSlackBotToken(channelId);
+
+  if (!botToken) {
+    log.warn("No Slack bot token available for top-level channel message", { channelId });
+  }
+
+  let lastTs: string | undefined;
+  for (const chunk of chunks) {
+    const result = await slackApp.client.chat.postMessage({
+      channel: rawChannelId,
+      text: chunk,
+      token: botToken,
+    });
+    lastTs = result.ts;
+    if (botToken && result.ts) {
       slackAuthRegistry.setMessageBotToken(rawChannelId, result.ts, botToken);
     }
   }

--- a/packages/ims/slack/index.ts
+++ b/packages/ims/slack/index.ts
@@ -3,6 +3,7 @@ export {
   getApp,
   getApps,
   sendMessage,
+  sendChannelMessage,
   deleteMessage,
   setupMessageHandlers,
   recoverPendingRequests,

--- a/packages/web-ui/src/routes/(settings)/+layout.svelte
+++ b/packages/web-ui/src/routes/(settings)/+layout.svelte
@@ -13,11 +13,13 @@
 
   const pathname = $derived($page.url.pathname);
   const normalizedPathname = $derived(pathname.endsWith("/") && pathname.length > 1 ? pathname.slice(0, -1) : pathname);
-  const activeSection = $derived.by<"general" | "agents" | "inbox" | "workspace">(() =>
+  const activeSection = $derived.by<"general" | "agents" | "inbox" | "cronJobs" | "workspace">(() =>
     normalizedPathname === "/agents"
       ? "agents"
       : normalizedPathname === "/inbox"
         ? "inbox"
+      : normalizedPathname === "/cron-jobs"
+        ? "cronJobs"
       : normalizedPathname.startsWith("/workspace")
         ? "workspace"
         : "general"
@@ -205,6 +207,13 @@
           on:click={() => goto("/inbox")}
         >
           {t("Inbox", "收件箱")}
+        </Button>
+        <Button
+          variant={activeSection === "cronJobs" ? "default" : "secondary"}
+          className="w-full justify-start"
+          on:click={() => goto("/cron-jobs")}
+        >
+          {t("Cron Jobs", "定时任务")}
         </Button>
       </div>
     </Card>

--- a/packages/web-ui/src/routes/(settings)/cron-jobs/+page.svelte
+++ b/packages/web-ui/src/routes/(settings)/cron-jobs/+page.svelte
@@ -1,0 +1,445 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { AlarmClock, Pencil, Plus, RefreshCw, Trash2 } from "lucide-svelte";
+  import { Badge, Button, Card, Input, Label, Select, Textarea } from "$lib/components/ui";
+  import { locale } from "$lib/i18n";
+
+  type CronJobPlatform = "slack" | "discord" | "lark";
+  type CronJobRunStatus = "idle" | "running" | "success" | "failed";
+
+  type CronJobRecord = {
+    id: string;
+    title: string;
+    cronExpression: string;
+    platform: CronJobPlatform;
+    workspaceId: string | null;
+    workspaceName: string | null;
+    channelId: string;
+    channelName: string | null;
+    messageText: string;
+    enabled: boolean;
+    lastTriggeredAt: number | null;
+    lastCompletedAt: number | null;
+    lastRunStatus: CronJobRunStatus;
+    lastError: string | null;
+    createdAt: number;
+    updatedAt: number;
+  };
+
+  type CronJobChannelOption = {
+    value: string;
+    platform: CronJobPlatform;
+    workspaceId: string;
+    workspaceName: string;
+    channelId: string;
+    channelName: string;
+    label: string;
+  };
+
+  type CronJobPayload = {
+    jobs: CronJobRecord[];
+    channels: CronJobChannelOption[];
+  };
+
+  let jobs = $state<CronJobRecord[]>([]);
+  let channels = $state<CronJobChannelOption[]>([]);
+  let isLoading = $state(false);
+  let isSaving = $state(false);
+  let message = $state("");
+
+  let editingJobId = $state<string | null>(null);
+  let formTitle = $state("");
+  let formCronExpression = $state("0 9 * * 1-5");
+  let formChannelId = $state("");
+  let formMessageText = $state("");
+  let formEnabled = $state(true);
+
+  function t(en: string, zh: string): string {
+    return $locale === "zh-CN" ? zh : en;
+  }
+
+  function formatTimestamp(timestamp: number | null | undefined): string {
+    if (!timestamp || !Number.isFinite(timestamp)) return t("Never", "从未");
+    return new Date(timestamp).toLocaleString($locale === "zh-CN" ? "zh-CN" : "en-US");
+  }
+
+  function getRunStatusVariant(status: CronJobRunStatus): "secondary" | "success" | "destructive" {
+    if (status === "success") return "success";
+    if (status === "failed") return "destructive";
+    return "secondary";
+  }
+
+  function getRunStatusLabel(status: CronJobRunStatus): string {
+    if (status === "running") return t("Running", "运行中");
+    if (status === "success") return t("Success", "成功");
+    if (status === "failed") return t("Failed", "失败");
+    return t("Idle", "空闲");
+  }
+
+  function getEnabledLabel(enabled: boolean): string {
+    return enabled ? t("Enabled", "已启用") : t("Disabled", "已停用");
+  }
+
+  function getChannelLabel(job: CronJobRecord): string {
+    const workspace = job.workspaceName || job.workspaceId || t("Unknown workspace", "未知工作区");
+    const channel = job.channelName || job.channelId;
+    return `${workspace} / ${channel}`;
+  }
+
+  function findChannelFormValue(job: CronJobRecord): string {
+    const exactMatch = channels.find((channel) =>
+      channel.channelId === job.channelId
+      && channel.workspaceId === (job.workspaceId || channel.workspaceId)
+      && channel.platform === job.platform
+    );
+    if (exactMatch) return exactMatch.value;
+
+    const fallbackMatch = channels.find((channel) => channel.channelId === job.channelId);
+    return fallbackMatch?.value ?? job.channelId;
+  }
+
+  function applyPayload(payload: CronJobPayload): void {
+    jobs = payload.jobs;
+    channels = payload.channels;
+
+    const hasSelectedChannel = channels.some((channel) => channel.value === formChannelId);
+    if (!hasSelectedChannel) {
+      formChannelId = channels[0]?.value ?? "";
+    }
+  }
+
+  function resetForm(): void {
+    editingJobId = null;
+    formTitle = "";
+    formCronExpression = "0 9 * * 1-5";
+    formChannelId = channels[0]?.value ?? "";
+    formMessageText = "";
+    formEnabled = true;
+  }
+
+  function startEdit(job: CronJobRecord): void {
+    editingJobId = job.id;
+    formTitle = job.title;
+    formCronExpression = job.cronExpression;
+    formChannelId = findChannelFormValue(job);
+    formMessageText = job.messageText;
+    formEnabled = job.enabled;
+    message = "";
+  }
+
+  async function loadCronJobs(): Promise<void> {
+    isLoading = true;
+    message = "";
+    try {
+      const response = await fetch("/api/cron-jobs");
+      const payload = (await response.json()) as {
+        ok?: boolean;
+        error?: string;
+        result?: CronJobPayload;
+      };
+      if (!response.ok || !payload.ok || !payload.result) {
+        throw new Error(payload.error || "Failed to load cron jobs");
+      }
+      applyPayload(payload.result);
+      if (!editingJobId && !formChannelId && payload.result.channels.length > 0) {
+        formChannelId = payload.result.channels[0]!.value;
+      }
+    } catch (error) {
+      message = `Cron jobs load failed: ${error instanceof Error ? error.message : String(error)}`;
+    } finally {
+      isLoading = false;
+    }
+  }
+
+  async function saveCronJob(): Promise<void> {
+    if (channels.length === 0) {
+      message = t("Add a workspace channel first before creating cron jobs.", "请先添加工作区和频道，再创建定时任务。");
+      return;
+    }
+
+    isSaving = true;
+    message = "";
+    try {
+      const response = await fetch(editingJobId ? `/api/cron-jobs/${encodeURIComponent(editingJobId)}` : "/api/cron-jobs", {
+        method: editingJobId ? "PUT" : "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          title: formTitle,
+          cronExpression: formCronExpression,
+          channelId: formChannelId,
+          messageText: formMessageText,
+          enabled: formEnabled,
+        }),
+      });
+      const payload = (await response.json()) as {
+        ok?: boolean;
+        error?: string;
+        result?: CronJobPayload;
+      };
+      if (!response.ok || !payload.ok || !payload.result) {
+        throw new Error(payload.error || "Failed to save cron job");
+      }
+      applyPayload(payload.result);
+      message = editingJobId
+        ? t("Cron job updated.", "定时任务已更新。")
+        : t("Cron job created.", "定时任务已创建。");
+      resetForm();
+    } catch (error) {
+      message = `Cron job save failed: ${error instanceof Error ? error.message : String(error)}`;
+    } finally {
+      isSaving = false;
+    }
+  }
+
+  async function removeCronJob(job: CronJobRecord): Promise<void> {
+    const confirmText = $locale === "zh-CN"
+      ? `确认删除定时任务「${job.title}」？`
+      : `Delete cron job '${job.title}'?`;
+    if (!window.confirm(confirmText)) return;
+
+    isSaving = true;
+    message = "";
+    try {
+      const response = await fetch(`/api/cron-jobs/${encodeURIComponent(job.id)}`, {
+        method: "DELETE",
+      });
+      const payload = (await response.json()) as {
+        ok?: boolean;
+        error?: string;
+        result?: CronJobPayload;
+      };
+      if (!response.ok || !payload.ok || !payload.result) {
+        throw new Error(payload.error || "Failed to delete cron job");
+      }
+      applyPayload(payload.result);
+      if (editingJobId === job.id) {
+        resetForm();
+      }
+      message = t("Cron job deleted.", "定时任务已删除。");
+    } catch (error) {
+      message = `Cron job delete failed: ${error instanceof Error ? error.message : String(error)}`;
+    } finally {
+      isSaving = false;
+    }
+  }
+
+  onMount(() => {
+    void loadCronJobs();
+  });
+</script>
+
+<Card className="p-5">
+  <div class="mb-4 flex flex-wrap items-center justify-between gap-3">
+    <div class="flex items-center gap-2">
+      <AlarmClock class="h-4 w-4 text-[hsl(var(--muted-foreground))]" />
+      <div>
+        <h2 class="text-lg font-semibold">{t("Cron Jobs", "定时任务")}</h2>
+        <p class="text-xs text-[hsl(var(--muted-foreground))]">
+          {t("SQLite-backed scheduled prompts. Only the final result is posted into the target channel.", "基于 SQLite 持久化的定时消息。执行时不会推送 live status，只会把最终结果发到目标频道。")}
+        </p>
+      </div>
+    </div>
+
+    <div class="flex items-center gap-2">
+      <Button
+        variant="outline"
+        on:click={resetForm}
+        disabled={isSaving}
+      >
+        <Plus class="h-4 w-4" />
+        {t("New Job", "新建任务")}
+      </Button>
+      <Button
+        variant="outline"
+        on:click={() => void loadCronJobs()}
+        disabled={isLoading}
+      >
+        <RefreshCw class="h-4 w-4" />
+        {isLoading ? t("Loading...", "加载中...") : t("Refresh", "刷新")}
+      </Button>
+    </div>
+  </div>
+
+  <div class="grid gap-4 xl:grid-cols-[minmax(0,1.15fr)_minmax(0,0.85fr)]">
+    <div class="space-y-3">
+      <div class="rounded-lg border p-4">
+        <div class="mb-3 flex items-center justify-between gap-2">
+          <div>
+            <p class="text-sm font-medium">{t("Scheduled Jobs", "任务列表")}</p>
+            <p class="text-xs text-[hsl(var(--muted-foreground))]">
+              {t("Each run is persisted to SQLite and the generated inbox record is marked with its cron source.", "每次执行都会持久化到 SQLite，同时在 Inbox 中标记对应的 Cron 来源。")}
+            </p>
+          </div>
+          <Badge variant="outline">{jobs.length} {t("jobs", "个任务")}</Badge>
+        </div>
+
+        {#if isLoading && jobs.length === 0}
+          <p class="text-sm text-[hsl(var(--muted-foreground))]">{t("Loading cron jobs...", "正在加载定时任务...")}</p>
+        {:else if jobs.length === 0}
+          <p class="text-sm text-[hsl(var(--muted-foreground))]">{t("No cron jobs yet.", "还没有定时任务。")}</p>
+        {:else}
+          <div class="space-y-3">
+            {#each jobs as job}
+              <div class="rounded-lg border p-4">
+                <div class="mb-3 flex flex-wrap items-start justify-between gap-3">
+                  <div class="space-y-2">
+                    <div class="flex flex-wrap items-center gap-2">
+                      <Badge variant={job.enabled ? "success" : "secondary"}>{getEnabledLabel(job.enabled)}</Badge>
+                      <Badge variant={getRunStatusVariant(job.lastRunStatus)}>{getRunStatusLabel(job.lastRunStatus)}</Badge>
+                      <Badge variant="outline">{job.platform}</Badge>
+                    </div>
+                    <p class="text-sm font-medium">{job.title}</p>
+                    <p class="text-xs text-[hsl(var(--muted-foreground))]">
+                      {t("Cron", "Cron")}: <code>{job.cronExpression}</code>
+                    </p>
+                    <p class="text-xs text-[hsl(var(--muted-foreground))]">{getChannelLabel(job)}</p>
+                  </div>
+
+                  <div class="flex items-center gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      on:click={() => startEdit(job)}
+                    >
+                      <Pencil class="h-3.5 w-3.5" />
+                      {t("Edit", "编辑")}
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      on:click={() => void removeCronJob(job)}
+                      disabled={isSaving}
+                    >
+                      <Trash2 class="h-3.5 w-3.5" />
+                      {t("Delete", "删除")}
+                    </Button>
+                  </div>
+                </div>
+
+                <div class="rounded-md bg-[hsl(var(--muted)/0.4)] p-3">
+                  <p class="mb-1 text-xs font-medium uppercase tracking-wide text-[hsl(var(--muted-foreground))]">{t("Message", "消息内容")}</p>
+                  <p class="text-sm leading-6 whitespace-pre-wrap">{job.messageText}</p>
+                </div>
+
+                <div class="mt-3 grid gap-2 text-xs text-[hsl(var(--muted-foreground))] md:grid-cols-2">
+                  <p>{t("Last triggered", "上次触发")}: {formatTimestamp(job.lastTriggeredAt)}</p>
+                  <p>{t("Last completed", "上次完成")}: {formatTimestamp(job.lastCompletedAt)}</p>
+                  <p>{t("Created", "创建于")}: {formatTimestamp(job.createdAt)}</p>
+                  <p>{t("Updated", "更新于")}: {formatTimestamp(job.updatedAt)}</p>
+                </div>
+
+                {#if job.lastError}
+                  <div class="mt-3 rounded-md border border-[hsl(var(--destructive)/0.35)] bg-[hsl(var(--destructive)/0.08)] p-3 text-sm text-[hsl(var(--destructive))]">
+                    {job.lastError}
+                  </div>
+                {/if}
+              </div>
+            {/each}
+          </div>
+        {/if}
+      </div>
+    </div>
+
+    <div class="rounded-lg border p-4">
+      <div class="mb-4">
+        <p class="text-sm font-medium">
+          {editingJobId ? t("Edit Cron Job", "编辑定时任务") : t("Create Cron Job", "创建定时任务")}
+        </p>
+        <p class="text-xs text-[hsl(var(--muted-foreground))]">
+          {t("Use standard 5-field cron syntax, for example `0 9 * * 1-5` for weekdays at 09:00.", "使用标准 5 段 Cron 表达式，例如 `0 9 * * 1-5` 表示工作日 09:00。")}
+        </p>
+      </div>
+
+      <div class="space-y-4">
+        <div class="space-y-2">
+          <Label for="cron-title">{t("Title", "标题")}</Label>
+          <Input
+            id="cron-title"
+            value={formTitle}
+            placeholder={t("Morning standup summary", "早会摘要")}
+            on:input={(event) => {
+              formTitle = (event.currentTarget as HTMLInputElement).value;
+            }}
+          />
+        </div>
+
+        <div class="space-y-2">
+          <Label for="cron-expression">{t("Cron Expression", "Cron 表达式")}</Label>
+          <Input
+            id="cron-expression"
+            value={formCronExpression}
+            placeholder="0 9 * * 1-5"
+            on:input={(event) => {
+              formCronExpression = (event.currentTarget as HTMLInputElement).value;
+            }}
+          />
+        </div>
+
+        <div class="space-y-2">
+          <Label for="cron-channel">{t("Channel", "频道")}</Label>
+          <Select id="cron-channel" bind:value={formChannelId} disabled={channels.length === 0}>
+            {#if channels.length === 0}
+              <option value="">{t("No available channels", "暂无可用频道")}</option>
+            {:else}
+              {#each channels as channel}
+                <option value={channel.value}>
+                  {channel.label} ({channel.platform})
+                </option>
+              {/each}
+            {/if}
+          </Select>
+        </div>
+
+        <div class="space-y-2">
+          <Label for="cron-message">{t("Message", "消息")}</Label>
+          <Textarea
+            id="cron-message"
+            className="min-h-[180px]"
+            value={formMessageText}
+            placeholder={t("Review the open PRs in this workspace and summarize blockers.", "检查当前工作区里打开的 PR，并总结 blocker。")}
+            on:input={(event) => {
+              formMessageText = (event.currentTarget as HTMLTextAreaElement).value;
+            }}
+          />
+        </div>
+
+        <label class="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={formEnabled}
+            onchange={(event) => {
+              formEnabled = (event.currentTarget as HTMLInputElement).checked;
+            }}
+          />
+          <span>{t("Enable this cron job immediately", "创建后立即启用")}</span>
+        </label>
+
+        <div class="flex flex-wrap items-center gap-2">
+          <Button
+            on:click={() => void saveCronJob()}
+            disabled={isSaving || channels.length === 0}
+          >
+            {isSaving
+              ? t("Saving...", "保存中...")
+              : editingJobId
+                ? t("Update Job", "更新任务")
+                : t("Create Job", "创建任务")}
+          </Button>
+          {#if editingJobId}
+            <Button
+              variant="outline"
+              on:click={resetForm}
+              disabled={isSaving}
+            >
+              {t("Cancel Edit", "取消编辑")}
+            </Button>
+          {/if}
+        </div>
+      </div>
+    </div>
+  </div>
+
+  {#if message}
+    <p class="mt-4 text-sm text-[hsl(var(--muted-foreground))]">{message}</p>
+  {/if}
+</Card>

--- a/packages/web-ui/src/routes/(settings)/inbox/+page.svelte
+++ b/packages/web-ui/src/routes/(settings)/inbox/+page.svelte
@@ -6,10 +6,14 @@
   import { locale } from "$lib/i18n";
 
   type InboxStatus = "pending" | "completed" | "failed";
+  type InboxSourceKind = "user" | "cron_job";
 
   type InboxRecordSummary = {
     id: string;
     status: InboxStatus;
+    sourceKind: InboxSourceKind;
+    cronJobId: string | null;
+    cronJobTitle: string | null;
     platform: "slack" | "discord" | "lark";
     workspaceId: string | null;
     workspaceName: string | null;
@@ -79,6 +83,21 @@
     if (status === "completed") return "success";
     if (status === "failed") return "destructive";
     return "secondary";
+  }
+
+  function getSourceBadgeLabel(record: InboxRecordSummary): string {
+    if (record.sourceKind === "cron_job") {
+      return record.cronJobTitle
+        ? `${t("Cron Job", "定时任务")}: ${record.cronJobTitle}`
+        : t("Cron Job", "定时任务");
+    }
+    return t("User Message", "用户消息");
+  }
+
+  function getPromptPanelTitle(record: InboxRecordSummary): string {
+    return record.sourceKind === "cron_job"
+      ? t("Cron Message", "定时消息")
+      : t("User Message", "用户消息");
   }
 
   function formatContext(context: Record<string, unknown> | null): string {
@@ -205,6 +224,7 @@
                           ? t("Failed", "失败")
                           : t("Pending", "处理中")}
                     </Badge>
+                    <Badge variant="outline">{getSourceBadgeLabel(record)}</Badge>
                     <Badge variant="outline">{getProviderLabel(record.providerId)}</Badge>
                     <Badge variant="outline">{record.platform}</Badge>
                   </div>
@@ -229,7 +249,7 @@
 
               <div class="grid gap-3 md:grid-cols-2">
                 <div class="rounded-md bg-[hsl(var(--muted)/0.4)] p-3">
-                  <p class="mb-1 text-xs font-medium uppercase tracking-wide text-[hsl(var(--muted-foreground))]">{t("User Message", "用户消息")}</p>
+                  <p class="mb-1 text-xs font-medium uppercase tracking-wide text-[hsl(var(--muted-foreground))]">{getPromptPanelTitle(record)}</p>
                   <p class="text-sm leading-6">{record.promptSummary}</p>
                   <p class="mt-2 text-xs text-[hsl(var(--muted-foreground))]">{record.promptLength} chars</p>
                 </div>
@@ -291,6 +311,7 @@
             <Badge variant={getInboxStatusVariant(selectedInboxDetail.status)}>
               {selectedInboxDetail.status}
             </Badge>
+            <Badge variant="outline">{getSourceBadgeLabel(selectedInboxDetail)}</Badge>
             <Badge variant="outline">{getProviderLabel(selectedInboxDetail.providerId)}</Badge>
             <Badge variant="outline">{selectedInboxDetail.model || t("Default model", "默认模型")}</Badge>
             <Badge variant="outline">{selectedInboxDetail.channelName || selectedInboxDetail.channelId}</Badge>
@@ -298,7 +319,11 @@
 
           <div class="grid gap-4 xl:grid-cols-[1fr_1fr]">
             <div class="space-y-2">
-              <p class="text-sm font-medium">{t("Original Message", "原始消息")}</p>
+              <p class="text-sm font-medium">
+                {selectedInboxDetail.sourceKind === "cron_job"
+                  ? t("Cron Message", "定时消息")
+                  : t("Original Message", "原始消息")}
+              </p>
               <pre class="max-h-[420px] overflow-auto rounded-md bg-[hsl(var(--muted)/0.45)] p-3 text-xs leading-6 whitespace-pre-wrap">{selectedInboxDetail.promptText}</pre>
             </div>
 


### PR DESCRIPTION
## Summary
- add a dedicated Inbox settings page backed by SQLite with source metadata for user and cron messages
- add a dedicated Cron Jobs settings page, API routes, scheduler, and SQLite persistence
- send cron job final results directly to the configured channel and bump the app version to 0.1.23

## Verification
- bun test packages/config/local/inbox.test.ts packages/core/cron/expression.test.ts packages/core/test/web-routes.test.ts
- bun run typecheck
- bun run build:web