### PR TITLE
fix(slack): render question buttons for longer labels with graceful fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ode",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "Coding anywhere with your coding agents connected",
   "module": "packages/core/index.ts",
   "type": "module",

--- a/packages/core/runtime/helpers.ts
+++ b/packages/core/runtime/helpers.ts
@@ -118,9 +118,9 @@ export function buildQuestionAnswers(answers: string[]): Array<Array<string>> {
 
 /**
  * Heuristic for rendering a question's options as interactive UI (e.g. Slack
- * buttons) rather than plain "a / b / c" text. Conservative so we only promote
- * to buttons when labels are short enough to fit comfortably and the count is
- * within Slack's actions-block comfort zone.
+ * buttons) rather than plain "a / b / c" text. We promote to buttons whenever
+ * each option fits within Slack's native button-text limit (75 chars) and the
+ * count stays within Slack's actions-block comfort zone.
  */
 export function hasSimpleOptions(options: readonly string[] | undefined): boolean {
   if (!options) return false;
@@ -128,7 +128,7 @@ export function hasSimpleOptions(options: readonly string[] | undefined): boolea
   for (const opt of options) {
     const trimmed = opt?.trim?.();
     if (!trimmed) return false;
-    if (trimmed.length > 15) return false;
+    if (trimmed.length > 75) return false;
     if (/[\r\n]/.test(trimmed)) return false;
   }
   return true;

--- a/packages/core/test/runtime-helpers.test.ts
+++ b/packages/core/test/runtime-helpers.test.ts
@@ -89,11 +89,12 @@ describe("runtime helpers", () => {
       expect(hasSimpleOptions([])).toBe(false);
     });
 
-    it("rejects labels longer than 15 characters", () => {
-      expect(hasSimpleOptions(["short", "this label is definitely way too long"])).toBe(false);
-      // 15 is allowed; 16 is not.
-      expect(hasSimpleOptions(["abcdefghijklmno", "ok"])).toBe(true);
-      expect(hasSimpleOptions(["abcdefghijklmnop", "ok"])).toBe(false);
+    it("rejects labels longer than 75 characters", () => {
+      // 75 is allowed; 76 is not (Slack button text hard limit is 75).
+      expect(hasSimpleOptions(["short", "a".repeat(75)])).toBe(true);
+      expect(hasSimpleOptions(["short", "a".repeat(76)])).toBe(false);
+      // Realistic medium-length labels (previously rejected at 15) now pass.
+      expect(hasSimpleOptions(["Push to PR 98", "Leave uncommitted", "Commit but don't push"])).toBe(true);
     });
 
     it("rejects labels containing newlines", () => {

--- a/packages/ims/slack/api.ts
+++ b/packages/ims/slack/api.ts
@@ -65,6 +65,11 @@ function normalizeOptionLabel(option: unknown): string {
  * the user can tap a choice. Otherwise — including when there are no options
  * at all — we fall back to a plain text message listing the choices inline.
  *
+ * If Slack rejects the Block Kit payload (e.g. `invalid_blocks` because a
+ * button label still exceeds Slack's 75-char hard limit, or some other
+ * schema error), we catch the error, log it, and fall back to the same
+ * plain-text format so the user still sees the question.
+ *
  * Used by the runtime's `sendQuestion` path (SDK-emitted `question` events).
  */
 export async function postSlackQuestion(args: {
@@ -84,6 +89,17 @@ export async function postSlackQuestion(args: {
   const displayPrefix = prefix ?? "";
   const questionText = `${displayPrefix}${question}`;
 
+  const postPlainText = async (): Promise<string | undefined> => {
+    const optionText = options.length > 0 ? `\nOptions: ${options.join(" / ")}` : "";
+    const result = await client.chat.postMessage({
+      channel: channelId,
+      thread_ts: threadId,
+      text: `${questionText}${optionText}`,
+      token,
+    });
+    return result.ts ?? undefined;
+  };
+
   if (hasSimpleOptions(options)) {
     const buttons = options.map((opt, i) => ({
       type: "button" as const,
@@ -92,34 +108,38 @@ export async function postSlackQuestion(args: {
       value: opt,
     }));
 
-    const result = await client.chat.postMessage({
-      channel: channelId,
-      thread_ts: threadId,
-      text: questionText,
-      blocks: [
-        {
-          type: "section",
-          text: { type: "mrkdwn", text: questionText },
-        },
-        {
-          type: "actions",
-          block_id: "user_choice",
-          elements: buttons,
-        },
-      ],
-      token,
-    });
-    return result.ts ?? undefined;
+    try {
+      const result = await client.chat.postMessage({
+        channel: channelId,
+        thread_ts: threadId,
+        text: questionText,
+        blocks: [
+          {
+            type: "section",
+            text: { type: "mrkdwn", text: questionText },
+          },
+          {
+            type: "actions",
+            block_id: "user_choice",
+            elements: buttons,
+          },
+        ],
+        token,
+      });
+      return result.ts ?? undefined;
+    } catch (err) {
+      // Slack rejected the Block Kit payload (invalid_blocks, etc.). Log the
+      // underlying reason and fall back to the plain-text format so the user
+      // still sees the question rather than silently losing it.
+      const data = (err as { data?: { error?: string; errors?: string[] } } | undefined)?.data;
+      const slackError = data?.error ?? (err as Error | undefined)?.message ?? "unknown";
+      const details = Array.isArray(data?.errors) ? ` (${data?.errors?.join("; ")})` : "";
+      console.warn(`[slack] postSlackQuestion buttons rejected (${slackError})${details}; falling back to plain text`);
+      return postPlainText();
+    }
   }
 
-  const optionText = options.length > 0 ? `\nOptions: ${options.join(" / ")}` : "";
-  const result = await client.chat.postMessage({
-    channel: channelId,
-    thread_ts: threadId,
-    text: `${questionText}${optionText}`,
-    token,
-  });
-  return result.ts ?? undefined;
+  return postPlainText();
 }
 
 async function slackApiCall(method: string, body: Record<string, unknown>, token: string): Promise<unknown> {


### PR DESCRIPTION
## Summary
- Raise the `hasSimpleOptions` length cap from 15 → 75 chars (Slack button text hard limit) so realistic option labels like `Leave uncommitted` / `Commit but don't push` now render as tappable buttons instead of falling back to `Options: a / b / c`.
- Wrap `postSlackQuestion`'s Block Kit `chat.postMessage` in try/catch: if Slack still rejects the payload (e.g. `invalid_blocks`), log `error` + `errors` from the Slack response and re-post as plain text so the question is never silently lost.
- Update the `hasSimpleOptions` test to cover the new 75-char boundary and add a regression case for real-world labels.

## Why
Users were seeing "Options: a / b / c" instead of buttons even for totally button-able questions (2–3 short choices) because the old 15-char threshold was way below Slack's actual 75-char limit. Verified the Slack error directly — `invalid_blocks` with `must be less than 76 characters [json-pointer:/blocks/1/elements/0/text/text]` — so we now have two layers of protection:

1. `hasSimpleOptions` (pre-flight: 75 chars, 2–5 options, no newlines).
2. try/catch around the API call (runtime fallback if Slack rejects for any reason).

## Test Plan
- `bun test packages/core/test/runtime-helpers.test.ts` → 13 pass
- Manually probed Slack `chat.postMessage` with 155-char button labels; confirmed the error shape used by the new fallback log (`err.data.error === "invalid_blocks"`, `err.data.errors: string[]`).