### PR TITLE
fix(inbox): preserve task/cron source_kind in thread UPSERT

### DIFF
--- a/packages/config/local/inbox.test.ts
+++ b/packages/config/local/inbox.test.ts
@@ -150,6 +150,78 @@ describe("local inbox store", () => {
     expect(summary?.taskTitle).toBe("Check deploy status after 1h");
   });
 
+  it("preserves task/cron source_kind when a later ensureMessageThread call defaults to user", () => {
+    // Simulates the bug where a synthetic task thread was later re-ensured
+    // through a path (e.g. runtime-facade) that hardcodes sourceKind: "user".
+    const taskThreadKey = buildThreadKey("C-preserve", "task:task-99");
+    ensureMessageThread({
+      platform: "slack",
+      channelId: "C-preserve",
+      threadId: "task:task-99",
+      replyThreadId: "task:task-99",
+      sourceKind: "task",
+      taskId: "task-99",
+      taskTitle: "do the thing later",
+    });
+
+    // Second call without explicit sourceKind (defaults to "user") must NOT
+    // clobber the more specific "task" source already persisted.
+    ensureMessageThread({
+      platform: "slack",
+      channelId: "C-preserve",
+      threadId: "task:task-99",
+      replyThreadId: "task:task-99",
+    });
+
+    const taskDetail = getMessageThreadById(taskThreadKey);
+    expect(taskDetail?.sourceKind).toBe("task");
+    expect(taskDetail?.taskId).toBe("task-99");
+    expect(taskDetail?.taskTitle).toBe("do the thing later");
+
+    // Same protection for cron_job.
+    const cronThreadKey = buildThreadKey("C-preserve", "cron-job:job-99");
+    ensureMessageThread({
+      platform: "slack",
+      channelId: "C-preserve",
+      threadId: "cron-job:job-99",
+      replyThreadId: "cron-job:job-99",
+      sourceKind: "cron_job",
+      cronJobId: "job-99",
+      cronJobTitle: "nightly cron",
+    });
+    ensureMessageThread({
+      platform: "slack",
+      channelId: "C-preserve",
+      threadId: "cron-job:job-99",
+      replyThreadId: "cron-job:job-99",
+      sourceKind: "user",
+    });
+    const cronDetail = getMessageThreadById(cronThreadKey);
+    expect(cronDetail?.sourceKind).toBe("cron_job");
+    expect(cronDetail?.cronJobId).toBe("job-99");
+
+    // Sanity check: a plain user thread upgraded to task still reflects the
+    // more specific value (upgrades user -> task are allowed).
+    const upgradeKey = buildThreadKey("C-preserve", "T-upgrade");
+    ensureMessageThread({
+      platform: "slack",
+      channelId: "C-preserve",
+      threadId: "T-upgrade",
+      replyThreadId: "T-upgrade",
+    });
+    ensureMessageThread({
+      platform: "slack",
+      channelId: "C-preserve",
+      threadId: "T-upgrade",
+      replyThreadId: "T-upgrade",
+      sourceKind: "task",
+      taskId: "task-upgrade",
+    });
+    const upgraded = getMessageThreadById(upgradeKey);
+    expect(upgraded?.sourceKind).toBe("task");
+    expect(upgraded?.taskId).toBe("task-upgrade");
+  });
+
   it("captures a full question → reply → answer batch timeline", () => {
     const threadKey = buildThreadKey("C-q", "T-q");
     ensureMessageThread({

--- a/packages/config/local/inbox.ts
+++ b/packages/config/local/inbox.ts
@@ -632,7 +632,10 @@ export function ensureMessageThread(params: EnsureMessageThreadParams): string {
        working_directory    = COALESCE(excluded.working_directory, message_thread.working_directory),
        thread_owner_user_id = COALESCE(excluded.thread_owner_user_id, message_thread.thread_owner_user_id),
        branch_name          = COALESCE(excluded.branch_name, message_thread.branch_name),
-       source_kind          = excluded.source_kind,
+       source_kind          = CASE
+                                WHEN message_thread.source_kind IN ('task','cron_job') THEN message_thread.source_kind
+                                ELSE excluded.source_kind
+                              END,
        cron_job_id          = COALESCE(excluded.cron_job_id, message_thread.cron_job_id),
        cron_job_title       = COALESCE(excluded.cron_job_title, message_thread.cron_job_title),
        task_id              = COALESCE(excluded.task_id, message_thread.task_id),


### PR DESCRIPTION
## Summary
- One-time tasks were showing up as *User Thread* in the inbox UI because `ensureMessageThread`'s `ON CONFLICT` clause overwrote `source_kind` with `excluded.source_kind`, and `params.sourceKind ?? \"user\"` meant any re-ensure from a caller that didn't pass `sourceKind` (e.g. `runtime-facade.ts` hardcoding `\"user\"`) flipped a task/cron thread back to `user`.
- Make the UPSERT conservative: keep existing `source_kind` when it's already `'task'` or `'cron_job'`; otherwise take the incoming value. `user -> task/cron_job` upgrades still work.
- Adds a regression test covering task preservation, cron_job preservation, and the allowed `user -> task` upgrade.

## Files
- `packages/config/local/inbox.ts` — conservative `CASE` overwrite for `source_kind` in the thread UPSERT.
- `packages/config/local/inbox.test.ts` — regression test `preserves task/cron source_kind when a later ensureMessageThread call defaults to user`.

## Test Plan
- `bun test packages/config/local/inbox.test.ts` → 7/7 pass (6 existing + 1 new).
- `bun test packages/core/test/web-routes.test.ts` → 7/7 pass (inbox consumer unaffected).

## Notes
- Historical rows already flipped to `user` are not auto-repaired by this change. If we want to backfill, we'd add a one-shot `UPDATE message_thread SET source_kind='task' WHERE task_id IS NOT NULL AND source_kind='user'` (and the cron_job equivalent) on startup — happy to follow up if needed.