### PR TITLE
feat(scheduler): reconcile interrupted task and cron runs on startup

### DIFF
--- a/packages/config/local/cron-jobs.test.ts
+++ b/packages/config/local/cron-jobs.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+import { invalidateOdeConfigCache, ODE_CONFIG_FILE } from "./ode-store";
+import {
+  CRON_BACKFILL_WINDOW_MS,
+  clearCronJobsForTests,
+  closeCronJobDatabaseForTests,
+  createCronJob,
+  getCronJobById,
+  markCronJobCompleted,
+  markCronJobFailed,
+  markCronJobRunning,
+  reconcileInterruptedCronJobs,
+} from "./cron-jobs";
+
+// Storage-level tests for cron-jobs mirror the pattern used in tasks.test.ts:
+// we swap ODE_INBOX_DB_FILE to a per-test tempdir so nothing touches the
+// user's real inbox.db, and we stub ode.json so channel lookups succeed.
+
+let tempDir: string;
+let originalConfigEnv: string | undefined;
+let originalConfigContent: string | null;
+let originalConfigExisted: boolean;
+
+function writeTestOdeConfig(): void {
+  const config = {
+    user: {},
+    workspaces: [
+      {
+        id: "ws-test",
+        name: "Test Workspace",
+        type: "slack",
+        channelDetails: [{ id: "C_TEST", name: "general" }],
+      },
+    ],
+  };
+  fs.mkdirSync(path.dirname(ODE_CONFIG_FILE), { recursive: true });
+  fs.writeFileSync(ODE_CONFIG_FILE, JSON.stringify(config));
+  invalidateOdeConfigCache();
+}
+
+beforeEach(() => {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "ode-cron-jobs-test-"));
+  originalConfigEnv = process.env.ODE_INBOX_DB_FILE;
+  process.env.ODE_INBOX_DB_FILE = path.join(tempDir, "inbox.db");
+
+  originalConfigExisted = fs.existsSync(ODE_CONFIG_FILE);
+  originalConfigContent = originalConfigExisted
+    ? fs.readFileSync(ODE_CONFIG_FILE, "utf-8")
+    : null;
+  writeTestOdeConfig();
+
+  closeCronJobDatabaseForTests();
+  clearCronJobsForTests();
+});
+
+afterEach(() => {
+  closeCronJobDatabaseForTests();
+  if (originalConfigEnv === undefined) {
+    delete process.env.ODE_INBOX_DB_FILE;
+  } else {
+    process.env.ODE_INBOX_DB_FILE = originalConfigEnv;
+  }
+
+  try {
+    if (originalConfigExisted && originalConfigContent !== null) {
+      fs.writeFileSync(ODE_CONFIG_FILE, originalConfigContent);
+    } else {
+      fs.rmSync(ODE_CONFIG_FILE, { force: true });
+    }
+  } catch {
+    // Best effort.
+  }
+  invalidateOdeConfigCache();
+
+  try {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  } catch {
+    // Best effort.
+  }
+});
+
+function makeRunningJob(
+  overrides: { title?: string; triggeredAtMs?: number } = {},
+) {
+  const job = createCronJob({
+    title: overrides.title ?? "test-job",
+    cronExpression: "*/5 * * * *",
+    channelId: "C_TEST",
+    messageText: "heartbeat",
+  });
+  // Stamp the row as "currently running". We call the real helper so the
+  // test exercises the same SQL the scheduler uses for manual runs.
+  markCronJobRunning(job.id, overrides.triggeredAtMs ?? Date.now());
+  return job;
+}
+
+describe("reconcileInterruptedCronJobs", () => {
+  test("schedules a backfill when last_triggered_at is within the window", () => {
+    const now = Date.now();
+    const job = makeRunningJob({
+      triggeredAtMs: now - 30_000, // 30s ago — fresh
+    });
+
+    const entries = reconcileInterruptedCronJobs(now);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      id: job.id,
+      action: "backfill_scheduled",
+    });
+
+    // The row's status must still be cleared out of `running`, otherwise the
+    // backfill's own `markCronJobRunning` is fine but the transient state
+    // between reconcile and backfill would still look zombie-ish.
+    const after = getCronJobById(job.id)!;
+    expect(after.lastRunStatus).toBe("failed");
+    expect(after.lastError).toMatch(/runtime_interrupted/);
+  });
+
+  test("clears without backfill when last_triggered_at is outside the window", () => {
+    const now = Date.now();
+    const job = makeRunningJob({
+      triggeredAtMs: now - (CRON_BACKFILL_WINDOW_MS + 60_000),
+    });
+
+    const entries = reconcileInterruptedCronJobs(now);
+    expect(entries[0]).toMatchObject({
+      id: job.id,
+      action: "failed_stale",
+    });
+    expect(getCronJobById(job.id)?.lastRunStatus).toBe("failed");
+    expect(getCronJobById(job.id)?.lastError).toMatch(/missed window/);
+  });
+
+  test("clears without backfill when last_triggered_at is null", () => {
+    // Defensive: a row could in theory enter 'running' without a
+    // triggered_at (e.g. a bad manual write). We treat it as stale.
+    const job = createCronJob({
+      title: "null-trigger",
+      cronExpression: "*/5 * * * *",
+      channelId: "C_TEST",
+      messageText: "hello",
+    });
+    // Forcibly put it into 'running' with a NULL last_triggered_at.
+    const dbFile = process.env.ODE_INBOX_DB_FILE!;
+    const rawDb = new Database(dbFile);
+    rawDb
+      .query(
+        "UPDATE cron_jobs SET last_run_status = 'running', last_triggered_at = NULL WHERE id = ?",
+      )
+      .run(job.id);
+    rawDb.close();
+
+    const entries = reconcileInterruptedCronJobs(Date.now());
+    expect(entries[0]?.action).toBe("failed_stale");
+    expect(getCronJobById(job.id)?.lastRunStatus).toBe("failed");
+  });
+
+  test("leaves idle / success / failed jobs alone", () => {
+    const idle = createCronJob({
+      title: "idle",
+      cronExpression: "*/5 * * * *",
+      channelId: "C_TEST",
+      messageText: "idle",
+    });
+    const succeeded = createCronJob({
+      title: "ok",
+      cronExpression: "*/5 * * * *",
+      channelId: "C_TEST",
+      messageText: "ok",
+    });
+    markCronJobRunning(succeeded.id, Date.now() - 5_000);
+    markCronJobCompleted(succeeded.id);
+    const failed = createCronJob({
+      title: "nope",
+      cronExpression: "*/5 * * * *",
+      channelId: "C_TEST",
+      messageText: "nope",
+    });
+    markCronJobRunning(failed.id, Date.now() - 5_000);
+    markCronJobFailed(failed.id, "previous error");
+
+    const entries = reconcileInterruptedCronJobs(Date.now());
+    expect(entries).toHaveLength(0);
+    expect(getCronJobById(idle.id)?.lastRunStatus).toBe("idle");
+    expect(getCronJobById(succeeded.id)?.lastRunStatus).toBe("success");
+    // `failed` preserves its original error message — reconcile doesn't
+    // stomp on legitimate failures.
+    expect(getCronJobById(failed.id)?.lastError).toBe("previous error");
+  });
+
+  test("is idempotent: second pass is a no-op", () => {
+    const job = makeRunningJob({ triggeredAtMs: Date.now() - 30_000 });
+    const first = reconcileInterruptedCronJobs();
+    expect(first).toHaveLength(1);
+    const second = reconcileInterruptedCronJobs();
+    expect(second).toHaveLength(0);
+    // The row remains `failed` from the first pass.
+    expect(getCronJobById(job.id)?.lastRunStatus).toBe("failed");
+  });
+});

--- a/packages/config/local/cron-jobs.ts
+++ b/packages/config/local/cron-jobs.ts
@@ -450,6 +450,109 @@ export function markCronJobFailed(id: string, errorMessage: string): void {
   `).run(errorMessage, now, id);
 }
 
+// ---------------------------------------------------------------------------
+// Runtime interruption recovery.
+//
+// Same concern as `tasks.reconcileInterruptedTasks`: a cron run killed
+// mid-flight by SIGTERM / upgrade restart / crash leaves `last_run_status`
+// stuck at `running`. `reconcileInterruptedCronJobs` is called on scheduler
+// startup to clear those zombies and (per product decision) optionally
+// backfill the most recent run so a fresh restart doesn't silently drop
+// time-sensitive work like a heartbeat or a just-missed daily digest.
+// ---------------------------------------------------------------------------
+
+/**
+ * If `last_triggered_at` (the minute-start that was about to run) is within
+ * this window, reconcile classifies the interrupted run as "backfillable"
+ * and flags the job for an immediate single re-run. Beyond the window we
+ * only clear the zombie status — the next scheduled tick takes over, which
+ * matches cron's usual "missed = missed" semantics.
+ *
+ * Default 10 min mirrors `tasks.TASK_RECENT_STALENESS_WINDOW_MS` so the two
+ * code paths behave predictably together.
+ */
+export const CRON_BACKFILL_WINDOW_MS = 10 * 60_000;
+
+export type CronReconcileAction = "backfill_scheduled" | "failed_stale";
+
+export type CronReconcileEntry = {
+  id: string;
+  title: string;
+  action: CronReconcileAction;
+  lastTriggeredAt: number | null;
+};
+
+/**
+ * Reconcile cron jobs whose `last_run_status='running'` was left behind by
+ * a previous runtime. Returns per-row summaries so callers can log them and
+ * drive the optional backfill step.
+ *
+ *   last_triggered_at within CRON_BACKFILL_WINDOW_MS -> status back to
+ *                                                       `failed`, caller
+ *                                                       should re-trigger.
+ *   otherwise                                        -> status to `failed`
+ *                                                       (no backfill).
+ *
+ * We mark the zombie as `failed` in both cases because the previous run
+ * genuinely did not complete. The caller (the scheduler) is responsible for
+ * issuing the backfill re-run separately via `beginTriggerCronJobNow`. That
+ * split keeps the storage layer pure SQL and lets the scheduler decide
+ * whether it's safe to spawn a run on boot (e.g. it could suppress backfills
+ * during integration tests).
+ */
+export function reconcileInterruptedCronJobs(
+  nowMs: number = Date.now(),
+): CronReconcileEntry[] {
+  const db = getDatabase();
+  const rows = db
+    .query("SELECT * FROM cron_jobs WHERE last_run_status = 'running'")
+    .all() as CronJobRow[];
+
+  const entries: CronReconcileEntry[] = [];
+  const clearStmt = db.query(`
+    UPDATE cron_jobs
+    SET
+      last_run_status = 'failed',
+      last_error = ?,
+      updated_at = ?
+    WHERE id = ? AND last_run_status = 'running'
+  `);
+
+  for (const row of rows) {
+    const job = mapRow(row);
+    const triggeredAt = job.lastTriggeredAt;
+    const isBackfillable =
+      triggeredAt !== null && nowMs - triggeredAt <= CRON_BACKFILL_WINDOW_MS;
+
+    if (isBackfillable) {
+      clearStmt.run(
+        "runtime_interrupted (scheduling backfill)",
+        nowMs,
+        job.id,
+      );
+      entries.push({
+        id: job.id,
+        title: job.title,
+        action: "backfill_scheduled",
+        lastTriggeredAt: triggeredAt,
+      });
+    } else {
+      clearStmt.run(
+        "runtime_interrupted (missed window; next tick will run)",
+        nowMs,
+        job.id,
+      );
+      entries.push({
+        id: job.id,
+        title: job.title,
+        action: "failed_stale",
+        lastTriggeredAt: triggeredAt,
+      });
+    }
+  }
+  return entries;
+}
+
 export function clearCronJobsForTests(): void {
   const db = getDatabase();
   db.exec("DELETE FROM cron_jobs;");

--- a/packages/config/local/tasks.test.ts
+++ b/packages/config/local/tasks.test.ts
@@ -15,6 +15,9 @@ import {
   markTaskCompleted,
   markTaskFailed,
   markTaskTriggered,
+  MAX_TASK_AUTO_RETRIES,
+  reconcileInterruptedTasks,
+  TASK_RECENT_STALENESS_WINDOW_MS,
   updateTask,
 } from "./tasks";
 
@@ -186,18 +189,29 @@ describe("tasks storage", () => {
     expect(getTaskById(b.id)?.lastError).toBe("boom");
   });
 
-  test("cancelTask only cancels pending tasks", () => {
+  test("cancelTask also rescues running tasks stuck after a crash", () => {
+    // Pending -> cancelled is the usual happy path.
     const task = createTask({ title: "c", scheduledAt: Date.now() + 60_000, channelId: "C_TEST", messageText: "hi" });
     expect(cancelTask(task.id)).toBe(true);
     expect(getTaskById(task.id)?.status).toBe("cancelled");
     // Second cancel is a no-op.
     expect(cancelTask(task.id)).toBe(false);
 
-    // Cannot cancel a running or completed task.
+    // Running tasks are also cancellable: a runtime crash can leave a row
+    // in `running` forever, and `cancelTask` now lets the user reclaim it
+    // via the UI / CLI without having to `delete` the row outright.
     const running = createTask({ title: "r", scheduledAt: Date.now(), channelId: "C_TEST", messageText: "r" });
     markTaskTriggered(running.id);
-    expect(cancelTask(running.id)).toBe(false);
-    expect(getTaskById(running.id)?.status).toBe("running");
+    expect(cancelTask(running.id)).toBe(true);
+    expect(getTaskById(running.id)?.status).toBe("cancelled");
+    expect(getTaskById(running.id)?.completedAt).not.toBeNull();
+
+    // Terminal rows (success / failed / already cancelled) stay put.
+    const done = createTask({ title: "d", scheduledAt: Date.now(), channelId: "C_TEST", messageText: "d" });
+    markTaskTriggered(done.id);
+    markTaskCompleted(done.id);
+    expect(cancelTask(done.id)).toBe(false);
+    expect(getTaskById(done.id)?.status).toBe("success");
   });
 
   test("updateTask rejects edits on non-pending tasks", () => {
@@ -287,5 +301,139 @@ describe("tasks storage", () => {
     });
     expect(() => updateTask(task.id, { agent: "claude-code-beta" })).toThrow(/Unsupported agent/);
     expect(getTaskById(task.id)?.agent).toBe("opencode");
+  });
+});
+
+describe("reconcileInterruptedTasks", () => {
+  test("requeues a recently triggered running task and bumps retry_count", () => {
+    const now = Date.now();
+    const task = createTask({
+      title: "recent",
+      scheduledAt: now - 30_000, // 30s ago — well within the staleness window
+      channelId: "C_TEST",
+      messageText: "go",
+    });
+    markTaskTriggered(task.id);
+    expect(getTaskById(task.id)?.status).toBe("running");
+
+    const entries = reconcileInterruptedTasks(now);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      id: task.id,
+      action: "requeued",
+      retryCount: 1,
+    });
+
+    const after = getTaskById(task.id)!;
+    expect(after.status).toBe("pending");
+    expect(after.triggeredAt).toBeNull();
+    expect(after.retryCount).toBe(1);
+    expect(after.lastError).toMatch(/runtime_interrupted/);
+  });
+
+  test("requeues future-scheduled tasks regardless of absolute elapsed time", () => {
+    // A task whose scheduledAt is still in the future should always be
+    // re-queued: the restart happened before its intended firing time, so
+    // the user's original intent is untouched.
+    const now = Date.now();
+    const task = createTask({
+      title: "future",
+      scheduledAt: now + 60 * 60_000, // one hour from now
+      channelId: "C_TEST",
+      messageText: "later",
+    });
+    markTaskTriggered(task.id);
+
+    const entries = reconcileInterruptedTasks(now);
+    expect(entries[0]?.action).toBe("requeued");
+    expect(getTaskById(task.id)?.status).toBe("pending");
+  });
+
+  test("fails a stale interrupted task outside the staleness window", () => {
+    const now = Date.now();
+    const task = createTask({
+      title: "stale",
+      scheduledAt: now - (TASK_RECENT_STALENESS_WINDOW_MS + 60_000),
+      channelId: "C_TEST",
+      messageText: "too late",
+    });
+    markTaskTriggered(task.id);
+
+    const entries = reconcileInterruptedTasks(now);
+    expect(entries[0]).toMatchObject({
+      id: task.id,
+      action: "failed_stale",
+      retryCount: 0,
+    });
+    const after = getTaskById(task.id)!;
+    expect(after.status).toBe("failed");
+    expect(after.retryCount).toBe(0);
+    expect(after.lastError).toMatch(/too stale/);
+    expect(after.completedAt).not.toBeNull();
+  });
+
+  test("enforces MAX_TASK_AUTO_RETRIES to prevent crash loops", () => {
+    // A task that already bounced MAX times must terminate, even if it's
+    // otherwise fresh — we assume something about it is crashing the runtime.
+    const now = Date.now();
+    const task = createTask({
+      title: "looping",
+      scheduledAt: now - 30_000,
+      channelId: "C_TEST",
+      messageText: "crash me",
+    });
+    markTaskTriggered(task.id);
+    // Pretend the previous reconcile already bumped retry_count to the cap.
+    // We reach into the DB directly because there's no public API for
+    // setting retryCount (it's only incremented by reconcile itself).
+    const dbFile = process.env.ODE_INBOX_DB_FILE!;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { Database } = require("bun:sqlite") as typeof import("bun:sqlite");
+    const rawDb = new Database(dbFile);
+    rawDb.query("UPDATE tasks SET retry_count = ? WHERE id = ?").run(
+      MAX_TASK_AUTO_RETRIES,
+      task.id,
+    );
+    rawDb.close();
+
+    const entries = reconcileInterruptedTasks(now);
+    expect(entries[0]).toMatchObject({
+      id: task.id,
+      action: "failed_retry_cap",
+      retryCount: MAX_TASK_AUTO_RETRIES,
+    });
+    expect(getTaskById(task.id)?.status).toBe("failed");
+    expect(getTaskById(task.id)?.lastError).toMatch(/retry cap/);
+  });
+
+  test("leaves non-running tasks alone (pending / success / failed / cancelled)", () => {
+    const now = Date.now();
+    const pending = createTask({ title: "p", scheduledAt: now - 1000, channelId: "C_TEST", messageText: "p" });
+    const done = createTask({ title: "d", scheduledAt: now - 1000, channelId: "C_TEST", messageText: "d" });
+    markTaskTriggered(done.id);
+    markTaskCompleted(done.id);
+    const cancelled = createTask({ title: "c", scheduledAt: now + 60_000, channelId: "C_TEST", messageText: "c" });
+    cancelTask(cancelled.id);
+
+    const entries = reconcileInterruptedTasks(now);
+    expect(entries).toHaveLength(0);
+    expect(getTaskById(pending.id)?.status).toBe("pending");
+    expect(getTaskById(done.id)?.status).toBe("success");
+    expect(getTaskById(cancelled.id)?.status).toBe("cancelled");
+  });
+
+  test("is idempotent: a second run is a no-op once rows are terminal", () => {
+    const now = Date.now();
+    const fresh = createTask({ title: "f", scheduledAt: now - 30_000, channelId: "C_TEST", messageText: "f" });
+    const stale = createTask({ title: "s", scheduledAt: now - (TASK_RECENT_STALENESS_WINDOW_MS + 60_000), channelId: "C_TEST", messageText: "s" });
+    markTaskTriggered(fresh.id);
+    markTaskTriggered(stale.id);
+
+    const first = reconcileInterruptedTasks(now);
+    expect(first).toHaveLength(2);
+    const second = reconcileInterruptedTasks(now);
+    // Fresh task was re-queued to pending; stale task is terminal. Neither
+    // is still `running`, so the second pass has nothing to do.
+    expect(second).toHaveLength(0);
   });
 });

--- a/packages/config/local/tasks.ts
+++ b/packages/config/local/tasks.ts
@@ -49,6 +49,14 @@ export type TaskRecord = {
   lastError: string | null;
   triggeredAt: number | null;
   completedAt: number | null;
+  /**
+   * Number of times this task has been auto-retried after a runtime
+   * interruption (SIGTERM / crash / upgrade restart). Bumped by
+   * `reconcileInterruptedTasks` when it resurrects a still-actionable task.
+   * Capped at `MAX_TASK_AUTO_RETRIES` to prevent crash loops from spamming
+   * chat channels.
+   */
+  retryCount: number;
   createdAt: number;
   updatedAt: number;
 };
@@ -97,6 +105,7 @@ type TaskRow = {
   last_error: string | null;
   triggered_at: number | null;
   completed_at: number | null;
+  retry_count: number;
   created_at: number;
   updated_at: number;
 };
@@ -143,10 +152,20 @@ function initializeDatabase(db: Database): void {
       last_error TEXT,
       triggered_at INTEGER,
       completed_at INTEGER,
+      retry_count INTEGER NOT NULL DEFAULT 0,
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL
     );
   `);
+  // Idempotent migration: add `retry_count` to databases created before the
+  // column existed. SQLite has no `IF NOT EXISTS` for ALTER TABLE, so we peek
+  // at PRAGMA first.
+  const hasRetryCount = (db
+    .query("PRAGMA table_info(tasks);")
+    .all() as Array<{ name: string }>).some((col) => col.name === "retry_count");
+  if (!hasRetryCount) {
+    db.exec("ALTER TABLE tasks ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0;");
+  }
   db.exec("CREATE INDEX IF NOT EXISTS idx_tasks_status_scheduled ON tasks(status, scheduled_at);");
   db.exec("CREATE INDEX IF NOT EXISTS idx_tasks_channel ON tasks(channel_id, scheduled_at DESC);");
 }
@@ -189,6 +208,7 @@ function mapRow(row: TaskRow): TaskRecord {
     lastError: row.last_error,
     triggeredAt: row.triggered_at,
     completedAt: row.completed_at,
+    retryCount: row.retry_count ?? 0,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -498,9 +518,17 @@ export function markTaskFailed(id: string, errorMessage: string): void {
 }
 
 /**
- * Cancel a pending task. Returns true if the task was cancellable (was
- * pending). Returns false if the task was already running / finished /
- * cancelled / missing — callers can treat that as a no-op.
+ * Cancel a task. Returns true if the task moved to `cancelled` state.
+ *
+ * Accepts both `pending` and `running` tasks:
+ *   - `pending` tasks stop before they fire.
+ *   - `running` tasks let users reclaim a row stuck in `running` after a
+ *     runtime crash / SIGTERM. The in-process agent turn (if still alive) is
+ *     NOT torn down by this call — it's a DB-level bookkeeping op. The next
+ *     reconcile pass will see the row is already terminal and leave it alone.
+ *
+ * Returns false for already-terminal rows (`success` / `failed` / `cancelled`)
+ * or missing ids — callers should treat that as a no-op.
  */
 export function cancelTask(id: string): boolean {
   const db = getDatabase();
@@ -509,10 +537,145 @@ export function cancelTask(id: string): boolean {
     UPDATE tasks
     SET
       status = 'cancelled',
+      completed_at = ?,
       updated_at = ?
-    WHERE id = ? AND status = 'pending'
-  `).run(now, id);
+    WHERE id = ? AND status IN ('pending', 'running')
+  `).run(now, now, id);
   return result.changes > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Runtime interruption recovery.
+//
+// When the runtime is killed while a task is mid-flight (upgrade restart,
+// SIGTERM, OS crash, OOM), the row stays `status='running'` forever because
+// the SIGTERM handler doesn't await in-flight runs and there's no heartbeat
+// column. `reconcileInterruptedTasks` is called on scheduler startup to
+// resurrect or retire those zombies based on staleness + retry budget.
+// ---------------------------------------------------------------------------
+
+/**
+ * Maximum number of auto-retries per task. Once `retry_count` reaches this
+ * number the next reconcile pass will terminate the task as `failed` instead
+ * of putting it back in `pending`. Guards against crash loops — if a task
+ * reliably takes the runtime down, we stop re-arming the foot-gun.
+ *
+ * Matches the product decision in the rollout discussion: one automatic
+ * retry after a restart, then hand off to the human.
+ */
+export const MAX_TASK_AUTO_RETRIES = 1;
+
+/**
+ * Grace window for deciding whether an interrupted task is still fresh
+ * enough to auto-retry. A task whose `scheduledAt` is more than this far
+ * in the past is considered stale — the user may have already worked
+ * around the failure, the scheduled moment may no longer be meaningful
+ * (e.g. "post daily digest at 9am" is useless at 11am), and a silent
+ * replay could produce duplicate side effects (messages, comments, PRs).
+ *
+ * 10 minutes mirrors the window in `packages/core/kernel/recovery.ts`
+ * for chat-session activeRequest recovery.
+ */
+export const TASK_RECENT_STALENESS_WINDOW_MS = 10 * 60_000;
+
+export type TaskReconcileAction = "requeued" | "failed_stale" | "failed_retry_cap";
+
+export type TaskReconcileEntry = {
+  id: string;
+  title: string;
+  action: TaskReconcileAction;
+  retryCount: number;
+};
+
+/**
+ * Reconcile tasks that were left stuck in `status='running'` by a previous
+ * runtime. Classifies each zombie row and updates it in-place; returns a
+ * per-row summary so callers can log / emit metrics.
+ *
+ * Decision table:
+ *
+ *   retry_count already >= MAX_TASK_AUTO_RETRIES     -> `failed` (retry cap)
+ *   scheduled_at in the future                       -> `pending`, bump retry
+ *   scheduled_at within TASK_RECENT_STALENESS_WINDOW -> `pending`, bump retry
+ *   scheduled_at further in the past                 -> `failed` (stale)
+ *
+ * Callers should invoke this ONCE on scheduler startup, before the polling
+ * loop starts. Safe to call multiple times (idempotent on terminal rows).
+ */
+export function reconcileInterruptedTasks(nowMs: number = Date.now()): TaskReconcileEntry[] {
+  const db = getDatabase();
+  const rows = db
+    .query("SELECT * FROM tasks WHERE status = 'running'")
+    .all() as TaskRow[];
+
+  const entries: TaskReconcileEntry[] = [];
+  const requeueStmt = db.query(`
+    UPDATE tasks
+    SET
+      status = 'pending',
+      triggered_at = NULL,
+      last_error = ?,
+      retry_count = retry_count + 1,
+      updated_at = ?
+    WHERE id = ? AND status = 'running'
+  `);
+  const failStmt = db.query(`
+    UPDATE tasks
+    SET
+      status = 'failed',
+      last_error = ?,
+      completed_at = ?,
+      updated_at = ?
+    WHERE id = ? AND status = 'running'
+  `);
+
+  for (const row of rows) {
+    const task = mapRow(row);
+
+    if (task.retryCount >= MAX_TASK_AUTO_RETRIES) {
+      failStmt.run(
+        "runtime_interrupted (retry cap reached)",
+        nowMs,
+        nowMs,
+        task.id,
+      );
+      entries.push({
+        id: task.id,
+        title: task.title,
+        action: "failed_retry_cap",
+        retryCount: task.retryCount,
+      });
+      continue;
+    }
+
+    const isFresh =
+      task.scheduledAt > nowMs ||
+      nowMs - task.scheduledAt <= TASK_RECENT_STALENESS_WINDOW_MS;
+
+    if (isFresh) {
+      requeueStmt.run("runtime_interrupted (auto-retrying)", nowMs, task.id);
+      entries.push({
+        id: task.id,
+        title: task.title,
+        action: "requeued",
+        retryCount: task.retryCount + 1,
+      });
+    } else {
+      failStmt.run(
+        "runtime_interrupted (scheduled time too stale to auto-retry)",
+        nowMs,
+        nowMs,
+        task.id,
+      );
+      entries.push({
+        id: task.id,
+        title: task.title,
+        action: "failed_stale",
+        retryCount: task.retryCount,
+      });
+    }
+  }
+  return entries;
 }
 
 export function clearTasksForTests(): void {

--- a/packages/core/cli-handlers/task.ts
+++ b/packages/core/cli-handlers/task.ts
@@ -119,6 +119,9 @@ function printTaskDetail(task: TaskRecord): void {
   console.log(`completedAt:   ${formatTimestamp(task.completedAt)}`);
   console.log(`createdAt:     ${formatTimestamp(task.createdAt)}`);
   console.log(`updatedAt:     ${formatTimestamp(task.updatedAt)}`);
+  if (task.retryCount > 0) {
+    console.log(`retryCount:    ${task.retryCount}`);
+  }
   if (task.lastError) {
     console.log(`lastError:     ${task.lastError}`);
   }

--- a/packages/core/cron/scheduler.ts
+++ b/packages/core/cron/scheduler.ts
@@ -15,6 +15,7 @@ import {
   markCronJobFailed,
   markCronJobRunning,
   markCronJobTriggered,
+  reconcileInterruptedCronJobs,
 } from "@/config/local/cron-jobs";
 import {
   buildThreadKey,
@@ -455,6 +456,44 @@ async function tickCronJobs(): Promise<void> {
 
 export function startCronJobScheduler(): void {
   if (cronSchedulerTimer) return;
+  // Reconcile rows left in `last_run_status='running'` by a previous
+  // runtime. Any row whose `last_triggered_at` is fresh enough gets a
+  // backfill re-run kicked off synchronously (via the usual `beginTriggerX`
+  // code path) so time-sensitive jobs don't silently skip a cycle when the
+  // daemon restarts for an upgrade.
+  try {
+    const reconciled = reconcileInterruptedCronJobs();
+    if (reconciled.length > 0) {
+      log.info("Reconciled interrupted cron jobs from previous runtime", {
+        count: reconciled.length,
+        entries: reconciled,
+      });
+      for (const entry of reconciled) {
+        if (entry.action !== "backfill_scheduled") continue;
+        // Fire-and-forget: `beginTriggerCronJobNow` returns a detached
+        // promise for the agent turn, we just want it kicked off. Errors
+        // are already logged inside `runCronJob`.
+        try {
+          const promise = beginTriggerCronJobNow(entry.id);
+          promise.catch((error) => {
+            log.warn("Cron backfill run failed", {
+              cronJobId: entry.id,
+              error: String(error),
+            });
+          });
+        } catch (error) {
+          log.warn("Failed to start cron backfill run", {
+            cronJobId: entry.id,
+            error: String(error),
+          });
+        }
+      }
+    }
+  } catch (error) {
+    log.warn("Failed to reconcile interrupted cron jobs on startup", {
+      error: String(error),
+    });
+  }
   void tickCronJobs();
   cronSchedulerTimer = setInterval(() => {
     void tickCronJobs();

--- a/packages/core/tasks/scheduler.test.ts
+++ b/packages/core/tasks/scheduler.test.ts
@@ -62,6 +62,7 @@ function makeTask(overrides: Partial<TaskRecord> = {}): TaskRecord {
     lastError: null,
     triggeredAt: null,
     completedAt: null,
+    retryCount: 0,
     createdAt: Date.now(),
     updatedAt: Date.now(),
     ...overrides,

--- a/packages/core/tasks/scheduler.ts
+++ b/packages/core/tasks/scheduler.ts
@@ -15,6 +15,7 @@ import {
   markTaskCompleted,
   markTaskFailed,
   markTaskTriggered,
+  reconcileInterruptedTasks,
 } from "@/config/local/tasks";
 import {
   buildThreadKey,
@@ -55,6 +56,64 @@ import { log } from "@/utils";
 // ---------------------------------------------------------------------------
 
 const TASK_POLL_INTERVAL_MS = 10_000;
+
+/**
+ * Hard upper bound for a task's session-preparation phase (creating the
+ * agent session + setting up a worktree). Mirrors
+ * `CRON_PREPARE_TIMEOUT_MS`: if this step hangs (SDK call never returns, or
+ * `git worktree add` stalls) the run would otherwise occupy the in-process
+ * `runningTaskIds` guard indefinitely. Bounding it lets the row flip to
+ * `failed` so users can retry or the next reconcile pass can resurrect it.
+ */
+const TASK_PREPARE_TIMEOUT_MS = parsePositiveIntEnv(
+  process.env.ODE_TASK_PREPARE_TIMEOUT_MS,
+  2 * 60_000,
+);
+
+/**
+ * Hard upper bound for the actual agent turn (`agent.sendMessage`). OpenCode
+ * sessions can wedge waiting on approvals or remote provider calls; we bound
+ * the run so a stuck turn doesn't permanently lock out the task row. Matches
+ * the cron default (2h) — tasks tend to be heavier since they often do
+ * scripted long-running work, but anything longer than 2h should really be
+ * split into multiple scheduled runs.
+ */
+const TASK_AGENT_TIMEOUT_MS = parsePositiveIntEnv(
+  process.env.ODE_TASK_AGENT_TIMEOUT_MS,
+  2 * 60 * 60_000,
+);
+
+function parsePositiveIntEnv(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+class TaskStepTimeoutError extends Error {
+  constructor(step: string, timeoutMs: number) {
+    super(`${step} timed out after ${timeoutMs}ms`);
+    this.name = "TaskStepTimeoutError";
+  }
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, step: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new TaskStepTimeoutError(step, timeoutMs));
+    }, timeoutMs);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
 
 let taskSchedulerTimer: ReturnType<typeof setInterval> | null = null;
 const runningTaskIds = new Set<string>();
@@ -291,7 +350,11 @@ async function runTask(task: TaskRecord): Promise<void> {
   let threadKey: string | null = null;
 
   try {
-    const { session, sessionId, cwd, threadId } = await prepareTaskSession(task);
+    const { session, sessionId, cwd, threadId } = await withTimeout(
+      prepareTaskSession(task),
+      TASK_PREPARE_TIMEOUT_MS,
+      "Task session preparation",
+    );
     threadKey = buildThreadKey(task.channelId, threadId);
     const providerId = agent.getProviderForSession(sessionId);
     const options = buildMessageOptions({
@@ -352,13 +415,17 @@ async function runTask(task: TaskRecord): Promise<void> {
       });
     }
 
-    const responses = await agent.sendMessage(
-      task.channelId,
-      sessionId,
-      task.messageText,
-      cwd,
-      options,
-      buildTaskAgentContext(task),
+    const responses = await withTimeout(
+      agent.sendMessage(
+        task.channelId,
+        sessionId,
+        task.messageText,
+        cwd,
+        options,
+        buildTaskAgentContext(task),
+      ),
+      TASK_AGENT_TIMEOUT_MS,
+      "Task agent turn",
     );
     const finalText = buildFinalResponseText(responses) ?? "_Done_";
 
@@ -440,6 +507,25 @@ async function tickTasks(): Promise<void> {
 
 export function startTaskScheduler(): void {
   if (taskSchedulerTimer) return;
+  // Before the polling loop starts, reconcile any rows left stuck in
+  // `status='running'` from a previous runtime (SIGTERM during upgrade,
+  // crash, OOM, etc.). Staleness-based classification lives in the storage
+  // layer; we just log the outcome so it shows up in daemon.log.
+  try {
+    const reconciled = reconcileInterruptedTasks();
+    if (reconciled.length > 0) {
+      log.info("Reconciled interrupted tasks from previous runtime", {
+        count: reconciled.length,
+        entries: reconciled,
+      });
+    }
+  } catch (error) {
+    // Reconciliation is best-effort; a corrupted DB or schema mismatch
+    // should not prevent the scheduler from ticking.
+    log.warn("Failed to reconcile interrupted tasks on startup", {
+      error: String(error),
+    });
+  }
   void tickTasks();
   taskSchedulerTimer = setInterval(() => {
     void tickTasks();

--- a/packages/core/web/routes/tasks.ts
+++ b/packages/core/web/routes/tasks.ts
@@ -201,9 +201,11 @@ export function registerTaskRoutes(app: Elysia): void {
         if (!existing) throw new Error("Task not found");
         const cancelled = cancelTask(id);
         if (!cancelled) {
-          // Either already cancelled / completed / running. Surface the
-          // current status so the UI can show a sensible message.
-          throw new Error(`Task is not pending (status: ${existing.status})`);
+          // Row is already terminal (cancelled / success / failed). Surface
+          // the current status so the UI can show a sensible message. Note
+          // that `running` is now cancellable alongside `pending`; this
+          // branch is only for irrecoverable terminal states.
+          throw new Error(`Task cannot be cancelled (status: ${existing.status})`);
         }
         return {
           task: getTaskById(id),
@@ -217,7 +219,7 @@ export function registerTaskRoutes(app: Elysia): void {
         resolveStatus: (message) => {
           if (message === "Missing task id") return 400;
           if (message === "Task not found") return 404;
-          if (message.startsWith("Task is not pending")) return 409;
+          if (message.startsWith("Task cannot be cancelled")) return 409;
           return 500;
         },
       },


### PR DESCRIPTION
## Summary
- Task and cron rows left in `status='running'` after SIGTERM / crash / upgrade restart are now reconciled on scheduler startup instead of staying stuck forever.
- Tasks: fresh zombies go back to `pending` with a bumped `retry_count` (capped at 1 via `MAX_TASK_AUTO_RETRIES`); stale or over-budget rows are marked `failed`.
- Cron jobs: zombie `running` status is cleared, and a single backfill run is kicked off when `last_triggered_at` sits inside a 10 min window so time-sensitive jobs don't silently skip a cycle across a restart.

## Safety rails
- Bounds task preparation (`ODE_TASK_PREPARE_TIMEOUT_MS`, default 2 min) and agent turn (`ODE_TASK_AGENT_TIMEOUT_MS`, default 2 h) with `withTimeout` so a hung step can't permanently occupy the in-process `runningTaskIds` guard.
- `cancelTask` now also accepts `running` rows so humans can reclaim a stuck task from CLI / Web UI; the web route updates its 409 message accordingly.
- Reconciliation is pure SQL in the storage layer; the scheduler only logs the outcome and fires the backfill. Errors are non-fatal — a corrupt DB won't block the polling loop.

## Test plan
- `bun test packages/config/local/tasks.test.ts packages/config/local/cron-jobs.test.ts packages/core/tasks/scheduler.test.ts` -> 32 pass, 0 fail.
- New `cron-jobs.test.ts` covers the backfill vs `failed_stale` classification; `tasks.test.ts` covers requeue / retry-cap / stale paths and the new `running`-cancel behavior.

## Migration
- Adds a `retry_count INTEGER NOT NULL DEFAULT 0` column to `tasks`. Migration is idempotent (PRAGMA check + `ALTER TABLE` on older DBs); existing rows default to 0.