### PR TITLE
feat(inbox): surface task source metadata + v0.1.32

### DIFF
--- a/.opencode/package-lock.json
+++ b/.opencode/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@opencode-ai/plugin": "1.4.7"
+        "@opencode-ai/plugin": "1.14.18"
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -87,18 +87,18 @@
       ]
     },
     "node_modules/@opencode-ai/plugin": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.4.7.tgz",
-      "integrity": "sha512-RbzMl7ILvQDHpZNvqzi6RCYaGcB3eBwNIMRZww467drLvMd1eOwr4/qAurrvYDsIIEctE6cKsrLuSGIKCW/Fxg==",
+      "version": "1.14.18",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/plugin/-/plugin-1.14.18.tgz",
+      "integrity": "sha512-oF1U7Aipz8A93WGllrwxYugopeL4ml/zd6ywoFIyuF2gbvEhOGFomAvqt1E5YjLN0wEL8nCPwFine3l7pqgNUA==",
       "license": "MIT",
       "dependencies": {
-        "@opencode-ai/sdk": "1.4.7",
+        "@opencode-ai/sdk": "1.14.18",
         "effect": "4.0.0-beta.48",
         "zod": "4.1.8"
       },
       "peerDependencies": {
-        "@opentui/core": ">=0.1.99",
-        "@opentui/solid": ">=0.1.99"
+        "@opentui/core": ">=0.1.100",
+        "@opentui/solid": ">=0.1.100"
       },
       "peerDependenciesMeta": {
         "@opentui/core": {
@@ -110,9 +110,9 @@
       }
     },
     "node_modules/@opencode-ai/sdk": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.4.7.tgz",
-      "integrity": "sha512-onEtaooQyoDP5gTShQeQSf0Sd8V7949G9pPNyIyRXnVtFqyDIhUDLGtL/a/+EIW9x5s+Y6lDy/3oVoGMvQ0rQQ==",
+      "version": "1.14.18",
+      "resolved": "https://registry.npmjs.org/@opencode-ai/sdk/-/sdk-1.14.18.tgz",
+      "integrity": "sha512-E0QiiB+9rv/TPH0a1GunKl6LnuXDRHDiJaIFHOPaBL364rQx+3ClHwHkz78/KBsjhjeLrC2CaLgK+CoxV/XUIQ==",
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "7.0.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ode",
-  "version": "0.1.31",
+  "version": "0.1.32",
   "description": "Coding anywhere with your coding agents connected",
   "module": "packages/core/index.ts",
   "type": "module",

--- a/packages/config/local/inbox.test.ts
+++ b/packages/config/local/inbox.test.ts
@@ -119,6 +119,37 @@ describe("local inbox store", () => {
     expect(detail?.cronJobTitle).toBe("Morning Sync");
   });
 
+  it("records one-time task source metadata at the thread level", () => {
+    const threadKey = buildThreadKey("C-task", "task:task-42");
+    ensureMessageThread({
+      platform: "slack",
+      channelId: "C-task",
+      threadId: "task:task-42",
+      replyThreadId: "task:task-42",
+      sourceKind: "task",
+      taskId: "task-42",
+      taskTitle: "Check deploy status after 1h",
+    });
+    recordUserPrompt({
+      threadKey,
+      messageId: "1234",
+      userId: "task:task-42",
+      promptText: "ping deploy status",
+    });
+
+    const detail = getMessageThreadById(threadKey);
+    expect(detail).not.toBeNull();
+    expect(detail?.sourceKind).toBe("task");
+    expect(detail?.taskId).toBe("task-42");
+    expect(detail?.taskTitle).toBe("Check deploy status after 1h");
+
+    const page = getMessageThreadPage({ page: 1, pageSize: 10 });
+    const summary = page.items.find((item) => item.id === threadKey);
+    expect(summary?.sourceKind).toBe("task");
+    expect(summary?.taskId).toBe("task-42");
+    expect(summary?.taskTitle).toBe("Check deploy status after 1h");
+  });
+
   it("captures a full question → reply → answer batch timeline", () => {
     const threadKey = buildThreadKey("C-q", "T-q");
     ensureMessageThread({

--- a/packages/config/local/inbox.ts
+++ b/packages/config/local/inbox.ts
@@ -50,6 +50,8 @@ export interface MessageThreadSummary {
   sourceKind: MessageThreadSourceKind;
   cronJobId: string | null;
   cronJobTitle: string | null;
+  taskId: string | null;
+  taskTitle: string | null;
   detailCount: number;
   firstMessageAt: number;
   lastMessageAt: number;
@@ -120,6 +122,8 @@ export interface EnsureMessageThreadParams {
   sourceKind?: MessageThreadSourceKind;
   cronJobId?: string | null;
   cronJobTitle?: string | null;
+  taskId?: string | null;
+  taskTitle?: string | null;
   context?: Record<string, unknown> | null;
 }
 
@@ -208,6 +212,8 @@ type ThreadRow = {
   source_kind: MessageThreadSourceKind;
   cron_job_id: string | null;
   cron_job_title: string | null;
+  task_id: string | null;
+  task_title: string | null;
   context_json: string | null;
   detail_count: number;
   first_message_at: number;
@@ -295,6 +301,8 @@ function initializeDatabase(db: Database): void {
       source_kind           TEXT NOT NULL DEFAULT 'user',
       cron_job_id           TEXT,
       cron_job_title        TEXT,
+      task_id               TEXT,
+      task_title            TEXT,
       context_json          TEXT,
       detail_count          INTEGER NOT NULL DEFAULT 0,
       first_message_at      INTEGER NOT NULL,
@@ -333,6 +341,18 @@ function initializeDatabase(db: Database): void {
   db.exec("CREATE INDEX IF NOT EXISTS idx_message_detail_thread_seq ON message_detail(thread_id, seq);");
   db.exec("CREATE INDEX IF NOT EXISTS idx_message_detail_question ON message_detail(question_source_id);");
   db.exec("CREATE INDEX IF NOT EXISTS idx_message_detail_status ON message_detail(status);");
+
+  // Lightweight migrations for DBs created before the columns existed.
+  // sqlite's `ALTER TABLE ... ADD COLUMN` is idempotent-friendly if we first
+  // check PRAGMA table_info, which avoids throwing on repeated startup.
+  ensureThreadColumn(db, "task_id", "TEXT");
+  ensureThreadColumn(db, "task_title", "TEXT");
+}
+
+function ensureThreadColumn(db: Database, column: string, type: string): void {
+  const rows = db.query(`PRAGMA table_info(message_thread)`).all() as Array<{ name: string }>;
+  if (rows.some((row) => row.name === column)) return;
+  db.exec(`ALTER TABLE message_thread ADD COLUMN ${column} ${type};`);
 }
 
 function getDatabase(): Database {
@@ -500,6 +520,8 @@ function mapThreadSummaryRow(
     sourceKind: row.source_kind,
     cronJobId: row.cron_job_id,
     cronJobTitle: row.cron_job_title,
+    taskId: row.task_id,
+    taskTitle: row.task_title,
     detailCount: row.detail_count,
     firstMessageAt: row.first_message_at,
     lastMessageAt: row.last_message_at,
@@ -576,6 +598,7 @@ export function ensureMessageThread(params: EnsureMessageThreadParams): string {
        session_id, provider_id, model, working_directory,
        thread_owner_user_id, branch_name,
        source_kind, cron_job_id, cron_job_title,
+       task_id, task_title,
        context_json,
        detail_count,
        first_message_at, last_message_at,
@@ -588,6 +611,7 @@ export function ensureMessageThread(params: EnsureMessageThreadParams): string {
        ?, ?, ?, ?,
        ?, ?,
        ?, ?, ?,
+       ?, ?,
        ?,
        0,
        ?, ?,
@@ -611,6 +635,8 @@ export function ensureMessageThread(params: EnsureMessageThreadParams): string {
        source_kind          = excluded.source_kind,
        cron_job_id          = COALESCE(excluded.cron_job_id, message_thread.cron_job_id),
        cron_job_title       = COALESCE(excluded.cron_job_title, message_thread.cron_job_title),
+       task_id              = COALESCE(excluded.task_id, message_thread.task_id),
+       task_title           = COALESCE(excluded.task_title, message_thread.task_title),
        context_json         = COALESCE(excluded.context_json, message_thread.context_json),
        updated_at           = excluded.updated_at
     `
@@ -633,6 +659,8 @@ export function ensureMessageThread(params: EnsureMessageThreadParams): string {
     sourceKind,
     params.cronJobId ?? null,
     params.cronJobTitle ?? null,
+    params.taskId ?? null,
+    params.taskTitle ?? null,
     toJsonText(params.context ?? null),
     now,
     now,

--- a/packages/core/tasks/scheduler.ts
+++ b/packages/core/tasks/scheduler.ts
@@ -314,6 +314,8 @@ async function runTask(task: TaskRecord): Promise<void> {
         threadOwnerUserId: session.threadOwnerUserId ?? getTaskUserId(task.id),
         branchName: session.branchName,
         sourceKind: "task",
+        taskId: task.id,
+        taskTitle: task.title,
         context: {
           sourceKind: "task",
           taskId: task.id,

--- a/packages/web-ui/src/routes/(settings)/inbox/+page.svelte
+++ b/packages/web-ui/src/routes/(settings)/inbox/+page.svelte
@@ -5,7 +5,7 @@
   import { Badge, Button, Card } from "$lib/components/ui";
   import { locale } from "$lib/i18n";
 
-  type ThreadSourceKind = "user" | "cron_job";
+  type ThreadSourceKind = "user" | "cron_job" | "task";
 
   type MessageThreadSummary = {
     id: string;
@@ -26,6 +26,8 @@
     sourceKind: ThreadSourceKind;
     cronJobId: string | null;
     cronJobTitle: string | null;
+    taskId: string | null;
+    taskTitle: string | null;
     detailCount: number;
     firstMessageAt: number;
     lastMessageAt: number;
@@ -73,6 +75,11 @@
       return thread.cronJobTitle
         ? `${t("Cron Job", "定时任务")}: ${thread.cronJobTitle}`
         : t("Cron Job", "定时任务");
+    }
+    if (thread.sourceKind === "task") {
+      return thread.taskTitle
+        ? `${t("One-time Task", "一次性任务")}: ${thread.taskTitle}`
+        : t("One-time Task", "一次性任务");
     }
     return t("User Thread", "用户会话");
   }

--- a/packages/web-ui/src/routes/(settings)/inbox/[threadId]/+page.svelte
+++ b/packages/web-ui/src/routes/(settings)/inbox/[threadId]/+page.svelte
@@ -6,7 +6,7 @@
   import { Badge, Button, Card } from "$lib/components/ui";
   import { locale } from "$lib/i18n";
 
-  type ThreadSourceKind = "user" | "cron_job";
+  type ThreadSourceKind = "user" | "cron_job" | "task";
 
   type MessageThreadSummary = {
     id: string;
@@ -27,6 +27,8 @@
     sourceKind: ThreadSourceKind;
     cronJobId: string | null;
     cronJobTitle: string | null;
+    taskId: string | null;
+    taskTitle: string | null;
     detailCount: number;
     firstMessageAt: number;
     lastMessageAt: number;
@@ -120,6 +122,11 @@
       return t_.cronJobTitle
         ? `${t("Cron Job", "定时任务")}: ${t_.cronJobTitle}`
         : t("Cron Job", "定时任务");
+    }
+    if (t_.sourceKind === "task") {
+      return t_.taskTitle
+        ? `${t("One-time Task", "一次性任务")}: ${t_.taskTitle}`
+        : t("One-time Task", "一次性任务");
     }
     return t("User Thread", "用户会话");
   }

--- a/packages/web-ui/src/routes/(settings)/tasks/+page.svelte
+++ b/packages/web-ui/src/routes/(settings)/tasks/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onMount } from "svelte";
-  import { Ban, CalendarClock, Pencil, Play, Plus, RefreshCw, Trash2 } from "lucide-svelte";
+  import { Ban, CalendarClock, ChevronDown, ChevronRight, Pencil, Play, Plus, RefreshCw, Trash2 } from "lucide-svelte";
   import { Badge, Button, Card, Input, Label, Select, Textarea } from "$lib/components/ui";
   import { locale } from "$lib/i18n";
   import {
@@ -65,6 +65,8 @@
   let formScheduledLocal = $state("");
   let formRunImmediately = $state(false);
   let runningTaskIds = $state<Set<string>>(new Set());
+  // Create/edit form is collapsible, collapsed by default. Auto-expands when editing.
+  let isCreateFormOpen = $state(false);
 
   function isProviderEnabled(provider: AgentProviderId): boolean {
     const agents = $localSettingStore.config.agents as Record<string, { enabled?: boolean }>;
@@ -161,6 +163,7 @@
     formScheduledLocal = toLocalDatetimeInput(task.scheduledAt);
     formRunImmediately = false;
     message = "";
+    isCreateFormOpen = true;
     if (typeof window !== "undefined") {
       window.scrollTo({ top: 0, behavior: "smooth" });
     }
@@ -346,16 +349,27 @@
 </script>
 
 <Card className="p-5">
-  <div class="mb-4 flex flex-wrap items-center justify-between gap-3">
-    <div class="flex items-center gap-2">
-      <CalendarClock class="h-4 w-4 text-[hsl(var(--muted-foreground))]" />
-      <h2 class="text-lg font-semibold">{t("One-time Tasks", "一次性任务")}</h2>
+  <div class="mb-4 flex flex-wrap items-start justify-between gap-3">
+    <div class="flex items-start gap-2">
+      <CalendarClock class="mt-1 h-4 w-4 text-[hsl(var(--muted-foreground))]" />
+      <div class="space-y-1">
+        <h2 class="text-lg font-semibold">{t("One-time Tasks", "一次性任务")}</h2>
+        <p class="text-xs text-[hsl(var(--muted-foreground))]">
+          {t(
+            "Most one-time tasks are created by agents themselves; you can also create them manually. Agents schedule one-time tasks to defer an operation, or to hand work off to a sub-agent.",
+            "一次性任务大多是由 Agent 自己创建的，你也可以手动创建一次性任务。这些 Agent 可以通过创建一次性任务，来延后执行某个操作，或者调用其他的 sub-agent。",
+          )}
+        </p>
+      </div>
     </div>
 
     <div class="flex items-center gap-2">
       <Button
         variant="outline"
-        on:click={resetForm}
+        on:click={() => {
+          resetForm();
+          isCreateFormOpen = true;
+        }}
         disabled={isSaving}
       >
         <Plus class="h-4 w-4" />
@@ -373,21 +387,36 @@
   </div>
 
   <div class="space-y-6">
-    <!-- Create / edit form -->
+    <!-- Create / edit form (collapsible, collapsed by default) -->
     <div class="rounded-lg border p-4">
-      <div class="mb-4">
-        <p class="text-sm font-medium">
-          {editingTaskId ? t("Edit Task", "编辑任务") : t("Create Task", "创建任务")}
-        </p>
-        <p class="mt-1 text-xs text-[hsl(var(--muted-foreground))]">
-          {t(
-            "Tasks fire once at the scheduled time. When a thread is set, the task reuses that thread's session to keep context; otherwise it posts as a fresh channel message.",
-            "任务会在设定的时间一次性触发。如填写 Thread，则会复用该 Thread 的会话保留上下文；否则作为新的频道消息发送。",
-          )}
-        </p>
-      </div>
+      <button
+        type="button"
+        class="flex w-full items-center justify-between gap-2 text-left"
+        onclick={() => {
+          isCreateFormOpen = !isCreateFormOpen;
+        }}
+        aria-expanded={isCreateFormOpen}
+      >
+        <div>
+          <p class="text-sm font-medium">
+            {editingTaskId ? t("Edit Task", "编辑任务") : t("Create Task", "创建任务")}
+          </p>
+          <p class="mt-1 text-xs text-[hsl(var(--muted-foreground))]">
+            {t(
+              "Tasks fire once at the scheduled time. When a thread is set, the task reuses that thread's session to keep context; otherwise it posts as a fresh channel message.",
+              "任务会在设定的时间一次性触发。如填写 Thread，则会复用该 Thread 的会话保留上下文；否则作为新的频道消息发送。",
+            )}
+          </p>
+        </div>
+        {#if isCreateFormOpen}
+          <ChevronDown class="h-4 w-4 shrink-0 text-[hsl(var(--muted-foreground))]" />
+        {:else}
+          <ChevronRight class="h-4 w-4 shrink-0 text-[hsl(var(--muted-foreground))]" />
+        {/if}
+      </button>
 
-      <div class="space-y-4">
+      {#if isCreateFormOpen}
+        <div class="mt-4 space-y-4">
         <div class="space-y-2">
           <Label for="task-title">{t("Title", "标题")}</Label>
           <Input
@@ -522,6 +551,7 @@
           {/if}
         </div>
       </div>
+      {/if}
     </div>
 
     <!-- Task list -->


### PR DESCRIPTION
## Summary
- Track `taskId`/`taskTitle` on `message_thread` so inbox can label threads that originated from one-time tasks
- Add idempotent sqlite migration for the new columns, plus test coverage in `packages/config/local/inbox.test.ts`
- Task scheduler now forwards task metadata through `ensureMessageThread`
- Web UI inbox list + thread detail render `One-time Task: <title>` badges
- Tasks page: create/edit form is collapsible (collapsed by default, auto-expands when editing or clicking *New*) and gains an explainer copy block
- Bump version to 0.1.32

## Test plan
- `bun test packages/config/local/inbox.test.ts`