### PR TITLE
Add IM delivery observability and harden Slack status-message flow

### DIFF
--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@opencode-ai/plugin": "1.4.6"
+        "@opencode-ai/plugin": "1.4.7"
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -87,12 +87,12 @@
       ]
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.4.6.tgz",
-      "integrity": "sha512-w+55uE4tCpFoK+MtWeGoPDmpuuabw8m5WVpmucIKoTO5SgD/3EwXVPBqAh44iS72ve1Eu+uhhzeVQ070x9bVjg==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.4.7.tgz",
+      "integrity": "sha512-RbzMl7ILvQDHpZNvqzi6RCYaGcB3eBwNIMRZww467drLvMd1eOwr4/qAurrvYDsIIEctE6cKsrLuSGIKCW/Fxg==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "1.4.6",
+        "@opencode-ai/sdk": "1.4.7",
         "effect": "4.0.0-beta.48",
         "zod": "4.1.8"
       },
@@ -110,9 +110,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.4.6.tgz",
-      "integrity": "sha512-sQaVfEfQW3m3DeCVlurSTUjgIYdIk+gIfOys51MVFYzJHw+FyjjuAt7EKKA+LeZU5AiWGlpkIRa1rJo5KWMXCw==",
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.4.7.tgz",
+      "integrity": "sha512-onEtaooQyoDP5gTShQeQSf0Sd8V7949G9pPNyIyRXnVtFqyDIhUDLGtL/a/+EIW9x5s+Y6lDy/3oVoGMvQ0rQQ==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@larksuiteoapi/node-sdk": "^1.55.0",
         "@opencode-ai/sdk": "^1.1.25",
+        "@sentry/bun": "^10.49.0",
         "@slack/bolt": "^4.6.0",
         "@slack/socket-mode": "^2.0.5",
         "@slack/web-api": "^7.13.0",
@@ -41,13 +42,77 @@
 
     "@discordjs/ws": ["@discordjs/ws@1.2.3", "", { "dependencies": { "@discordjs/collection": "^2.1.0", "@discordjs/rest": "^2.5.1", "@discordjs/util": "^1.1.0", "@sapphire/async-queue": "^1.5.2", "@types/ws": "^8.5.10", "@vladfrangu/async_event_emitter": "^2.2.4", "discord-api-types": "^0.38.1", "tslib": "^2.6.2", "ws": "^8.17.0" } }, "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw=="],
 
+    "@fastify/otel": ["@fastify/otel@0.18.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.212.0", "@opentelemetry/semantic-conventions": "^1.28.0", "minimatch": "^10.2.4" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" } }, "sha512-3TASCATfw+ctICSb4ymrv7iCm0qJ0N9CarB+CZ7zIJ7KqNbwI5JjyDL1/sxoC0ccTO1Zyd1iQ+oqncPg5FJXaA=="],
+
     "@ioredis/commands": ["@ioredis/commands@1.5.0", "", {}, "sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow=="],
 
     "@larksuiteoapi/node-sdk": ["@larksuiteoapi/node-sdk@1.59.0", "", { "dependencies": { "axios": "~1.13.3", "lodash.identity": "^3.0.0", "lodash.merge": "^4.6.2", "lodash.pickby": "^4.6.0", "protobufjs": "^7.2.6", "qs": "^6.14.2", "ws": "^8.19.0" } }, "sha512-sBpkruTvZDOxnVtoTbepWKRX0j1Y1ZElQYu0x7+v088sI9pcpbVp6ZzCGn62dhrKPatzNyCJyzYCPXPYQWccrA=="],
 
     "@opencode-ai/sdk": ["@opencode-ai/sdk@1.1.25", "", {}, "sha512-mWUX489ArEF2ICg3iZsx2VQaGS3Z2j/dwAJDacao9t7dGDzjOIaacPw2weZ10zld7XmT9V9C0PM/A5lDZ52J+w=="],
 
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
+    "@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.214.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.6.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g=="],
+
+    "@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.214.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.214.0", "import-in-the-middle": "^3.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w=="],
+
+    "@opentelemetry/instrumentation-amqplib": ["@opentelemetry/instrumentation-amqplib@0.61.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.33.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-mCKoyTGfRNisge4br0NpOFSy2Z1NnEW8hbCJdUDdJFHrPqVzc4IIBPA/vX0U+LUcQqrQvJX+HMIU0dbDRe0i0Q=="],
+
+    "@opentelemetry/instrumentation-connect": ["@opentelemetry/instrumentation-connect@0.57.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.27.0", "@types/connect": "3.4.38" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-FMEBChnI4FLN5TE9DHwfH7QpNir1JzXno1uz/TAucVdLCyrG0jTrKIcNHt/i30A0M2AunNBCkcd8Ei26dIPKdg=="],
+
+    "@opentelemetry/instrumentation-dataloader": ["@opentelemetry/instrumentation-dataloader@0.31.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-f654tZFQXS5YeLDNb9KySrwtg7SnqZN119FauD7acBoTzuLduaiGTNz88ixcVSOOMGZ+EjJu/RFtx5klObC95g=="],
+
+    "@opentelemetry/instrumentation-fs": ["@opentelemetry/instrumentation-fs@0.33.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.214.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-sCZWXGalQ01wr3tAhSR9ucqFJ0phidpAle6/17HVjD6gN8FLmZMK/8sKxdXYHy3PbnlV1P4zeiSVFNKpbFMNLA=="],
+
+    "@opentelemetry/instrumentation-generic-pool": ["@opentelemetry/instrumentation-generic-pool@0.57.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-orhmlaK+ZIW9hKU+nHTbXrCSXZcH83AescTqmpamHRobRmYSQwRbD0a1odc0yAzuzOtxYiHiXAnpnIpaSSY7Ow=="],
+
+    "@opentelemetry/instrumentation-graphql": ["@opentelemetry/instrumentation-graphql@0.62.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-3YNuLVPUxafXkH1jBAbGsKNsP3XVzcFDhCDCE3OqBwCwShlqQbLMRMFh1T/d5jaVZiGVmSsfof+ICKD2iOV8xg=="],
+
+    "@opentelemetry/instrumentation-hapi": ["@opentelemetry/instrumentation-hapi@0.60.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.27.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-aNljZKYrEa7obLAxd1bCEDxF7kzCLGXTuTJZ8lMR9rIVEjmuKBXN1gfqpm/OB//Zc2zP4iIve1jBp7sr3mQV6w=="],
+
+    "@opentelemetry/instrumentation-http": ["@opentelemetry/instrumentation-http@0.214.0", "", { "dependencies": { "@opentelemetry/core": "2.6.1", "@opentelemetry/instrumentation": "0.214.0", "@opentelemetry/semantic-conventions": "^1.29.0", "forwarded-parse": "2.1.2" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-FlkDhZDRjDJDcO2LcSCtjRpkal1NJ8y0fBqBhTvfAR3JSYY2jAIj1kSS5IjmEBt4c3aWv+u/lqLuoCDrrKCSKg=="],
+
+    "@opentelemetry/instrumentation-ioredis": ["@opentelemetry/instrumentation-ioredis@0.62.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/redis-common": "^0.38.2", "@opentelemetry/semantic-conventions": "^1.33.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-ZYt//zcPve8qklaZX+5Z4MkU7UpEkFRrxsf2cnaKYBitqDnsCN69CPAuuMOX6NYdW2rG9sFy7V/QWtBlP5XiNQ=="],
+
+    "@opentelemetry/instrumentation-kafkajs": ["@opentelemetry/instrumentation-kafkajs@0.23.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.30.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-4K+nVo+zI+aDz0Z85SObwbdixIbzS9moIuKJaYsdlzcHYnKOPtB7ya8r8Ezivy/GVIBHiKJVq4tv+BEkgOMLaQ=="],
+
+    "@opentelemetry/instrumentation-knex": ["@opentelemetry/instrumentation-knex@0.58.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.33.1" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Hc/o8fSsaWxZ8r1Yw4rNDLwTpUopTf4X32y4W6UhlHmW8Wizz8wfhgOKIelSeqFVTKBBPIDUOsQWuIMxBmu8Bw=="],
+
+    "@opentelemetry/instrumentation-koa": ["@opentelemetry/instrumentation-koa@0.62.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.36.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0" } }, "sha512-uVip0VuGUQXZ+vFxkKxAUNq8qNl+VFlyHDh/U6IQ8COOEDfbEchdaHnpFrMYF3psZRUuoSIgb7xOeXj00RdwDA=="],
+
+    "@opentelemetry/instrumentation-lru-memoizer": ["@opentelemetry/instrumentation-lru-memoizer@0.58.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-6grM3TdMyHzlGY1cUA+mwoPueB1F3dYKgKtZIH6jOFXqfHAByyLTc+6PFjGM9tKh52CFBJaDwodNlL/Td39z7Q=="],
+
+    "@opentelemetry/instrumentation-mongodb": ["@opentelemetry/instrumentation-mongodb@0.67.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.33.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-1WJp5N1lYfHq2IhECOTewFs5Tf2NfUOwQRqs/rZdXKTezArMlucxgzAaqcgp3A3YREXopXTpXHsxZTGHjNhMdQ=="],
+
+    "@opentelemetry/instrumentation-mongoose": ["@opentelemetry/instrumentation-mongoose@0.60.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.33.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-8BahAZpKsOoc+lrZGb7Ofn4g3z8qtp5IxDfvAVpKXsEheQN7ONMH5djT5ihy6yf8yyeQJGS0gXFfpEAEeEHqQg=="],
+
+    "@opentelemetry/instrumentation-mysql": ["@opentelemetry/instrumentation-mysql@0.60.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.33.0", "@types/mysql": "2.15.27" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-08pO8GFPEIz2zquKDGteBZDNmwketdgH8hTe9rVYgW9kCJXq1Psj3wPQGx+VaX4ZJKCfPeoLMYup9+cxHvZyVQ=="],
+
+    "@opentelemetry/instrumentation-mysql2": ["@opentelemetry/instrumentation-mysql2@0.60.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.33.0", "@opentelemetry/sql-common": "^0.41.2" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-m/5d3bxQALllCzezYDk/6vajh0tj5OijMMvOZGr+qN1NMXm1dzMNwyJ0gNZW7Fo3YFRyj/jJMxIw+W7d525dlw=="],
+
+    "@opentelemetry/instrumentation-pg": ["@opentelemetry/instrumentation-pg@0.66.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.34.0", "@opentelemetry/sql-common": "^0.41.2", "@types/pg": "8.15.6", "@types/pg-pool": "2.0.7" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-KxfLGXBb7k2ueaPJfq2GXBDXBly8P+SpR/4Mj410hhNgmQF3sCqwXvUBQxZQkDAmsdBAoenM+yV1LhtsMRamcA=="],
+
+    "@opentelemetry/instrumentation-redis": ["@opentelemetry/instrumentation-redis@0.62.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/redis-common": "^0.38.2", "@opentelemetry/semantic-conventions": "^1.27.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-y3pPpot7WzR/8JtHcYlTYsyY8g+pbFhAqbwAuG5bLPnR6v6pt1rQc0DpH0OlGP/9CZbWBP+Zhwp9yFoygf/ZXQ=="],
+
+    "@opentelemetry/instrumentation-tedious": ["@opentelemetry/instrumentation-tedious@0.33.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.33.0", "@types/tedious": "^4.0.14" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-Q6WQwAD01MMTub31GlejoiFACYNw26J426wyjvU7by7fDIr2nZXNW4vhTGs7i7F0TnXBO3xN688g1tdUgYwJ5w=="],
+
+    "@opentelemetry/instrumentation-undici": ["@opentelemetry/instrumentation-undici@0.24.0", "", { "dependencies": { "@opentelemetry/core": "^2.0.0", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/semantic-conventions": "^1.24.0" }, "peerDependencies": { "@opentelemetry/api": "^1.7.0" } }, "sha512-oKzZ3uvqP17sV0EsoQcJgjEfIp0kiZRbYu/eD8p13Cbahumf8lb/xpYeNr/hfAJ4owzEtIDcGIjprfLcYbIKBQ=="],
+
+    "@opentelemetry/redis-common": ["@opentelemetry/redis-common@0.38.2", "", {}, "sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.6.1", "", { "dependencies": { "@opentelemetry/core": "2.6.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.6.1", "", { "dependencies": { "@opentelemetry/core": "2.6.1", "@opentelemetry/resources": "2.6.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-r86ut4T1e8vNwB35CqCcKd45yzqH6/6Wzvpk2/cZB8PsPLlZFTvrh8yfOS3CYZYcUmAx4hHTZJ8AO8Dj8nrdhw=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.40.0", "", {}, "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw=="],
+
+    "@opentelemetry/sql-common": ["@opentelemetry/sql-common@0.41.2", "", { "dependencies": { "@opentelemetry/core": "^2.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0" } }, "sha512-4mhWm3Z8z+i508zQJ7r6Xi7y4mmoJpdvH0fZPFRkWrdp5fq7hhZ2HhYokEOLkfqSMgPR4Z9EyB3DBkbKGOqZiQ=="],
+
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
+
+    "@prisma/instrumentation": ["@prisma/instrumentation@7.6.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.207.0" }, "peerDependencies": { "@opentelemetry/api": "^1.8" } }, "sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
@@ -74,6 +139,16 @@
     "@sapphire/shapeshift": ["@sapphire/shapeshift@4.0.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "lodash": "^4.17.21" } }, "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg=="],
 
     "@sapphire/snowflake": ["@sapphire/snowflake@3.5.3", "", {}, "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ=="],
+
+    "@sentry/bun": ["@sentry/bun@10.49.0", "", { "dependencies": { "@sentry/core": "10.49.0", "@sentry/node": "10.49.0" } }, "sha512-0oM0MIavDfenrjQWGXPU3ng0Gg4DAUjIWAtsr8XbsVvBa+a/JNSAzYxXvbjQ9QNK1ACYjVyNQg4Q6S+v7tgKtQ=="],
+
+    "@sentry/core": ["@sentry/core@10.49.0", "", {}, "sha512-UaFeum3LUM1mB0d67jvKnqId1yWQjyqmaDV6kWngG03x+jqXb08tJdGpSoxjXZe13jFBbiBL/wKDDYIK7rCK4g=="],
+
+    "@sentry/node": ["@sentry/node@10.49.0", "", { "dependencies": { "@fastify/otel": "0.18.0", "@opentelemetry/api": "^1.9.1", "@opentelemetry/core": "^2.6.1", "@opentelemetry/instrumentation": "^0.214.0", "@opentelemetry/instrumentation-amqplib": "0.61.0", "@opentelemetry/instrumentation-connect": "0.57.0", "@opentelemetry/instrumentation-dataloader": "0.31.0", "@opentelemetry/instrumentation-fs": "0.33.0", "@opentelemetry/instrumentation-generic-pool": "0.57.0", "@opentelemetry/instrumentation-graphql": "0.62.0", "@opentelemetry/instrumentation-hapi": "0.60.0", "@opentelemetry/instrumentation-http": "0.214.0", "@opentelemetry/instrumentation-ioredis": "0.62.0", "@opentelemetry/instrumentation-kafkajs": "0.23.0", "@opentelemetry/instrumentation-knex": "0.58.0", "@opentelemetry/instrumentation-koa": "0.62.0", "@opentelemetry/instrumentation-lru-memoizer": "0.58.0", "@opentelemetry/instrumentation-mongodb": "0.67.0", "@opentelemetry/instrumentation-mongoose": "0.60.0", "@opentelemetry/instrumentation-mysql": "0.60.0", "@opentelemetry/instrumentation-mysql2": "0.60.0", "@opentelemetry/instrumentation-pg": "0.66.0", "@opentelemetry/instrumentation-redis": "0.62.0", "@opentelemetry/instrumentation-tedious": "0.33.0", "@opentelemetry/instrumentation-undici": "0.24.0", "@opentelemetry/sdk-trace-base": "^2.6.1", "@opentelemetry/semantic-conventions": "^1.40.0", "@prisma/instrumentation": "7.6.0", "@sentry/core": "10.49.0", "@sentry/node-core": "10.49.0", "@sentry/opentelemetry": "10.49.0", "import-in-the-middle": "^3.0.0" } }, "sha512-xr+HXABCiO5mgAJRQxsXRdNOLO0+Ee6CvXAAIqovL2A1GlhxNWc5ooPWeIrrLDJ/KGyT8zI91O5scpVXdXs0uQ=="],
+
+    "@sentry/node-core": ["@sentry/node-core@10.49.0", "", { "dependencies": { "@sentry/core": "10.49.0", "@sentry/opentelemetry": "10.49.0", "import-in-the-middle": "^3.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1", "@opentelemetry/instrumentation": ">=0.57.1 <1", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" }, "optionalPeers": ["@opentelemetry/api", "@opentelemetry/core", "@opentelemetry/exporter-trace-otlp-http", "@opentelemetry/instrumentation", "@opentelemetry/sdk-trace-base", "@opentelemetry/semantic-conventions"] }, "sha512-7WO0KuCDPSq3G54TVUSI1CKFJwB67LasG+n/gDMBqbrarzs/Yh/s34OOMU5gfVQpncxQAmQsy4nEboQms8iNqA=="],
+
+    "@sentry/opentelemetry": ["@sentry/opentelemetry@10.49.0", "", { "dependencies": { "@sentry/core": "10.49.0" }, "peerDependencies": { "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^1.30.1 || ^2.1.0", "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0", "@opentelemetry/semantic-conventions": "^1.39.0" } }, "sha512-XNLm4dXmtegXQf+EEE2Cs84Ymlo/f5wMx+lg2S2XS4qLbXaPN/HttjhwKftd8D+8iUNfmH+xNMCSshx4s1B/1w=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.48", "", {}, "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA=="],
 
@@ -109,7 +184,13 @@
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
+    "@types/mysql": ["@types/mysql@2.15.27", "", { "dependencies": { "@types/node": "*" } }, "sha512-YfWiV16IY0OeBfBCk8+hXKmdTKrKlwKN1MNKAPBu5JYxLwBEZl7QzeEpGnlZb3VMGJrrGmB84gXiH+ofs/TezA=="],
+
     "@types/node": ["@types/node@25.0.5", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-FuLxeLuSVOqHPxSN1fkcD8DLU21gAP7nCKqGRJ/FglbCUBs0NYN6TpHcdmyLeh8C0KwGIaZQJSv+OYG+KZz+Gw=="],
+
+    "@types/pg": ["@types/pg@8.15.6", "", { "dependencies": { "@types/node": "*", "pg-protocol": "*", "pg-types": "^2.2.0" } }, "sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ=="],
+
+    "@types/pg-pool": ["@types/pg-pool@2.0.7", "", { "dependencies": { "@types/pg": "*" } }, "sha512-U4CwmGVQcbEuqpyju8/ptOKg6gEC+Tqsvj2xS9o1g71bUh8twxnC6ZL5rZKCsGN0iyH0CwgUyc9VR5owNQF9Ng=="],
 
     "@types/qs": ["@types/qs@6.14.0", "", {}, "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ=="],
 
@@ -121,11 +202,17 @@
 
     "@types/serve-static": ["@types/serve-static@2.2.0", "", { "dependencies": { "@types/http-errors": "*", "@types/node": "*" } }, "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ=="],
 
+    "@types/tedious": ["@types/tedious@4.0.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw=="],
+
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@vladfrangu/async_event_emitter": ["@vladfrangu/async_event_emitter@2.4.7", "", {}, "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "acorn-import-attributes": ["acorn-import-attributes@1.9.5", "", { "peerDependencies": { "acorn": "^8" } }, "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
@@ -133,9 +220,13 @@
 
     "axios": ["axios@1.13.5", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^1.1.0" } }, "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q=="],
 
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
     "bottleneck": ["bottleneck@2.19.5", "", {}, "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="],
+
+    "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
 
@@ -146,6 +237,8 @@
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
+    "cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
 
     "cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
 
@@ -223,6 +316,8 @@
 
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
+    "forwarded-parse": ["forwarded-parse@2.1.2", "", {}, "sha512-alTFZZQDKMporBH77856pXgzhEzaUVmLCDk+egLgIgHst3Tpndzz8MnKe+GzRJRfvVdn69HhpW7cmXzvtLvJAw=="],
+
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
@@ -246,6 +341,8 @@
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
+    "import-in-the-middle": ["import-in-the-middle@3.0.1", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
@@ -313,7 +410,11 @@
 
     "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
+
+    "module-details-from-path": ["module-details-from-path@1.0.4", "", {}, "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
@@ -341,6 +442,12 @@
 
     "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
+    "pg-int8": ["pg-int8@1.0.1", "", {}, "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw=="],
+
+    "pg-protocol": ["pg-protocol@1.13.0", "", {}, "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w=="],
+
+    "pg-types": ["pg-types@2.2.0", "", { "dependencies": { "pg-int8": "1.0.1", "postgres-array": "~2.0.0", "postgres-bytea": "~1.0.0", "postgres-date": "~1.0.4", "postgres-interval": "^1.1.0" } }, "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA=="],
+
     "pino": ["pino@10.1.1", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^4.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-3qqVfpJtRQUCAOs4rTOEwLH6mwJJ/CSAlbis8fKOiMzTtXh0HN/VLsn3UWVTJ7U8DsWmxeNon2IpGb+wORXH4g=="],
 
     "pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
@@ -348,6 +455,14 @@
     "pino-pretty": ["pino-pretty@13.1.3", "", { "dependencies": { "colorette": "^2.0.7", "dateformat": "^4.6.3", "fast-copy": "^4.0.0", "fast-safe-stringify": "^2.1.1", "help-me": "^5.0.0", "joycon": "^3.1.1", "minimist": "^1.2.6", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pump": "^3.0.0", "secure-json-parse": "^4.0.0", "sonic-boom": "^4.0.1", "strip-json-comments": "^5.0.2" }, "bin": { "pino-pretty": "bin.js" } }, "sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg=="],
 
     "pino-std-serializers": ["pino-std-serializers@7.0.0", "", {}, "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA=="],
+
+    "postgres-array": ["postgres-array@2.0.0", "", {}, "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA=="],
+
+    "postgres-bytea": ["postgres-bytea@1.0.1", "", {}, "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ=="],
+
+    "postgres-date": ["postgres-date@1.0.7", "", {}, "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q=="],
+
+    "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
     "process-warning": ["process-warning@5.0.0", "", {}, "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA=="],
 
@@ -372,6 +487,8 @@
     "redis-errors": ["redis-errors@1.2.0", "", {}, "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="],
 
     "redis-parser": ["redis-parser@3.0.0", "", { "dependencies": { "redis-errors": "^1.0.0" } }, "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A=="],
+
+    "require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
 
     "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 
@@ -443,11 +560,17 @@
 
     "ws": ["ws@8.19.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg=="],
 
+    "xtend": ["xtend@4.0.2", "", {}, "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="],
+
     "zod": ["zod@4.3.5", "", {}, "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g=="],
 
     "@discordjs/rest/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
 
     "@discordjs/ws/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
+
+    "@fastify/otel/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.212.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.212.0", "import-in-the-middle": "^2.0.6", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg=="],
+
+    "@prisma/instrumentation/@opentelemetry/instrumentation": ["@opentelemetry/instrumentation@0.207.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.207.0", "import-in-the-middle": "^2.0.0", "require-in-the-middle": "^8.0.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-y6eeli9+TLKnznrR8AZlQMSJT7wILpXH+6EYq5Vf/4Ao+huI7EedxQHwRgVUOMLFbe7VFDvHJrX9/f4lcwnJsA=="],
 
     "@slack/bolt/axios": ["axios@1.13.2", "", { "dependencies": { "follow-redirects": "^1.15.6", "form-data": "^4.0.4", "proxy-from-env": "^1.1.0" } }, "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA=="],
 
@@ -462,6 +585,14 @@
     "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "p-queue/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
+
+    "@fastify/otel/@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.212.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg=="],
+
+    "@fastify/otel/@opentelemetry/instrumentation/import-in-the-middle": ["import-in-the-middle@2.0.6", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw=="],
+
+    "@prisma/instrumentation/@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.207.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-lAb0jQRVyleQQGiuuvCOTDVspc14nx6XJjP4FspJ1sNARo3Regq4ZZbrc3rN4b1TYSuUCvgH+UXUPug4SLOqEQ=="],
+
+    "@prisma/instrumentation/@opentelemetry/instrumentation/import-in-the-middle": ["import-in-the-middle@2.0.6", "", { "dependencies": { "acorn": "^8.15.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^2.2.0", "module-details-from-path": "^1.0.4" } }, "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw=="],
 
     "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ode",
-  "version": "0.1.23",
+  "version": "0.1.24",
   "description": "Coding anywhere with your coding agents connected",
   "module": "packages/core/index.ts",
   "type": "module",
@@ -31,14 +31,15 @@
   "dependencies": {
     "@larksuiteoapi/node-sdk": "^1.55.0",
     "@opencode-ai/sdk": "^1.1.25",
+    "@sentry/bun": "^10.49.0",
     "@slack/bolt": "^4.6.0",
     "@slack/socket-mode": "^2.0.5",
     "@slack/web-api": "^7.13.0",
+    "bottleneck": "^2.19.5",
     "discord.js": "^14.25.1",
     "elysia": "^1.4.25",
     "ioredis": "^5.9.2",
     "lru-cache": "^11.2.2",
-    "bottleneck": "^2.19.5",
     "pino": "^10.1.1",
     "pino-pretty": "^13.1.3",
     "zod": "^4.3.5"

--- a/packages/config/local/sessions.ts
+++ b/packages/config/local/sessions.ts
@@ -381,7 +381,8 @@ export function createActiveRequest(
 export function updateActiveRequest(
   channelId: string,
   threadId: string,
-  updates: Partial<ActiveRequest>
+  updates: Partial<ActiveRequest>,
+  options?: { immediate?: boolean }
 ): void {
   const session = loadSession(channelId, threadId);
   if (!session?.activeRequest) return;
@@ -389,7 +390,7 @@ export function updateActiveRequest(
   const sanitized = { ...updates } as Partial<ActiveRequest>;
   delete sanitized.tools;
   Object.assign(session.activeRequest, sanitized, { lastUpdatedAt: Date.now() });
-  saveSession(session, { immediate: false });
+  saveSession(session, { immediate: options?.immediate ?? false });
 }
 
 export function completeActiveRequest(

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -11,6 +11,7 @@ import {
   stopDiscordRuntime,
   startLarkRuntime,
   stopLarkRuntime,
+  deliveryStats,
 } from "@/ims";
 import { type ChildProcess } from "child_process";
 import { watchFile, unwatchFile } from "fs";
@@ -32,6 +33,7 @@ import { markRuntimeReady, scheduleUpgradeRestart } from "@/core/daemon/control"
 import { checkForUpdate, isInstalledBinary, performUpgrade } from "./upgrade";
 import { runOnboardingIfNeeded } from "./onboarding";
 import { startCronJobScheduler, stopCronJobScheduler } from "@/core/cron/scheduler";
+import { initSentry, shutdownSentry } from "@/core/observability/sentry";
 import packageJson from "../../package.json" with { type: "json" };
 
 const CONFIG_WATCH_INTERVAL_MS = 1000;
@@ -255,6 +257,8 @@ function startLocalConfigWatcher(): void {
 }
 
 async function main(): Promise<void> {
+  initSentry({ release: `ode@${CURRENT_VERSION}` });
+
   let defaultCwd: string | null = null;
   try {
     defaultCwd = getDefaultCwd();
@@ -306,6 +310,15 @@ async function main(): Promise<void> {
       }
       stopAutoUpgradeScheduler();
       await stopAllServers();
+      try {
+        const dumpPath = deliveryStats.dumpToFileSync();
+        log.info("Delivery stats snapshot written", { dumpPath });
+      } catch (err) {
+        log.warn("Failed to write delivery stats snapshot on shutdown", {
+          error: String(err),
+        });
+      }
+      await shutdownSentry();
       log.debug("Cleanup complete");
       process.exit(0);
     } catch (err) {

--- a/packages/core/kernel/request-run.ts
+++ b/packages/core/kernel/request-run.ts
@@ -285,28 +285,40 @@ async function startKernelEventStreamWatcher(params: {
       onUpdate();
 
       void (async () => {
-        const updatedStatusTs = await deps.im.updateMessage(
-          request.channelId,
-          request.statusMessageTs,
-          buildStatusMessageForAgent({
-            agent: deps.agent,
-            request,
-            workingPath,
-            state: liveParsedState.get(messageKey),
-            statusMessageFormat: getUserGeneralSettings().defaultStatusMessageFormat,
-          })
-        );
-        if (typeof updatedStatusTs === "string" && updatedStatusTs !== request.statusMessageTs) {
-          request.statusMessageTs = updatedStatusTs;
-          updateActiveRequest(request.channelId, request.threadId, { statusMessageTs: updatedStatusTs });
+        try {
+          const updatedStatusTs = await deps.im.updateMessage(
+            request.channelId,
+            request.statusMessageTs,
+            buildStatusMessageForAgent({
+              agent: deps.agent,
+              request,
+              workingPath,
+              state: liveParsedState.get(messageKey),
+              statusMessageFormat: getUserGeneralSettings().defaultStatusMessageFormat,
+            })
+          );
+          if (typeof updatedStatusTs === "string" && updatedStatusTs !== request.statusMessageTs) {
+            request.statusMessageTs = updatedStatusTs;
+            updateActiveRequest(request.channelId, request.threadId, { statusMessageTs: updatedStatusTs });
+          }
+          setPendingQuestion(request.channelId, request.threadId, {
+            requestId,
+            sessionId: properties.sessionID ?? request.sessionId,
+            askedAt: Date.now(),
+            questions: normalized,
+            messageTs: request.statusMessageTs,
+          });
+        } catch (err) {
+          // Fire-and-forget update for an ask_user prompt. If this throws,
+          // we want to still register the pending question so the reply
+          // handler works; just surface the edit failure.
+          log.warn("Failed to refresh status for ask_user prompt", {
+            channelId: request.channelId,
+            threadId: request.threadId,
+            requestId,
+            error: String(err),
+          });
         }
-        setPendingQuestion(request.channelId, request.threadId, {
-          requestId,
-          sessionId: properties.sessionID ?? request.sessionId,
-          askedAt: Date.now(),
-          questions: normalized,
-          messageTs: request.statusMessageTs,
-        });
       })();
       return;
     }
@@ -341,11 +353,25 @@ export async function runOpenRequest(
 
   const providerLabel = deps.agent.getDisplayNameForSession(sessionId);
 
-  const initialStatusTs = await deps.im.sendMessage(
-    context.channelId,
-    context.replyThreadId,
-    `${providerLabel} is running...`
-  );
+  let initialStatusTs: string | undefined;
+  try {
+    initialStatusTs = await deps.im.sendMessage(
+      context.channelId,
+      context.replyThreadId,
+      `${providerLabel} is running...`
+    );
+  } catch (err) {
+    // Swallow initial-status send failure so the request lifecycle below never
+    // gets skipped by an unhandled rejection. A transient Slack error on the
+    // very first chat.postMessage should not abort the whole run: the user
+    // already sent us a message and is waiting for agent output.
+    log.error("Initial status message send threw", {
+      channelId: context.channelId,
+      threadId: context.replyThreadId,
+      error: String(err),
+    });
+    initialStatusTs = undefined;
+  }
 
   if (!initialStatusTs) {
     log.error("Failed to send status message");
@@ -422,24 +448,48 @@ export async function runOpenRequest(
         }
 
         const updateError = deps.im.takeUpdateError?.(context.channelId, statusTs);
-        if (updateError) {
+        // Only post a fallback replacement if the request is still processing.
+        // A stop command or failure could have transitioned us to "failed"
+        // between the update attempt and now; posting a replacement status
+        // after stop would ghost-write the status back into the channel.
+        if (updateError && request.state === "processing") {
           const compactError = updateError.replace(/\s+/g, " ").trim().slice(0, 180);
           const fallbackNotice = compactError.length > 0
             ? `Status update failed: ${compactError}`
             : "Status update failed due to an unknown error.";
-          await deps.im.sendMessage(
-            context.channelId,
-            context.replyThreadId,
-            `${fallbackNotice}\nSwitching to a new status message below.`
-          );
-          const replacementStatusTs = await deps.im.sendMessage(
-            context.channelId,
-            context.replyThreadId,
-            statusText
-          );
-          if (typeof replacementStatusTs === "string" && replacementStatusTs.length > 0) {
-            statusTs = replacementStatusTs;
-            request.statusMessageTs = replacementStatusTs;
+          try {
+            await deps.im.sendMessage(
+              context.channelId,
+              context.replyThreadId,
+              `${fallbackNotice}\nSwitching to a new status message below.`
+            );
+            const replacementStatusTs = await deps.im.sendMessage(
+              context.channelId,
+              context.replyThreadId,
+              statusText
+            );
+            if (typeof replacementStatusTs === "string" && replacementStatusTs.length > 0) {
+              statusTs = replacementStatusTs;
+              request.statusMessageTs = replacementStatusTs;
+              // Persist the new statusTs immediately so a crash before the
+              // next debounced save doesn't leave disk pointing at the old
+              // rate-limited TS (which would mis-route recovery edits).
+              updateActiveRequest(
+                context.channelId,
+                context.threadId,
+                { statusMessageTs: replacementStatusTs },
+                { immediate: true }
+              );
+            }
+          } catch (err) {
+            // Replacement send failed (likely also rate-limited or channel-
+            // level throttled). Don't crash the tick — keep statusTs pointing
+            // at the old message; the next tick will try to update again.
+            log.warn("Fallback status replacement send failed", {
+              channelId: context.channelId,
+              threadId: context.replyThreadId,
+              error: String(err),
+            });
           }
         }
       }
@@ -518,6 +568,16 @@ export async function runTrackedRequest(
     progressInFlight = true;
     try {
       await onProgressTick();
+    } catch (err) {
+      // A throw from onProgressTick would otherwise become an unhandled
+      // rejection via `void runProgressTick()` in setInterval below, leaving
+      // the status message frozen for the rest of the run. Log and continue;
+      // the next tick will retry.
+      log.warn("Progress tick failed", {
+        sessionId: request.sessionId,
+        channelId: request.channelId,
+        error: String(err),
+      });
     } finally {
       progressInFlight = false;
     }

--- a/packages/core/kernel/stop-command.ts
+++ b/packages/core/kernel/stop-command.ts
@@ -29,8 +29,17 @@ export async function handleStopCommand(params: {
   try {
     const cwd = session.workingDirectory;
     await deps.agent.abortSession(session.sessionId, cwd);
-  } catch {
-    // Ignore abort errors
+  } catch (err) {
+    // An abort failure means the agent may keep emitting events and burning
+    // tokens while the user thinks the request is stopped. Surface it so we
+    // can investigate, but don't fail the stop path — delete/clear below is
+    // still the right thing.
+    log.warn("Failed to abort agent session on stop", {
+      sessionId: session.sessionId,
+      channelId,
+      threadId,
+      error: String(err),
+    });
   }
 
   if (!request || request.state !== "processing") {

--- a/packages/core/observability/sentry.ts
+++ b/packages/core/observability/sentry.ts
@@ -1,0 +1,199 @@
+import * as Sentry from "@sentry/bun";
+import { log } from "@/utils";
+import type {
+  DeliveryOp,
+  DeliveryPlatform,
+  FailureRecord,
+} from "@/ims/shared/delivery-stats";
+import { deliveryStats } from "@/ims/shared/delivery-stats";
+
+/**
+ * Default Sentry DSN. Can be overridden via ODE_SENTRY_DSN, and disabled via
+ * ODE_SENTRY_DISABLED=1 or by setting the DSN to an empty string.
+ *
+ * The DSN is a public identifier (safe to commit). It only grants the ability
+ * to submit events to a specific Sentry project.
+ */
+const DEFAULT_SENTRY_DSN =
+  "https://f609ba8642f76d2d884374dcb4d15345@o4511218045222912.ingest.us.sentry.io/4511234426994689";
+
+let initialized = false;
+
+/**
+ * Dedup / rate-limit key → last send timestamp. Keeps Sentry quota from
+ * being burned by a flapping channel. Same idea as the throttled WARN log.
+ */
+const lastCaptureByKey = new Map<string, number>();
+
+// Minimum interval between Sentry events for the same fingerprint, in ms.
+const RATE_LIMIT_CAPTURE_INTERVAL_MS = 5 * 60_000; // 429s: 1 per 5 min per channel+op
+const ERROR_CAPTURE_INTERVAL_MS = 60_000;          // Other errors: 1 per min per channel+op
+
+function resolveDsn(): string | undefined {
+  if (process.env.ODE_SENTRY_DISABLED === "1") return undefined;
+  const override = process.env.ODE_SENTRY_DSN;
+  if (typeof override === "string") {
+    const trimmed = override.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  return DEFAULT_SENTRY_DSN;
+}
+
+export function initSentry(params?: { release?: string; environment?: string }): void {
+  if (initialized) return;
+  const dsn = resolveDsn();
+  if (!dsn) {
+    log.info("Sentry disabled (no DSN configured)");
+    return;
+  }
+
+  try {
+    Sentry.init({
+      dsn,
+      environment:
+        params?.environment ?? process.env.ODE_ENVIRONMENT ?? process.env.NODE_ENV ?? "development",
+      release: params?.release,
+      // We don't need perf traces for now — just error capture.
+      tracesSampleRate: 0,
+      // Send default PII like IP = off; channel IDs are opaque but messages are not.
+      sendDefaultPii: false,
+      // Limit breadcrumbs (they include console logs which are extensive via pino).
+      maxBreadcrumbs: 30,
+    });
+
+    initialized = true;
+    log.info("Sentry initialized");
+
+    // Install the failure hook so every delivery failure is captured.
+    deliveryStats.setFailureHook((failure) => {
+      captureDeliveryFailure(failure);
+    });
+  } catch (err) {
+    log.warn("Failed to initialize Sentry", { error: String(err) });
+  }
+}
+
+/**
+ * Flush pending events and close the Sentry client. Call on graceful shutdown
+ * so buffered events reach Sentry before the process exits.
+ */
+export async function shutdownSentry(timeoutMs = 2000): Promise<void> {
+  if (!initialized) return;
+  try {
+    await Sentry.flush(timeoutMs);
+    await Sentry.close(timeoutMs);
+  } catch (err) {
+    log.warn("Failed to flush Sentry on shutdown", { error: String(err) });
+  } finally {
+    initialized = false;
+  }
+}
+
+export function isSentryInitialized(): boolean {
+  return initialized;
+}
+
+/**
+ * Generic helper to capture any handled error with structured context.
+ * Use this for failures you already log but also want to track in Sentry.
+ */
+export function captureHandledError(
+  err: unknown,
+  context?: {
+    tags?: Record<string, string>;
+    extra?: Record<string, unknown>;
+    fingerprint?: string[];
+    level?: "warning" | "error" | "fatal";
+  },
+): void {
+  if (!initialized) return;
+  try {
+    Sentry.withScope((scope) => {
+      if (context?.tags) {
+        for (const [k, v] of Object.entries(context.tags)) scope.setTag(k, v);
+      }
+      if (context?.extra) {
+        for (const [k, v] of Object.entries(context.extra)) scope.setExtra(k, v);
+      }
+      if (context?.fingerprint) scope.setFingerprint(context.fingerprint);
+      if (context?.level) scope.setLevel(context.level);
+      Sentry.captureException(err);
+    });
+  } catch (hookErr) {
+    log.debug("Sentry capture failed", { error: String(hookErr) });
+  }
+}
+
+function shouldCapture(key: string, intervalMs: number): boolean {
+  const now = Date.now();
+  const last = lastCaptureByKey.get(key) ?? 0;
+  if (now - last < intervalMs) return false;
+  lastCaptureByKey.set(key, now);
+  return true;
+}
+
+function buildFailureFingerprint(
+  platform: DeliveryPlatform,
+  op: DeliveryOp,
+  rateLimited: boolean,
+  channelId: string,
+): string[] {
+  // Group by (platform, op, rateLimited, channelId) so each channel's flapping
+  // rolls up into one issue, not one per message.
+  return [
+    "ode-delivery-failure",
+    platform,
+    op,
+    rateLimited ? "rate_limited" : "error",
+    channelId,
+  ];
+}
+
+function captureDeliveryFailure(failure: FailureRecord): void {
+  if (!initialized) return;
+
+  const dedupKey = `${failure.platform}|${failure.op}|${failure.rateLimited ? "rl" : "err"}|${failure.channelId}`;
+  const interval = failure.rateLimited
+    ? RATE_LIMIT_CAPTURE_INTERVAL_MS
+    : ERROR_CAPTURE_INTERVAL_MS;
+  if (!shouldCapture(dedupKey, interval)) return;
+
+  try {
+    Sentry.withScope((scope) => {
+      scope.setTag("platform", failure.platform);
+      scope.setTag("op", failure.op);
+      scope.setTag("rate_limited", failure.rateLimited ? "true" : "false");
+      scope.setTag("channel_id", failure.channelId);
+      if (failure.processorId) {
+        scope.setTag("processor_id", failure.processorId);
+      }
+      scope.setContext("delivery", {
+        platform: failure.platform,
+        op: failure.op,
+        channelId: failure.channelId,
+        processorId: failure.processorId,
+        messageTs: failure.messageTs,
+        rateLimited: failure.rateLimited,
+        timestamp: new Date(failure.timestamp).toISOString(),
+      });
+      scope.setFingerprint(
+        buildFailureFingerprint(
+          failure.platform,
+          failure.op,
+          failure.rateLimited,
+          failure.channelId,
+        ),
+      );
+      // 429 is expected pressure signal, not a bug → warning.
+      // Other errors may indicate auth / payload / network issues → error.
+      scope.setLevel(failure.rateLimited ? "warning" : "error");
+
+      const title = failure.rateLimited
+        ? `IM ${failure.platform} ${failure.op} rate limited (429)`
+        : `IM ${failure.platform} ${failure.op} failed: ${failure.error}`;
+      Sentry.captureMessage(title);
+    });
+  } catch (hookErr) {
+    log.debug("Sentry capture failed", { error: String(hookErr) });
+  }
+}

--- a/packages/core/runtime/message-updates.ts
+++ b/packages/core/runtime/message-updates.ts
@@ -2,11 +2,7 @@ import type { IMAdapter } from "@/core/types";
 import { getMessageUpdateIntervalMs } from "@/config";
 import { log } from "@/utils";
 import { CoalescedUpdateQueue } from "@/shared/queue/coalesced-update-queue";
-
-function isRateLimitError(error: unknown): boolean {
-  const message = String(error || "").toLowerCase();
-  return message.includes("429") || message.includes("rate limit") || message.includes("ratelimit") || message.includes("rate_limited");
-}
+import { isRateLimitError } from "@/shared/delivery/rate-limit";
 
 export function createRateLimitedImAdapter(
   im: IMAdapter,

--- a/packages/core/test/runtime-resilience-e2e.test.ts
+++ b/packages/core/test/runtime-resilience-e2e.test.ts
@@ -70,11 +70,28 @@ function createFakeIm(logs: {
 }, options?: {
   failUpdateWith429?: boolean;
   failUpdateWithErrorOnce?: string;
+  failAllSendsWith?: string;
+  failInitialSendWith?: string;
+  failReplacementSendWith?: string;
 }): IMAdapter {
   let nextTs = 0;
-  let failedOnce = false;
+  let failedUpdateOnce = false;
+  let sendCallCount = 0;
   return {
     sendMessage: async (channelId, threadId, text) => {
+      sendCallCount += 1;
+      if (options?.failInitialSendWith && sendCallCount === 1) {
+        throw new Error(options.failInitialSendWith);
+      }
+      if (
+        options?.failReplacementSendWith
+        && (text.startsWith("Status update failed:") || /switching to a new status message/i.test(text))
+      ) {
+        throw new Error(options.failReplacementSendWith);
+      }
+      if (options?.failAllSendsWith) {
+        throw new Error(options.failAllSendsWith);
+      }
       nextTs += 1;
       const messageTs = `ts-${nextTs}`;
       logs.sends.push({ channelId, threadId, text, messageTs });
@@ -85,8 +102,8 @@ function createFakeIm(logs: {
       if (options?.failUpdateWith429) {
         throw new Error("429 rate limited");
       }
-      if (!failedOnce && options?.failUpdateWithErrorOnce) {
-        failedOnce = true;
+      if (!failedUpdateOnce && options?.failUpdateWithErrorOnce) {
+        failedUpdateOnce = true;
         throw new Error(options.failUpdateWithErrorOnce);
       }
     },
@@ -324,8 +341,76 @@ describe("core runtime resilience e2e", () => {
     deleteSession(context.channelId, context.threadId);
   });
 
-  it("recovers pending in-flight requests after restart", async () => {
+  it("does not crash when the initial status send throws", async () => {
+    const logs = { sends: [], updates: [] } as {
+      sends: Array<{ channelId: string; threadId: string; text: string; messageTs: string }>;
+      updates: Array<{ channelId: string; messageTs: string; text: string }>;
+    };
+    const im = createFakeIm(logs, { failInitialSendWith: "socket hang up" });
+    const { agent } = createFakeAgent({ responseText: "never mind" });
+    const runtime = createCoreRuntime({ platform: "slack", im, agent });
+
+    const channelId = uniqueId("CE2E-INIT-FAIL");
+    const threadId = uniqueId("TE2E-INIT-FAIL");
+
+    // Should not throw — initial send failure used to bubble up as an
+    // unhandled rejection and abort the whole request silently.
+    await expect(
+      runtime.handleInboundEvent(toInboundEvent({
+        channelId,
+        threadId,
+        userId: "UE2E-init",
+        messageId: uniqueId("ME2E-init"),
+        text: "hello",
+      }))
+    ).resolves.toBeUndefined();
+
+    deleteSession(channelId, threadId);
+  }, 10000);
+
+  it("does not crash when the fallback replacement send also fails", async () => {
     await withFastMessageUpdates(async () => {
+      const logs = { sends: [], updates: [] } as {
+        sends: Array<{ channelId: string; threadId: string; text: string; messageTs: string }>;
+        updates: Array<{ channelId: string; messageTs: string; text: string }>;
+      };
+      // First update always 429s → triggers the fallback path. Replacement
+      // sends also fail, simulating channel-wide throttle. The tick should
+      // absorb the error and keep running.
+      const im = createFakeIm(logs, {
+        failUpdateWith429: true,
+        failReplacementSendWith: "rate_limited",
+      });
+      const { agent } = createFakeAgent({
+        delayMs: 1200,
+        responseText: "agent finished anyway",
+      });
+      const runtime = createCoreRuntime({ platform: "slack", im, agent });
+
+      const channelId = uniqueId("CE2E-FB-FAIL");
+      const threadId = uniqueId("TE2E-FB-FAIL");
+
+      await runtime.handleInboundEvent(toInboundEvent({
+        channelId,
+        threadId,
+        userId: "UE2E-fbfail",
+        messageId: uniqueId("ME2E-fbfail"),
+        text: "channel-wide throttle scenario",
+      }));
+
+      // Final agent output should still reach the channel as a new message,
+      // proving the tick didn't crash.
+      await waitFor(
+        () => logs.sends.some((entry) => entry.text === "agent finished anyway"),
+        6000,
+      );
+      expect(logs.sends.some((entry) => entry.text === "agent finished anyway")).toBe(true);
+
+      deleteSession(channelId, threadId);
+    });
+  }, 15000);
+
+  it("recovers pending in-flight requests after restart", async () => {    await withFastMessageUpdates(async () => {
     const logs = { sends: [], updates: [] } as {
       sends: Array<{ channelId: string; threadId: string; text: string; messageTs: string }>;
       updates: Array<{ channelId: string; messageTs: string; text: string }>;

--- a/packages/ims/discord/client.ts
+++ b/packages/ims/discord/client.ts
@@ -101,7 +101,7 @@ async function maybeHandleLauncherCommand(params: {
   logContext: "thread" | "parent channel" | "mention";
 }): Promise<boolean> {
   const command = parseIncomingCommand(params.text);
-  if (!command) return false;
+  if (command !== "setting") return false;
   await sendLauncherReplyForMessage({
     message: params.message,
     command,

--- a/packages/ims/index.ts
+++ b/packages/ims/index.ts
@@ -1,6 +1,12 @@
 export * from "./slack";
 export * from "./discord";
 export * from "./lark";
+export {
+  deliveryStats,
+  renderDeliveryStatsForSlack,
+  isRateLimitError,
+  defaultDumpPath as defaultDeliveryStatsDumpPath,
+} from "./shared/delivery-stats";
 
 import { recoverPendingRequests as recoverSlackPendingRequests } from "./slack/client";
 import { recoverPendingRequests as recoverDiscordPendingRequests } from "./discord/client";

--- a/packages/ims/shared/delivery-stats.test.ts
+++ b/packages/ims/shared/delivery-stats.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DeliveryStats,
+  isRateLimitError,
+  renderDeliveryStatsForSlack,
+} from "./delivery-stats";
+
+describe("DeliveryStats", () => {
+  test("records attempts/success/failures per channel and globally", () => {
+    const stats = new DeliveryStats();
+    stats.recordAttempt({ platform: "slack", channelId: "C1", op: "send" });
+    stats.recordSuccess({ platform: "slack", channelId: "C1", op: "send" });
+    stats.recordAttempt({ platform: "slack", channelId: "C1", op: "update" });
+    stats.recordFailure({
+      platform: "slack",
+      channelId: "C1",
+      op: "update",
+      error: new Error("boom"),
+    });
+    stats.recordAttempt({ platform: "slack", channelId: "C2", op: "update" });
+    stats.recordFailure({
+      platform: "slack",
+      channelId: "C2",
+      op: "update",
+      error: "ratelimited",
+      rateLimited: true,
+    });
+
+    const snap = stats.getSnapshot();
+    expect(snap.global.send.success).toBe(1);
+    expect(snap.global.update.attempts).toBe(2);
+    expect(snap.global.update.failure).toBe(2);
+    expect(snap.global.update.rateLimited).toBe(1);
+    expect(snap.channels).toHaveLength(2);
+    expect(snap.recentFailures).toHaveLength(2);
+    expect(snap.recentFailures[1]?.rateLimited).toBe(true);
+  });
+
+  test("caps recent failures ring buffer at 100", () => {
+    const stats = new DeliveryStats();
+    for (let i = 0; i < 150; i++) {
+      stats.recordFailure({
+        platform: "slack",
+        channelId: "C1",
+        op: "update",
+        error: `err-${i}`,
+      });
+    }
+    const snap = stats.getSnapshot();
+    expect(snap.recentFailures).toHaveLength(100);
+    expect(snap.recentFailures[0]?.error).toBe("err-50");
+    expect(snap.recentFailures[99]?.error).toBe("err-149");
+  });
+
+  test("tracks retries and retry successes", () => {
+    const stats = new DeliveryStats();
+    stats.recordAttempt({ platform: "slack", channelId: "C1", op: "update" });
+    stats.recordRetry({ platform: "slack", channelId: "C1", op: "update" });
+    stats.recordSuccess({
+      platform: "slack",
+      channelId: "C1",
+      op: "update",
+      retried: true,
+    });
+    const snap = stats.getSnapshot();
+    expect(snap.global.update.retries).toBe(1);
+    expect(snap.global.update.retrySuccess).toBe(1);
+    expect(snap.channels[0]?.ops.update.retrySuccess).toBe(1);
+  });
+
+  test("reset clears all state", () => {
+    const stats = new DeliveryStats();
+    stats.recordAttempt({ platform: "slack", channelId: "C1", op: "send" });
+    stats.recordFailure({
+      platform: "slack",
+      channelId: "C1",
+      op: "send",
+      error: "x",
+    });
+    stats.reset();
+    const snap = stats.getSnapshot();
+    expect(snap.channels).toHaveLength(0);
+    expect(snap.recentFailures).toHaveLength(0);
+    expect(snap.global.send.attempts).toBe(0);
+  });
+
+  test("invokes the failure hook with the recorded failure", () => {
+    const stats = new DeliveryStats();
+    const received: unknown[] = [];
+    stats.setFailureHook((failure) => {
+      received.push(failure);
+    });
+    stats.recordFailure({
+      platform: "slack",
+      channelId: "C1",
+      op: "update",
+      error: new Error("boom"),
+      rateLimited: true,
+    });
+    expect(received).toHaveLength(1);
+    const failure = received[0] as {
+      platform: string;
+      op: string;
+      rateLimited: boolean;
+      error: string;
+    };
+    expect(failure.platform).toBe("slack");
+    expect(failure.op).toBe("update");
+    expect(failure.rateLimited).toBe(true);
+    expect(failure.error).toBe("boom");
+  });
+
+  test("failure hook errors do not break recording", () => {
+    const stats = new DeliveryStats();
+    stats.setFailureHook(() => {
+      throw new Error("hook broken");
+    });
+    expect(() =>
+      stats.recordFailure({
+        platform: "slack",
+        channelId: "C1",
+        op: "send",
+        error: "x",
+      }),
+    ).not.toThrow();
+    expect(stats.getSnapshot().recentFailures).toHaveLength(1);
+  });
+
+  test("renders a slack-friendly snapshot string", () => {
+    const stats = new DeliveryStats();
+    stats.recordAttempt({ platform: "slack", channelId: "C1", op: "update" });
+    stats.recordFailure({
+      platform: "slack",
+      channelId: "C1",
+      op: "update",
+      error: "rate_limited",
+      rateLimited: true,
+    });
+    const rendered = renderDeliveryStatsForSlack({
+      channelId: "C1",
+      platform: "slack",
+      snapshot: stats.getSnapshot(),
+    });
+    expect(rendered).toContain("Delivery stats");
+    expect(rendered).toContain("`C1`");
+    expect(rendered).toContain("Recent failures");
+    expect(rendered).toContain("429");
+  });
+});
+
+describe("isRateLimitError", () => {
+  test("matches common 429 / rate-limit strings", () => {
+    expect(isRateLimitError(new Error("status 429"))).toBe(true);
+    expect(isRateLimitError(new Error("rate_limited"))).toBe(true);
+    expect(isRateLimitError(new Error("ratelimit"))).toBe(true);
+    expect(isRateLimitError(new Error("rate limit exceeded"))).toBe(true);
+  });
+
+  test("matches Slack SDK SlackAPIRateLimitedError shape", () => {
+    const err = Object.assign(new Error("An API error occurred"), {
+      data: { retry_after: 30 },
+    });
+    expect(isRateLimitError(err)).toBe(true);
+  });
+
+  test("returns false for unrelated errors", () => {
+    expect(isRateLimitError(new Error("not found"))).toBe(false);
+    expect(isRateLimitError(null)).toBe(false);
+    expect(isRateLimitError(undefined)).toBe(false);
+  });
+});

--- a/packages/ims/shared/delivery-stats.ts
+++ b/packages/ims/shared/delivery-stats.ts
@@ -1,0 +1,408 @@
+import { existsSync, mkdirSync } from "fs";
+import { writeFile } from "fs/promises";
+import { writeFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+import { log } from "@/utils";
+import { isRateLimitError as sharedIsRateLimitError } from "@/shared/delivery/rate-limit";
+
+export { getRetryAfterMs } from "@/shared/delivery/rate-limit";
+
+/**
+ * Process-wide observability for IM message delivery.
+ *
+ * This module is intentionally decoupled from Slack/Discord/Lark adapters so
+ * each platform client can record attempts/success/failures in one place and
+ * we can surface the data via a slash-style command or a JSON dump.
+ *
+ * Rationale: previously non-429 `chat.update` failures were swallowed at
+ * DEBUG log level in `packages/ims/slack/client.ts:performSlackMessageUpdate`,
+ * and `sendMessage` / `deleteMessage` had no retries or metrics. That made
+ * "status message disappeared" bugs essentially invisible. This gives us a
+ * baseline signal before we add retry / adaptive backoff.
+ */
+
+export type DeliveryPlatform = "slack" | "discord" | "lark";
+export type DeliveryOp = "send" | "update" | "delete";
+
+export type DeliveryCounters = {
+  attempts: number;
+  success: number;
+  failure: number;
+  rateLimited: number;
+  retries: number;
+  retrySuccess: number;
+};
+
+export type ChannelDeliveryStats = {
+  platform: DeliveryPlatform;
+  processorId?: string;
+  channelId: string;
+  ops: Record<DeliveryOp, DeliveryCounters>;
+  lastFailureAt?: number;
+  lastFailureError?: string;
+  lastSuccessAt?: number;
+};
+
+export type FailureRecord = {
+  timestamp: number;
+  platform: DeliveryPlatform;
+  processorId?: string;
+  channelId: string;
+  op: DeliveryOp;
+  error: string;
+  rateLimited: boolean;
+  messageTs?: string;
+};
+
+export type DeliveryStatsSnapshot = {
+  capturedAt: number;
+  global: Record<DeliveryOp, DeliveryCounters>;
+  channels: ChannelDeliveryStats[];
+  recentFailures: FailureRecord[];
+};
+
+const MAX_RECENT_FAILURES = 100;
+const DEFAULT_THROTTLE_MS = 60_000;
+
+const OPS: readonly DeliveryOp[] = ["send", "update", "delete"];
+
+function emptyCounters(): DeliveryCounters {
+  return {
+    attempts: 0,
+    success: 0,
+    failure: 0,
+    rateLimited: 0,
+    retries: 0,
+    retrySuccess: 0,
+  };
+}
+
+function emptyOpCounters(): Record<DeliveryOp, DeliveryCounters> {
+  return {
+    send: emptyCounters(),
+    update: emptyCounters(),
+    delete: emptyCounters(),
+  };
+}
+
+function buildKey(platform: DeliveryPlatform, channelId: string, processorId?: string): string {
+  return `${platform}|${processorId ?? "default"}|${channelId}`;
+}
+
+export class DeliveryStats {
+  private readonly channels = new Map<string, ChannelDeliveryStats>();
+  private readonly global = emptyOpCounters();
+  private readonly recentFailures: FailureRecord[] = [];
+  private readonly throttleState = new Map<string, number>();
+  private failureHook: ((failure: FailureRecord) => void) | undefined;
+
+  /**
+   * Register a callback invoked on every recorded failure. Used by the core
+   * layer to forward failures to Sentry without this module taking a direct
+   * dependency on observability infrastructure.
+   */
+  setFailureHook(hook: ((failure: FailureRecord) => void) | undefined): void {
+    this.failureHook = hook;
+  }
+
+  recordAttempt(params: {
+    platform: DeliveryPlatform;
+    channelId: string;
+    op: DeliveryOp;
+    processorId?: string;
+  }): void {
+    const channel = this.ensureChannel(params.platform, params.channelId, params.processorId);
+    channel.ops[params.op].attempts += 1;
+    this.global[params.op].attempts += 1;
+  }
+
+  recordSuccess(params: {
+    platform: DeliveryPlatform;
+    channelId: string;
+    op: DeliveryOp;
+    processorId?: string;
+    retried?: boolean;
+  }): void {
+    const channel = this.ensureChannel(params.platform, params.channelId, params.processorId);
+    channel.ops[params.op].success += 1;
+    this.global[params.op].success += 1;
+    channel.lastSuccessAt = Date.now();
+    if (params.retried) {
+      channel.ops[params.op].retrySuccess += 1;
+      this.global[params.op].retrySuccess += 1;
+    }
+  }
+
+  recordFailure(params: {
+    platform: DeliveryPlatform;
+    channelId: string;
+    op: DeliveryOp;
+    error: unknown;
+    rateLimited?: boolean;
+    processorId?: string;
+    messageTs?: string;
+  }): void {
+    const channel = this.ensureChannel(params.platform, params.channelId, params.processorId);
+    const errorText = stringifyError(params.error);
+    channel.ops[params.op].failure += 1;
+    this.global[params.op].failure += 1;
+    if (params.rateLimited) {
+      channel.ops[params.op].rateLimited += 1;
+      this.global[params.op].rateLimited += 1;
+    }
+    channel.lastFailureAt = Date.now();
+    channel.lastFailureError = errorText;
+
+    const record: FailureRecord = {
+      timestamp: Date.now(),
+      platform: params.platform,
+      processorId: params.processorId,
+      channelId: params.channelId,
+      op: params.op,
+      error: errorText,
+      rateLimited: Boolean(params.rateLimited),
+      messageTs: params.messageTs,
+    };
+    this.recentFailures.push(record);
+    if (this.recentFailures.length > MAX_RECENT_FAILURES) {
+      this.recentFailures.splice(0, this.recentFailures.length - MAX_RECENT_FAILURES);
+    }
+
+    if (this.failureHook) {
+      try {
+        this.failureHook(record);
+      } catch {
+        // Hook failures must never break the recording path.
+      }
+    }
+  }
+
+  recordRetry(params: {
+    platform: DeliveryPlatform;
+    channelId: string;
+    op: DeliveryOp;
+    processorId?: string;
+  }): void {
+    const channel = this.ensureChannel(params.platform, params.channelId, params.processorId);
+    channel.ops[params.op].retries += 1;
+    this.global[params.op].retries += 1;
+  }
+
+  /**
+   * Log a warning at WARN level at most once per `throttleMs` per key.
+   * Useful for noisy per-tick failures like a repeated `chat.update` error.
+   */
+  logThrottledWarn(
+    key: string,
+    message: string,
+    data?: Record<string, unknown>,
+    throttleMs: number = DEFAULT_THROTTLE_MS,
+  ): void {
+    const now = Date.now();
+    const last = this.throttleState.get(key) ?? 0;
+    if (now - last < throttleMs) return;
+    this.throttleState.set(key, now);
+    log.warn(message, data);
+  }
+
+  getSnapshot(): DeliveryStatsSnapshot {
+    return {
+      capturedAt: Date.now(),
+      global: cloneOpCounters(this.global),
+      channels: Array.from(this.channels.values()).map(cloneChannel),
+      recentFailures: [...this.recentFailures],
+    };
+  }
+
+  getChannelStats(
+    platform: DeliveryPlatform,
+    channelId: string,
+    processorId?: string,
+  ): ChannelDeliveryStats | undefined {
+    const channel = this.channels.get(buildKey(platform, channelId, processorId));
+    return channel ? cloneChannel(channel) : undefined;
+  }
+
+  reset(): void {
+    this.channels.clear();
+    this.recentFailures.length = 0;
+    for (const op of OPS) {
+      this.global[op] = emptyCounters();
+    }
+    this.throttleState.clear();
+  }
+
+  async dumpToFile(path: string = defaultDumpPath()): Promise<string> {
+    ensureDir(path);
+    const snapshot = this.getSnapshot();
+    await writeFile(path, JSON.stringify(snapshot, null, 2), "utf8");
+    return path;
+  }
+
+  dumpToFileSync(path: string = defaultDumpPath()): string {
+    ensureDir(path);
+    const snapshot = this.getSnapshot();
+    writeFileSync(path, JSON.stringify(snapshot, null, 2), "utf8");
+    return path;
+  }
+
+  private ensureChannel(
+    platform: DeliveryPlatform,
+    channelId: string,
+    processorId?: string,
+  ): ChannelDeliveryStats {
+    const key = buildKey(platform, channelId, processorId);
+    let channel = this.channels.get(key);
+    if (!channel) {
+      channel = {
+        platform,
+        processorId,
+        channelId,
+        ops: emptyOpCounters(),
+      };
+      this.channels.set(key, channel);
+    }
+    return channel;
+  }
+}
+
+export function defaultDumpPath(): string {
+  return join(homedir(), ".config", "ode", "diagnostics", "delivery-stats.json");
+}
+
+function ensureDir(filePath: string): void {
+  const dir = filePath.substring(0, filePath.lastIndexOf("/"));
+  if (dir && !existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+}
+
+function stringifyError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}
+
+function cloneOpCounters(
+  ops: Record<DeliveryOp, DeliveryCounters>,
+): Record<DeliveryOp, DeliveryCounters> {
+  return {
+    send: { ...ops.send },
+    update: { ...ops.update },
+    delete: { ...ops.delete },
+  };
+}
+
+function cloneChannel(channel: ChannelDeliveryStats): ChannelDeliveryStats {
+  return {
+    platform: channel.platform,
+    processorId: channel.processorId,
+    channelId: channel.channelId,
+    ops: cloneOpCounters(channel.ops),
+    lastFailureAt: channel.lastFailureAt,
+    lastFailureError: channel.lastFailureError,
+    lastSuccessAt: channel.lastSuccessAt,
+  };
+}
+
+// Module-level singleton so every IM adapter records into the same counters.
+export const deliveryStats = new DeliveryStats();
+
+/**
+ * Detect a rate-limit error across SDK variants. Thin re-export of the shared
+ * detector so both core and ims layers agree on 429 semantics — previously
+ * each had its own implementation and they disagreed on Slack SDK errors
+ * carrying `data.retry_after`.
+ */
+export const isRateLimitError = sharedIsRateLimitError;
+
+export function renderDeliveryStatsForSlack(params: {
+  channelId?: string;
+  platform?: DeliveryPlatform;
+  snapshot?: DeliveryStatsSnapshot;
+  recentLimit?: number;
+}): string {
+  const snapshot = params.snapshot ?? deliveryStats.getSnapshot();
+  const lines: string[] = [];
+  const platformLabel = params.platform ? `[${params.platform}] ` : "";
+  lines.push(`*${platformLabel}Delivery stats* (captured ${new Date(snapshot.capturedAt).toISOString()})`);
+
+  const globalLine = renderCountersLine(snapshot.global);
+  lines.push(`• *global* — ${globalLine}`);
+
+  const channels = snapshot.channels.filter((c) => {
+    if (params.platform && c.platform !== params.platform) return false;
+    if (params.channelId && c.channelId !== params.channelId) return false;
+    return true;
+  });
+
+  if (params.channelId) {
+    const match = channels.find((c) => c.channelId === params.channelId);
+    if (match) {
+      lines.push(`• *channel* \`${params.channelId}\` — ${renderCountersLine(match.ops)}`);
+      if (match.lastFailureError) {
+        const ts = match.lastFailureAt ? new Date(match.lastFailureAt).toISOString() : "?";
+        lines.push(`   last failure @ ${ts}: \`${truncate(match.lastFailureError, 200)}\``);
+      }
+    } else {
+      lines.push(`• *channel* \`${params.channelId}\` — no activity recorded yet`);
+    }
+  } else if (channels.length > 0) {
+    const top = [...channels]
+      .sort((a, b) => sumFailures(b.ops) - sumFailures(a.ops))
+      .slice(0, 5);
+    for (const c of top) {
+      lines.push(`• \`${c.channelId}\` (${c.platform}) — ${renderCountersLine(c.ops)}`);
+    }
+  }
+
+  const recent = snapshot.recentFailures
+    .filter((r) => {
+      if (params.platform && r.platform !== params.platform) return false;
+      if (params.channelId && r.channelId !== params.channelId) return false;
+      return true;
+    })
+    .slice(-(params.recentLimit ?? 5));
+
+  if (recent.length > 0) {
+    lines.push(`*Recent failures (${recent.length}):*`);
+    for (const failure of recent) {
+      const ts = new Date(failure.timestamp).toISOString();
+      const tag = failure.rateLimited ? "429" : "ERR";
+      lines.push(
+        `   [${tag}] ${ts} ${failure.op} \`${failure.channelId}\`: ${truncate(failure.error, 140)}`,
+      );
+    }
+  }
+  return lines.join("\n");
+}
+
+function renderCountersLine(ops: Record<DeliveryOp, DeliveryCounters>): string {
+  const parts: string[] = [];
+  for (const op of OPS) {
+    const c = ops[op];
+    if (c.attempts === 0 && c.failure === 0) continue;
+    const rate = c.attempts > 0 ? Math.round((c.success / c.attempts) * 100) : 0;
+    const pieces = [`${c.success}/${c.attempts} ok (${rate}%)`];
+    if (c.failure > 0) pieces.push(`${c.failure} fail`);
+    if (c.rateLimited > 0) pieces.push(`${c.rateLimited} 429`);
+    if (c.retries > 0) pieces.push(`${c.retries} retries`);
+    parts.push(`${op}: ${pieces.join(", ")}`);
+  }
+  if (parts.length === 0) return "(no activity)";
+  return parts.join(" · ");
+}
+
+function sumFailures(ops: Record<DeliveryOp, DeliveryCounters>): number {
+  return ops.send.failure + ops.update.failure + ops.delete.failure;
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, max - 1)}…`;
+}

--- a/packages/ims/shared/incoming-message-processor.test.ts
+++ b/packages/ims/shared/incoming-message-processor.test.ts
@@ -12,6 +12,16 @@ describe("incoming message flow helpers", () => {
     expect(parseIncomingCommand("help")).toBeNull();
   });
 
+  it("parses stats command variants", () => {
+    expect(parseIncomingCommand("<@U123> stats")).toBe("stats");
+    expect(parseIncomingCommand("@ode: stats")).toBe("stats");
+    expect(parseIncomingCommand("／stats")).toBe("stats");
+    expect(parseIncomingCommand("/stats")).toBe("stats");
+    expect(parseIncomingCommand("<@U123> debug stats")).toBe("stats");
+    expect(parseIncomingCommand("stats")).toBe("stats");
+    expect(parseIncomingCommand("statsy")).toBeNull();
+  });
+
   it("formats drop reason messages", () => {
     expect(formatIncomingDropMessage("not_mentioned_and_inactive")).toContain("Not mentioned");
     expect(formatIncomingDropMessage("self_message")).toContain("Self message");

--- a/packages/ims/shared/incoming-message-processor.ts
+++ b/packages/ims/shared/incoming-message-processor.ts
@@ -9,7 +9,7 @@ export type IncomingFlowResult =
   | { type: "stop"; text: string }
   | { type: "forward"; text: string };
 
-export type IncomingCommand = "setting";
+export type IncomingCommand = "setting" | "stats";
 
 export function formatIncomingDropMessage(reason: IncomingIgnoreReason): string {
   switch (reason) {
@@ -31,5 +31,6 @@ export function parseIncomingCommand(text: string): IncomingCommand | null {
     .replace(/^(?:<@[^>]+>|@[^\s:：,，]+)[:：,，]?\s+/g, "")
     .toLowerCase();
   if (/^\/?settings?\b/.test(normalized)) return "setting";
+  if (/^\/?(?:debug\s+)?stats\b/.test(normalized)) return "stats";
   return null;
 }

--- a/packages/ims/slack/client.ts
+++ b/packages/ims/slack/client.ts
@@ -29,6 +29,7 @@ import {
 import { createProcessorManager } from "@/ims/shared/processor-manager";
 import { SlackAuthRegistry, type WorkspaceAuth } from "@/ims/slack/state/auth-registry";
 import { SlackMessageUpdateManager } from "@/ims/slack/message-update-manager";
+import { deliveryStats, isRateLimitError } from "@/ims/shared/delivery-stats";
 
 export interface MessageContext {
   channelId: string;
@@ -330,16 +331,51 @@ export async function sendMessage(
 
   let lastTs: string | undefined;
   for (const chunk of chunks) {
-    const result = await slackApp.client.chat.postMessage({
-      channel: rawChannelId,
-      thread_ts: threadId,
-      text: chunk,
-      token: botToken,
+    deliveryStats.recordAttempt({
+      platform: "slack",
+      channelId: rawChannelId,
+      op: "send",
+      processorId,
     });
-    lastTs = result.ts;
-    if (botToken && result.ts) {
-      slackAuthRegistry.setThreadBotToken(rawChannelId, threadId, botToken);
-      slackAuthRegistry.setMessageBotToken(rawChannelId, result.ts, botToken);
+    try {
+      const result = await slackApp.client.chat.postMessage({
+        channel: rawChannelId,
+        thread_ts: threadId,
+        text: chunk,
+        token: botToken,
+      });
+      deliveryStats.recordSuccess({
+        platform: "slack",
+        channelId: rawChannelId,
+        op: "send",
+        processorId,
+      });
+      lastTs = result.ts;
+      if (botToken && result.ts) {
+        slackAuthRegistry.setThreadBotToken(rawChannelId, threadId, botToken);
+        slackAuthRegistry.setMessageBotToken(rawChannelId, result.ts, botToken);
+      }
+    } catch (err) {
+      const rateLimited = isRateLimitError(err);
+      deliveryStats.recordFailure({
+        platform: "slack",
+        channelId: rawChannelId,
+        op: "send",
+        error: err,
+        rateLimited,
+        processorId,
+      });
+      deliveryStats.logThrottledWarn(
+        `slack-send:${rawChannelId}`,
+        "Slack sendMessage failed",
+        {
+          channelId: rawChannelId,
+          threadId,
+          rateLimited,
+          error: String(err),
+        },
+      );
+      throw err;
     }
   }
   return lastTs;
@@ -375,14 +411,48 @@ export async function sendChannelMessage(
 
   let lastTs: string | undefined;
   for (const chunk of chunks) {
-    const result = await slackApp.client.chat.postMessage({
-      channel: rawChannelId,
-      text: chunk,
-      token: botToken,
+    deliveryStats.recordAttempt({
+      platform: "slack",
+      channelId: rawChannelId,
+      op: "send",
+      processorId,
     });
-    lastTs = result.ts;
-    if (botToken && result.ts) {
-      slackAuthRegistry.setMessageBotToken(rawChannelId, result.ts, botToken);
+    try {
+      const result = await slackApp.client.chat.postMessage({
+        channel: rawChannelId,
+        text: chunk,
+        token: botToken,
+      });
+      deliveryStats.recordSuccess({
+        platform: "slack",
+        channelId: rawChannelId,
+        op: "send",
+        processorId,
+      });
+      lastTs = result.ts;
+      if (botToken && result.ts) {
+        slackAuthRegistry.setMessageBotToken(rawChannelId, result.ts, botToken);
+      }
+    } catch (err) {
+      const rateLimited = isRateLimitError(err);
+      deliveryStats.recordFailure({
+        platform: "slack",
+        channelId: rawChannelId,
+        op: "send",
+        error: err,
+        rateLimited,
+        processorId,
+      });
+      deliveryStats.logThrottledWarn(
+        `slack-send-channel:${rawChannelId}`,
+        "Slack sendChannelMessage failed",
+        {
+          channelId: rawChannelId,
+          rateLimited,
+          error: String(err),
+        },
+      );
+      throw err;
     }
   }
   return lastTs;
@@ -393,8 +463,14 @@ export async function deleteMessage(
   messageTs: string,
   processorId?: string
 ): Promise<void> {
+  const rawChannelId = channelId;
+  deliveryStats.recordAttempt({
+    platform: "slack",
+    channelId: rawChannelId,
+    op: "delete",
+    processorId,
+  });
   try {
-    const rawChannelId = channelId;
     const slackApp = getApp();
     const botToken = getSlackBotTokenForProcessor(processorId)
       ?? slackAuthRegistry.getMessageBotToken(rawChannelId, messageTs)
@@ -407,8 +483,34 @@ export async function deleteMessage(
       ts: messageTs,
       token: botToken,
     });
-  } catch {
-    // Ignore delete failures
+    deliveryStats.recordSuccess({
+      platform: "slack",
+      channelId: rawChannelId,
+      op: "delete",
+      processorId,
+    });
+  } catch (err) {
+    const rateLimited = isRateLimitError(err);
+    deliveryStats.recordFailure({
+      platform: "slack",
+      channelId: rawChannelId,
+      op: "delete",
+      error: err,
+      rateLimited,
+      processorId,
+      messageTs,
+    });
+    deliveryStats.logThrottledWarn(
+      `slack-delete:${rawChannelId}`,
+      "Slack deleteMessage failed",
+      {
+        channelId: rawChannelId,
+        messageTs,
+        rateLimited,
+        error: String(err),
+      },
+    );
+    // Ignore delete failures for callers; recorded in stats instead.
   }
 }
 
@@ -418,8 +520,14 @@ async function performSlackMessageUpdate(
   text: string,
   processorId?: string
 ): Promise<void> {
+  const rawChannelId = channelId;
+  deliveryStats.recordAttempt({
+    platform: "slack",
+    channelId: rawChannelId,
+    op: "update",
+    processorId,
+  });
   try {
-    const rawChannelId = channelId;
     const slackApp = getApp();
     const formattedText = markdownToSlack(text);
     const truncatedText = truncateForSlack(formattedText);
@@ -435,13 +543,43 @@ async function performSlackMessageUpdate(
       text: truncatedText,
       token: botToken,
     });
+    deliveryStats.recordSuccess({
+      platform: "slack",
+      channelId: rawChannelId,
+      op: "update",
+      processorId,
+    });
   } catch (err) {
+    const rateLimited = isRateLimitError(err);
+    deliveryStats.recordFailure({
+      platform: "slack",
+      channelId: rawChannelId,
+      op: "update",
+      error: err,
+      rateLimited,
+      processorId,
+      messageTs,
+    });
     const message = String(err);
     log.debug("Failed to update message", { error: message });
-    const normalized = message.toLowerCase();
-    if (normalized.includes("429") || normalized.includes("rate_limited") || normalized.includes("rate limit")) {
+    if (rateLimited) {
+      // Rate-limit errors are rethrown so the core layer can mark the message
+      // as 429-ed and switch to the "post final result as a new message"
+      // fallback path in runtime-support.ts.
       throw err;
     }
+    // Non-429 update failures used to be silently swallowed at DEBUG level,
+    // which hid "status message disappeared" bugs. Surface them at WARN,
+    // throttled per channel to avoid flooding the logs on a flapping channel.
+    deliveryStats.logThrottledWarn(
+      `slack-update:${rawChannelId}`,
+      "Slack updateMessage failed (non-429)",
+      {
+        channelId: rawChannelId,
+        messageTs,
+        error: message,
+      },
+    );
   }
 }
 

--- a/packages/ims/slack/message-router.ts
+++ b/packages/ims/slack/message-router.ts
@@ -8,6 +8,10 @@ import type { InboundDecision } from "@/core/model/inbound-decision";
 import type { RawInboundEvent } from "@/core/model/raw-inbound-event";
 import { RuntimeCache } from "@/shared/cache/runtime-cache";
 import { SlackInboundAdapter } from "@/ims/slack/slack-inbound-adapter";
+import {
+  deliveryStats,
+  renderDeliveryStatsForSlack,
+} from "@/ims/shared/delivery-stats";
 
 type RouterDeps = {
   app: any;
@@ -163,27 +167,71 @@ async function maybeHandleLauncherCommand(params: {
   cleanText: string;
   isMention: boolean;
   channelId: string;
+  threadId: string;
   userId: string;
   client: any;
+  say: any;
 }): Promise<boolean> {
-  const { deps, cleanText, isMention, channelId, userId, client } = params;
+  const { deps, cleanText, isMention, channelId, threadId, userId, client, say } = params;
   const command = parseIncomingCommand(cleanText);
-  if (command !== "setting") return false;
-  if (isMention) {
-    log.info("Slack settings launcher command matched", {
-      channelId,
-      userId,
-      cleanText,
-    });
-    await deps.postGeneralSettingsLauncher(channelId, userId, client);
-  } else {
-    log.debug("Slack settings command ignored because bot was not mentioned", {
-      channelId,
-      userId,
-      cleanText,
-    });
+  if (command === "setting") {
+    if (isMention) {
+      log.info("Slack settings launcher command matched", {
+        channelId,
+        userId,
+        cleanText,
+      });
+      await deps.postGeneralSettingsLauncher(channelId, userId, client);
+    } else {
+      log.debug("Slack settings command ignored because bot was not mentioned", {
+        channelId,
+        userId,
+        cleanText,
+      });
+    }
+    return true;
   }
-  return true;
+  if (command === "stats") {
+    if (isMention) {
+      log.info("Slack delivery stats command matched", {
+        channelId,
+        userId,
+        cleanText,
+      });
+      await handleStatsCommand({ channelId, threadId, say });
+    } else {
+      log.debug("Slack stats command ignored because bot was not mentioned", {
+        channelId,
+        userId,
+        cleanText,
+      });
+    }
+    return true;
+  }
+  return false;
+}
+
+async function handleStatsCommand(params: {
+  channelId: string;
+  threadId: string;
+  say: any;
+}): Promise<void> {
+  const { channelId, threadId, say } = params;
+  const rendered = renderDeliveryStatsForSlack({
+    channelId,
+    platform: "slack",
+  });
+  let dumpNote = "";
+  try {
+    const dumpPath = await deliveryStats.dumpToFile();
+    dumpNote = `\n_dumped full snapshot to_ \`${dumpPath}\``;
+  } catch (err) {
+    dumpNote = `\n_failed to dump snapshot: ${String(err)}_`;
+  }
+  await say({
+    text: `${rendered}${dumpNote}`,
+    thread_ts: threadId,
+  });
 }
 
 function getCacheKey(credentialKey?: string): string | undefined {
@@ -341,8 +389,10 @@ export function registerSlackMessageRouter(deps: RouterDeps): void {
         cleanText,
         isMention,
         channelId,
+        threadId,
         userId,
         client,
+        say,
       })) {
         return;
       }

--- a/packages/shared/delivery/rate-limit.test.ts
+++ b/packages/shared/delivery/rate-limit.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test";
+import { isRateLimitError, getRetryAfterMs } from "./rate-limit";
+
+describe("shared isRateLimitError", () => {
+  test("matches explicit 429 / rate-limited strings", () => {
+    expect(isRateLimitError(new Error("status 429"))).toBe(true);
+    expect(isRateLimitError(new Error("rate_limited"))).toBe(true);
+    expect(isRateLimitError(new Error("rate limit exceeded"))).toBe(true);
+    expect(isRateLimitError(new Error("ratelimit"))).toBe(true);
+  });
+
+  test("matches Slack SDK error shape with data.retry_after", () => {
+    const err = Object.assign(new Error("An API error occurred: something"), {
+      data: { retry_after: 30, error: "unknown" },
+    });
+    expect(isRateLimitError(err)).toBe(true);
+  });
+
+  test("matches Discord-style err.code containing 'rate'", () => {
+    const err = Object.assign(new Error("http 429"), { code: "RateLimitedError" });
+    expect(isRateLimitError(err)).toBe(true);
+  });
+
+  test("rejects unrelated errors", () => {
+    expect(isRateLimitError(new Error("channel_not_found"))).toBe(false);
+    expect(isRateLimitError(null)).toBe(false);
+    expect(isRateLimitError(undefined)).toBe(false);
+    expect(isRateLimitError({ data: {} })).toBe(false);
+  });
+});
+
+describe("getRetryAfterMs", () => {
+  test("extracts Slack-style seconds", () => {
+    expect(getRetryAfterMs({ data: { retry_after: 30 } })).toBe(30_000);
+  });
+
+  test("returns millisecond values as-is", () => {
+    expect(getRetryAfterMs({ retry_after: 2500 })).toBe(2500);
+    expect(getRetryAfterMs({ retryAfter: 7500 })).toBe(7500);
+  });
+
+  test("parses string numerics", () => {
+    expect(getRetryAfterMs({ data: { retry_after: "10" } })).toBe(10_000);
+  });
+
+  test("returns undefined for missing/invalid", () => {
+    expect(getRetryAfterMs(null)).toBeUndefined();
+    expect(getRetryAfterMs(new Error("boom"))).toBeUndefined();
+    expect(getRetryAfterMs({ data: { retry_after: "nope" } })).toBeUndefined();
+  });
+});

--- a/packages/shared/delivery/rate-limit.ts
+++ b/packages/shared/delivery/rate-limit.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared rate-limit detection logic.
+ *
+ * Lives in @/shared so both @/core (runtime adapters) and @/ims (platform
+ * clients) can use the same detection — previously each layer had its own
+ * detector and the core one was weaker, letting Slack SDK errors that carry
+ * `data.retry_after` but no "429" substring escape detection. That caused
+ * `wasRateLimited()` to return false when it shouldn't, which in turn made
+ * the finalization path attempt a real edit/delete on an already-rate-limited
+ * message, amplifying the 429 burst.
+ */
+
+export function isRateLimitError(err: unknown): boolean {
+  if (!err) return false;
+  const message = stringifyError(err).toLowerCase();
+  if (
+    message.includes("429") ||
+    message.includes("rate_limited") ||
+    message.includes("rate limit") ||
+    message.includes("ratelimit")
+  ) {
+    return true;
+  }
+  if (typeof err === "object" && err !== null) {
+    const data = (err as { data?: { retry_after?: unknown } }).data;
+    if (data && typeof data.retry_after !== "undefined") return true;
+    const code = (err as { code?: unknown }).code;
+    if (typeof code === "string" && code.toLowerCase().includes("rate")) return true;
+  }
+  return false;
+}
+
+/**
+ * Best-effort extraction of a `Retry-After` hint in milliseconds.
+ * Slack SDK surfaces `err.data.retry_after` in seconds. Discord uses
+ * `err.retry_after` in ms or seconds depending on context; we normalize
+ * conservatively (values < 1000 treated as seconds).
+ */
+export function getRetryAfterMs(err: unknown): number | undefined {
+  if (!err || typeof err !== "object") return undefined;
+  const record = err as {
+    data?: { retry_after?: unknown };
+    retry_after?: unknown;
+    retryAfter?: unknown;
+  };
+  const candidate =
+    record.data?.retry_after ?? record.retry_after ?? record.retryAfter;
+  if (typeof candidate === "number" && Number.isFinite(candidate)) {
+    return candidate < 1000 ? candidate * 1000 : candidate;
+  }
+  if (typeof candidate === "string") {
+    const parsed = Number(candidate);
+    if (Number.isFinite(parsed)) {
+      return parsed < 1000 ? parsed * 1000 : parsed;
+    }
+  }
+  return undefined;
+}
+
+function stringifyError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}


### PR DESCRIPTION
## Why
Status messages in Slack sometimes disappeared or froze mid-run — the initial post was lost, the live-updating status stuck, or it kept trying to edit a 429'd message. Root causes were silent failure paths with no metrics to diagnose them.

## What — Observability
- `DeliveryStats` singleton (`packages/ims/shared/delivery-stats.ts`) tracks `attempts / success / failure / rateLimited / retries / retrySuccess` per `(platform, channelId, op)` + 100-entry ring buffer of recent failures.
- Instrument Slack `sendMessage`, `sendChannelMessage`, `updateMessage`, `deleteMessage`. Previously swallowed non-429 update failures are now `log.warn` (throttled 1/min per channel).
- `@ode stats` (also `/stats`, `debug stats`) renders current channel's counters and dumps full snapshot JSON to `~/.config/ode/diagnostics/delivery-stats.json`.
- Snapshot also dumped on `SIGTERM` / `SIGINT`.
- `@sentry/bun` integration (`packages/core/observability/sentry.ts`): every failure is captured with `platform / op / rate_limited / channel_id` tags + per-channel fingerprint dedup (429: 1/5min, other: 1/min). DSN configurable via `ODE_SENTRY_DSN`, disable via `ODE_SENTRY_DISABLED=1`.

## What — Resilience
- **Unified `isRateLimitError`** (`packages/shared/delivery/rate-limit.ts`) so core and ims layers agree. Previously core's substring-only detector missed Slack SDK errors carrying `data.retry_after` but no "429" string, causing `wasRateLimited()` to return false and letting `publishFinalText` trigger more 429s on an already-throttled message.
- **Progress tick no longer dies on fallback send throws.** `runProgressTick` and the replacement-status `sendMessage` calls are now wrapped — channel-wide throttling used to produce an unhandled rejection that froze the status for the rest of the run.
- **Initial `sendMessage` throw handled** in `runOpenRequest` — a transient hiccup no longer aborts the whole request silently.
- **Fallback guarded by `request.state === "processing"`** so a stop command mid-tick doesn't ghost-write a new status after the old one was deleted.
- **Replacement `statusTs` persisted immediately** (not debounced) so a crash in the window doesn't leave disk pointing at the old 429'd TS — recovery would otherwise edit the wrong message.
- `question.asked` fire-and-forget update now has a `catch`.
- `handleStopCommand` logs `abortSession` failures at `warn` instead of silent `catch {}`.

## Tests
- Unit: `DeliveryStats` aggregation + ring buffer, failure hook, shared rate-limit detector (Slack SDK shape, Discord `code`, null-safe).
- E2E: new cases in `runtime-resilience-e2e.test.ts` — initial send throws; fallback replacement send throws (simulates channel-wide 429).
- Full suite: **217 pass / 0 fail**, `bun run typecheck` clean.

## Behavior / ops notes
- Default Sentry DSN is committed (it's a public identifier; override with `ODE_SENTRY_DSN=<your-dsn>` or set `ODE_SENTRY_DISABLED=1` to turn off).
- `@ode stats` reply is a regular thread message (not ephemeral) — users in the channel can see it. Use the JSON dump for detailed diagnostics.
- No change to 429 fallback semantics (still switches to "post final as new message"). A future PR can add retry + adaptive throttling once stats/Sentry confirm where the failures are.

Version bumped to `0.1.24`.