### PR TITLE
fix(opencode): stop echoing user prompt as final reply

### DIFF
--- a/packages/agents/test/session-inspector.test.ts
+++ b/packages/agents/test/session-inspector.test.ts
@@ -627,4 +627,134 @@ describe("session inspector", () => {
       { content: "Keep final waiting state", status: "completed" },
     ]);
   });
+
+  it("ignores TextPart events that belong to a user message", () => {
+    const now = Date.now();
+    const userPrompt = "You can use accounts in infra/readme, can connect to staging db";
+
+    const state = buildSessionMessageState([
+      // OpenCode announces the user message first; this records role="user"
+      // for messageID "msg_user_1".
+      {
+        timestamp: now,
+        type: "message.updated",
+        data: {
+          payload: {
+            type: "message.updated",
+            properties: {
+              info: {
+                id: "msg_user_1",
+                sessionID: "ses_1",
+                role: "user",
+              },
+            },
+          },
+        },
+      },
+      // A TextPart for the user message arrives. This MUST NOT populate
+      // state.currentText - previously this caused the bot to echo the
+      // user's prompt back as the final response.
+      {
+        timestamp: now + 1,
+        type: "message.part.updated",
+        data: {
+          payload: {
+            type: "message.part.updated",
+            properties: {
+              part: {
+                id: "prt_user_text_1",
+                sessionID: "ses_1",
+                messageID: "msg_user_1",
+                type: "text",
+                text: userPrompt,
+              },
+            },
+          },
+        },
+      },
+      // The assistant message is created; role="assistant" now tracked
+      // under messageID "msg_asst_1". The turn runs a tool and stops
+      // without emitting any assistant text.
+      {
+        timestamp: now + 2,
+        type: "message.updated",
+        data: {
+          payload: {
+            type: "message.updated",
+            properties: {
+              info: {
+                id: "msg_asst_1",
+                sessionID: "ses_1",
+                role: "assistant",
+              },
+            },
+          },
+        },
+      },
+      {
+        timestamp: now + 3,
+        type: "message.part.updated",
+        data: {
+          payload: {
+            type: "message.part.updated",
+            properties: {
+              part: {
+                id: "tool_1",
+                sessionID: "ses_1",
+                messageID: "msg_asst_1",
+                type: "tool",
+                tool: "Read",
+                state: { status: "completed" },
+              },
+            },
+          },
+        },
+      },
+    ]);
+
+    expect(state.currentText).toBe("");
+    expect(state.tools.length).toBe(1);
+  });
+
+  it("still captures assistant TextPart as currentText", () => {
+    const now = Date.now();
+    const state = buildSessionMessageState([
+      {
+        timestamp: now,
+        type: "message.updated",
+        data: {
+          payload: {
+            type: "message.updated",
+            properties: {
+              info: {
+                id: "msg_asst_1",
+                sessionID: "ses_1",
+                role: "assistant",
+              },
+            },
+          },
+        },
+      },
+      {
+        timestamp: now + 1,
+        type: "message.part.updated",
+        data: {
+          payload: {
+            type: "message.part.updated",
+            properties: {
+              part: {
+                id: "prt_asst_text_1",
+                sessionID: "ses_1",
+                messageID: "msg_asst_1",
+                type: "text",
+                text: "Here is the summary of changes",
+              },
+            },
+          },
+        },
+      },
+    ]);
+
+    expect(state.currentText).toBe("Here is the summary of changes");
+  });
 });

--- a/packages/core/kernel/request-run.ts
+++ b/packages/core/kernel/request-run.ts
@@ -36,6 +36,22 @@ import {
   log,
 } from "@/utils";
 
+/**
+ * Guard against publishing the user's own prompt as the bot's final reply.
+ *
+ * OpenCode streams a TextPart for user messages too, and `request.currentText`
+ * may end up holding that user prompt if the turn produced no assistant text
+ * (e.g. tool-only turn or an empty `result.responses`). Previously this
+ * caused the bot to echo the user back into Slack verbatim.
+ */
+function isPromptEcho(candidate: string | undefined, prompt: string | undefined): boolean {
+  if (!candidate || !prompt) return false;
+  const c = candidate.trim();
+  const p = prompt.trim();
+  if (!c || !p) return false;
+  return c === p;
+}
+
 type RunnerDeps = {
   im: IMAdapter;
   agent: AgentAdapter;
@@ -784,7 +800,8 @@ export async function runTrackedRequest(
 
     if (result.type === "stop") {
       const fallbackText = request.currentText?.trim();
-      const finalText = fallbackText || "_Done_";
+      const safeFallback = isPromptEcho(fallbackText, request.prompt) ? undefined : fallbackText;
+      const finalText = safeFallback || "_Done_";
       await publishFinalText(finalText);
       tryCompleteAgentResult({
         detailId: agentResultDetailId,
@@ -800,7 +817,7 @@ export async function runTrackedRequest(
         log.debug("OpenCode prompt rejected after stop", { error: String(err) });
       });
 
-      return { responses: [], stopFallbackText: fallbackText };
+      return { responses: [], stopFallbackText: safeFallback };
     }
 
     if (result.responses.length === 0) {
@@ -812,7 +829,10 @@ export async function runTrackedRequest(
       });
     }
 
-    const finalText = buildFinalResponseText(result.responses) ?? (request.currentText?.trim() || "_Done_");
+    const builtText = buildFinalResponseText(result.responses);
+    const rawFallback = request.currentText?.trim();
+    const safeFallback = isPromptEcho(rawFallback, request.prompt) ? undefined : rawFallback;
+    const finalText = builtText ?? (safeFallback || "_Done_");
     await publishFinalText(finalText);
     tryCompleteAgentResult({
       detailId: agentResultDetailId,

--- a/packages/core/test/request-runner.test.ts
+++ b/packages/core/test/request-runner.test.ts
@@ -146,4 +146,42 @@ describe("runTrackedRequest", () => {
     expect(result.responses).toEqual([]);
     expect(published).toEqual(["_Done_"]);
   });
+
+  it("does not echo the user prompt when currentText is the prompt itself", async () => {
+    const request = buildRequest();
+    request.prompt = "You can use accounts in infra/readme, can connect to staging db";
+    // Simulate the bug where OpenCode's user TextPart leaked into
+    // currentText. Without the fix this value would be published back.
+    request.currentText = request.prompt;
+    const published: string[] = [];
+
+    const result = await runTrackedRequest({
+      deps: {
+        agent: {
+          supportsEventStream: false,
+        } as any,
+        im: {
+          updateMessage: async () => {},
+        } as any,
+      },
+      request,
+      workingPath: "/tmp/project",
+      liveEventHistory: new Map(),
+      liveParsedState: new Map(),
+      // Tool-only turn: no assistant text responses.
+      sendPrompt: async () => [],
+      onProgressTick: async () => {},
+      onComplete: () => {},
+      onFail: () => {},
+      publishFinalText: async (text) => {
+        published.push(text);
+      },
+      failureLogLabel: "runner failed",
+      ...buildRunParams(),
+    });
+
+    expect(result.responses).toEqual([]);
+    expect(published).toEqual(["_Done_"]);
+    expect(published[0]).not.toBe(request.prompt);
+  });
 });

--- a/packages/utils/session-inspector.ts
+++ b/packages/utils/session-inspector.ts
@@ -300,9 +300,21 @@ function extractMessageInfo(eventProps: Record<string, unknown>): Record<string,
   return message;
 }
 
-function applyMessageUpdatedEvent(state: SessionMessageState, eventProps: Record<string, unknown>): void {
+function applyMessageUpdatedEvent(
+  state: SessionMessageState,
+  eventProps: Record<string, unknown>,
+  messageRoles?: Map<string, string>
+): void {
   const info = extractMessageInfo(eventProps);
   if (!info) return;
+
+  if (messageRoles) {
+    const messageId = typeof info.id === "string" ? info.id : undefined;
+    const role = typeof info.role === "string" ? info.role : undefined;
+    if (messageId && role) {
+      messageRoles.set(messageId, role);
+    }
+  }
 
   applyMetadataFromRecord(state, info);
 }
@@ -360,11 +372,21 @@ function normalizeReasoningStatus(text: string): string {
 function applyMessagePartUpdatedEvent(
   state: SessionMessageState,
   eventProps: Record<string, unknown>,
-  provider?: AgentProviderId
+  provider?: AgentProviderId,
+  messageRoles?: Map<string, string>
 ): void {
   const part = (eventProps as { part?: Record<string, unknown> }).part;
   if (!part) return;
   const isSessionScopedPart = typeof part.sessionID === "string";
+
+  // Skip parts that belong to a user message (user prompt TextParts in
+  // OpenCode must not be treated as assistant output). If we don't yet
+  // know the role for this messageID we fall through; tool parts and
+  // assistant messages will still be applied, and any later
+  // message.updated event will correct the mapping for subsequent parts.
+  const messageId = typeof part.messageID === "string" ? part.messageID : undefined;
+  const role = messageId && messageRoles ? messageRoles.get(messageId) : undefined;
+  const isUserMessagePart = role === "user";
 
   if (part.type === "tool") {
     const toolState = (part.state || {}) as Record<string, unknown>;
@@ -403,6 +425,9 @@ function applyMessagePartUpdatedEvent(
   }
 
   if (part.type === "text" && typeof part.text === "string") {
+    if (isUserMessagePart) {
+      return;
+    }
     state.currentText = part.text;
     if (isSessionScopedPart) {
       updatePhaseStatus(state, "Drafting response", provider);
@@ -411,6 +436,9 @@ function applyMessagePartUpdatedEvent(
   }
 
   if (part.type === "reasoning" && typeof part.text === "string") {
+    if (isUserMessagePart) {
+      return;
+    }
     state.thinkingText = part.text;
     if (isSessionScopedPart) {
       updatePhaseStatus(state, normalizeReasoningStatus(part.text), provider);
@@ -419,6 +447,9 @@ function applyMessagePartUpdatedEvent(
   }
 
   if (part.type === "thinking" && typeof part.text === "string") {
+    if (isUserMessagePart) {
+      return;
+    }
     state.thinkingText = part.text;
     if (isSessionScopedPart) {
       updatePhaseStatus(state, normalizeReasoningStatus(part.text), provider);
@@ -531,6 +562,11 @@ export function buildSessionMessageState(
   const kiloToolById = new Map<string, SessionTool>();
   const geminiToolById = new Map<string, SessionTool>();
   const kiroTodoById = new Map<string, SessionTodo>();
+  // Map of messageID -> role ("user" | "assistant" | ...) built from
+  // `message.updated` events. Used to avoid treating user prompt TextParts
+  // as assistant output (OpenCode emits TextPart for both roles and
+  // TextPart itself does not carry a role field).
+  const messageRoles = new Map<string, string>();
   const kiloStreamState: StreamStateMaps<StreamToolState> = {
     textByIndex: sharedStreamState.textByIndex,
     thinkingByIndex: sharedStreamState.thinkingByIndex,
@@ -632,7 +668,7 @@ export function buildSessionMessageState(
     }
 
     if (type === "message.updated") {
-      applyMessageUpdatedEvent(state, eventProps);
+      applyMessageUpdatedEvent(state, eventProps, messageRoles);
     }
 
     if (type === "session.status") {
@@ -640,7 +676,7 @@ export function buildSessionMessageState(
     }
 
     if (type === "message.part.updated") {
-      applyMessagePartUpdatedEvent(state, eventProps, provider);
+      applyMessagePartUpdatedEvent(state, eventProps, provider, messageRoles);
     }
 
     if (type === "todo.updated") {


### PR DESCRIPTION
## Summary
- OpenCode emits a TextPart for both user and assistant messages; TextPart itself carries no `role`. `session-inspector` was blindly writing every text part into `state.currentText`, so a user prompt could leak in and then be published back to Slack as the bot's final reply whenever the turn produced no assistant text (tool-only turn or empty `result.responses`).
- Track `messageID -> role` from `message.updated` events in `buildSessionMessageState` and ignore `text` / `reasoning` / `thinking` parts belonging to user messages.
- Second line of defense in `request-run`: when the fallback text equals `request.prompt`, treat it as empty so we fall through to `_Done_` instead of echoing the user.

## Repro (observed)
Thread `C0ATGCJ0YK0:1776623330.971769` had two messages where the bot re-posted the user's own message verbatim. The persisted session showed `prompt` and `currentText` were identical, and `result.responses` was empty, causing `currentText` to be published as the final reply.

## Tests
- `packages/agents/test/session-inspector.test.ts`: new cases for user TextPart being ignored and assistant TextPart still populating `currentText`.
- `packages/core/test/request-runner.test.ts`: new case where `currentText === prompt` publishes `_Done_` instead of echoing the user.
- Full suite: `bun test` -> 271 pass, 0 fail, 1 skip.