### PR TITLE
fix(inbound): let synthetic-owner threads accept the first human reply

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ode",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "description": "Coding anywhere with your coding agents connected",
   "module": "packages/core/index.ts",
   "type": "module",

--- a/packages/ims/shared/inbound-policy.test.ts
+++ b/packages/ims/shared/inbound-policy.test.ts
@@ -29,4 +29,38 @@ describe("defaultInboundPolicy", () => {
 
     expect(decision).toEqual({ kind: "message", text: "continue" });
   });
+
+  it("adopts a synthetic-owner thread on the first human reply even when inactive", () => {
+    // cron/task seeds the session with a synthetic `lastActivityBotId`
+    // ("cron-job" / "task") which never matches the runtime Slack bot
+    // token, so `activeThread` is false for the very first human reply.
+    // The thread owner resolver marks synthetic-owned threads as claimable
+    // (threadOwnerMessage = true); the policy must let such replies
+    // through without requiring an @-mention.
+    const decision = defaultInboundPolicy({
+      selfMessage: false,
+      threadOwnerMessage: true,
+      isTopLevel: false,
+      hasAnyMention: false,
+      mentionedBot: false,
+      activeThread: false,
+      normalizedText: "thanks, now do X",
+    });
+
+    expect(decision).toEqual({ kind: "message", text: "thanks, now do X" });
+  });
+
+  it("still ignores stranger replies in inactive threads without a mention", () => {
+    const decision = defaultInboundPolicy({
+      selfMessage: false,
+      threadOwnerMessage: false,
+      isTopLevel: false,
+      hasAnyMention: false,
+      mentionedBot: false,
+      activeThread: false,
+      normalizedText: "random chatter",
+    });
+
+    expect(decision).toEqual({ kind: "ignore", reason: "not_mentioned_and_inactive" });
+  });
 });

--- a/packages/ims/shared/inbound-policy.ts
+++ b/packages/ims/shared/inbound-policy.ts
@@ -19,7 +19,14 @@ export function defaultInboundPolicy(params: {
   }
 
   if (!params.isTopLevel && !params.mentionedBot) {
-    if (!params.activeThread) {
+    // `threadOwnerMessage` is true either when the sender is the claimed
+    // owner of the thread, or when the thread is still owned by a synthetic
+    // placeholder (task:/cron:/cron-job:) waiting for the first human
+    // replier to adopt it. In both cases the bot should engage without
+    // requiring an @-mention, even if the activity window has lapsed or
+    // the last-activity bot id doesn't match (e.g. cron seeds the session
+    // with a synthetic `lastActivityBotId`).
+    if (!params.threadOwnerMessage && !params.activeThread) {
       return { kind: "ignore", reason: "not_mentioned_and_inactive" };
     }
     if (!params.threadOwnerMessage) {
@@ -29,7 +36,7 @@ export function defaultInboundPolicy(params: {
 
   const shouldProcess = params.isTopLevel
     ? params.mentionedBot
-    : (params.mentionedBot || params.activeThread);
+    : (params.mentionedBot || params.activeThread || params.threadOwnerMessage);
 
   if (!shouldProcess) {
     return { kind: "ignore", reason: "not_mentioned_and_inactive" };


### PR DESCRIPTION
## Summary

- Human replies in a cron/task-started Slack thread were being dropped unless the user @-mentioned the bot, regressing the behaviour introduced in 5f94e0e.
- Root cause: cron/task schedulers seed their channel-thread session with a synthetic `lastActivityBotId` (`"cron-job"` / `"task"`) that never matches the runtime Slack bot token, so `isThreadActive` always returns `false` for the first human reply. The inbound policy was short-circuiting on `!activeThread` at `packages/ims/shared/inbound-policy.ts:22` before it ever reached the `threadOwnerMessage` (synthetic-owner) branch.
- Fix: let the policy treat a claimed/synthetic-owned `threadOwnerMessage` as sufficient to engage even when `activeThread` is false. The Slack/Discord/Lark thread-owner resolvers already flag synthetic owners as claimable, so this re-aligns the gate with their intent.

## Behaviour change

Before: cron posts → human replies in thread → bot ignores reply unless @-mentioned.
After: cron posts → human replies in thread → bot picks it up and claims the thread (synthetic owner is overwritten with the human's user id on the next turn, via `session-bootstrap.ts:150`).

Stranger replies in inactive threads (no mention, not the owner) are still ignored — covered by a new regression test.

## Tests

- `bun test packages/ims/shared/inbound-policy.test.ts` — added two cases:
  - synthetic-owner first reply with `activeThread: false` → accepted
  - non-owner, inactive, no mention → still ignored
- `bun test packages/ims packages/core/kernel packages/core/cron packages/core/tasks` → 72 pass / 0 fail.