### PR TITLE
feat(slack): add /cron launcher with view-details and run-now buttons

### DIFF
--- a/packages/ims/shared/incoming-message-processor.test.ts
+++ b/packages/ims/shared/incoming-message-processor.test.ts
@@ -22,6 +22,15 @@ describe("incoming message flow helpers", () => {
     expect(parseIncomingCommand("statsy")).toBeNull();
   });
 
+  it("parses cron command variants", () => {
+    expect(parseIncomingCommand("<@U123> /cron")).toBe("cron");
+    expect(parseIncomingCommand("@ode: cron")).toBe("cron");
+    expect(parseIncomingCommand("／cron")).toBe("cron");
+    expect(parseIncomingCommand("/cron")).toBe("cron");
+    expect(parseIncomingCommand("crons")).toBe("cron");
+    expect(parseIncomingCommand("cronjob")).toBeNull();
+  });
+
   it("formats drop reason messages", () => {
     expect(formatIncomingDropMessage("not_mentioned_and_inactive")).toContain("Not mentioned");
     expect(formatIncomingDropMessage("self_message")).toContain("Self message");

--- a/packages/ims/shared/incoming-message-processor.ts
+++ b/packages/ims/shared/incoming-message-processor.ts
@@ -9,7 +9,7 @@ export type IncomingFlowResult =
   | { type: "stop"; text: string }
   | { type: "forward"; text: string };
 
-export type IncomingCommand = "setting" | "stats";
+export type IncomingCommand = "setting" | "stats" | "cron";
 
 export function formatIncomingDropMessage(reason: IncomingIgnoreReason): string {
   switch (reason) {
@@ -32,5 +32,6 @@ export function parseIncomingCommand(text: string): IncomingCommand | null {
     .toLowerCase();
   if (/^\/?settings?\b/.test(normalized)) return "setting";
   if (/^\/?(?:debug\s+)?stats\b/.test(normalized)) return "stats";
+  if (/^\/?crons?\b/.test(normalized)) return "cron";
   return null;
 }

--- a/packages/ims/slack/client.ts
+++ b/packages/ims/slack/client.ts
@@ -22,6 +22,7 @@ import { fetchThreadHistoryByClient } from "./message-history";
 import { registerSlackMessageRouter } from "./message-router";
 import { syncSlackWorkspace } from "@/core/web/local-settings";
 import { describeSlackSettingsIssues, postSlackGeneralSettingsLauncher } from "./settings";
+import { postSlackChannelCronLauncher } from "./cron";
 import {
   createProcessorId,
 } from "@/ims/shared/processor-id";
@@ -708,6 +709,7 @@ export function setupMessageHandlers(): void {
       },
       isThreadActive,
       postGeneralSettingsLauncher: postSlackGeneralSettingsLauncher,
+      postCronLauncher: postSlackChannelCronLauncher,
       describeSettingsIssues: describeSlackSettingsIssues,
       handleInboundEvent: async (event) => {
         const rawChannelId = event.rawChannelId ?? event.channelId;

--- a/packages/ims/slack/commands.ts
+++ b/packages/ims/slack/commands.ts
@@ -50,6 +50,17 @@ import {
   type GitStrategy,
 } from "@/config";
 import { refreshSettingsProviderData } from "@/ims/shared/settings-provider-data";
+import {
+  CRON_RUN_NOW_ACTION,
+  CRON_VIEW_DETAILS_ACTION,
+  buildCronJobDetailBlocks,
+  getCronJobForChannel,
+} from "./cron";
+import {
+  CronJobAlreadyRunningError,
+  CronJobNotFoundError,
+  beginTriggerCronJobNow,
+} from "@/core/cron/scheduler";
 
 const SETTINGS_LAUNCH_ACTION = "open_settings_modal";
 const SETTINGS_MODAL_ID = "settings_modal";
@@ -851,6 +862,88 @@ export function setupInteractiveHandlers(): void {
     if (selectionMsg.ts) {
       await handleButtonSelection(channel, threadTs, userId || "unknown", value, selectionMsg.ts);
     }
+    });
+
+    slackApp.action(CRON_VIEW_DETAILS_ACTION, async ({ ack, body, client }) => {
+      await ack();
+      const actionBody = body as SlackActionBody;
+      const jobId = actionBody.actions?.[0]?.value;
+      const channelId = actionBody.channel?.id;
+      const userId = getActionUserId(actionBody);
+      if (!jobId || !channelId || !userId) return;
+
+      const job = getCronJobForChannel(channelId, jobId);
+      if (!job) {
+        await client.chat.postEphemeral({
+          channel: channelId,
+          user: userId,
+          text: `Cron job \`${jobId}\` not found in this channel.`,
+        });
+        return;
+      }
+
+      await client.chat.postEphemeral({
+        channel: channelId,
+        user: userId,
+        text: `Cron job: ${job.title}`,
+        blocks: buildCronJobDetailBlocks(job),
+      });
+    });
+
+    slackApp.action(CRON_RUN_NOW_ACTION, async ({ ack, body, client }) => {
+      await ack();
+      const actionBody = body as SlackActionBody;
+      const jobId = actionBody.actions?.[0]?.value;
+      const channelId = actionBody.channel?.id;
+      const userId = getActionUserId(actionBody);
+      if (!jobId || !channelId || !userId) return;
+
+      const job = getCronJobForChannel(channelId, jobId);
+      if (!job) {
+        await client.chat.postEphemeral({
+          channel: channelId,
+          user: userId,
+          text: `Cron job \`${jobId}\` not found in this channel.`,
+        });
+        return;
+      }
+
+      try {
+        const runPromise = beginTriggerCronJobNow(job.id);
+        runPromise.catch((error) => {
+          console.warn("Manually triggered cron job run failed", {
+            cronJobId: job.id,
+            error: String(error),
+          });
+        });
+        await client.chat.postEphemeral({
+          channel: channelId,
+          user: userId,
+          text: `▶️ Triggered cron job *${job.title}* (\`${job.id}\`). It will run in the background.`,
+        });
+      } catch (error) {
+        if (error instanceof CronJobAlreadyRunningError) {
+          await client.chat.postEphemeral({
+            channel: channelId,
+            user: userId,
+            text: `⏳ Cron job *${job.title}* is already running.`,
+          });
+          return;
+        }
+        if (error instanceof CronJobNotFoundError) {
+          await client.chat.postEphemeral({
+            channel: channelId,
+            user: userId,
+            text: `Cron job \`${job.id}\` was not found.`,
+          });
+          return;
+        }
+        await client.chat.postEphemeral({
+          channel: channelId,
+          user: userId,
+          text: `Failed to trigger cron job: ${error instanceof Error ? error.message : String(error)}`,
+        });
+      }
     });
   }
 }

--- a/packages/ims/slack/cron.ts
+++ b/packages/ims/slack/cron.ts
@@ -1,0 +1,186 @@
+import { WebClient } from "@slack/web-api";
+import {
+  getCronJobById,
+  listCronJobs,
+  type CronJobRecord,
+} from "@/config/local/cron-jobs";
+
+export const CRON_VIEW_DETAILS_ACTION = "cron_view_details";
+export const CRON_RUN_NOW_ACTION = "cron_run_now";
+
+function listCronJobsForChannel(channelId: string): CronJobRecord[] {
+  return listCronJobs().filter((job) => job.channelId === channelId);
+}
+
+function formatTimestamp(value: number | null | undefined): string {
+  if (!value || !Number.isFinite(value)) return "n/a";
+  return new Date(value).toISOString();
+}
+
+function truncate(text: string, max: number): string {
+  if (!text) return "";
+  if (text.length <= max) return text;
+  return `${text.slice(0, Math.max(0, max - 1))}…`;
+}
+
+function statusEmoji(job: CronJobRecord): string {
+  if (!job.enabled) return "⏸️";
+  switch (job.lastRunStatus) {
+    case "running":
+      return "♻️";
+    case "success":
+      return "✅";
+    case "failed":
+      return "❌";
+    case "idle":
+    default:
+      return "🕒";
+  }
+}
+
+function buildJobRowBlocks(job: CronJobRecord): any[] {
+  const title = truncate(job.title || "Cron job", 120);
+  const summary = [
+    `${statusEmoji(job)} *${title}*`,
+    `\`${job.cronExpression}\` · ${job.enabled ? "enabled" : "disabled"} · last: ${job.lastRunStatus}`,
+    truncate(job.messageText.split("\n")[0] ?? "", 140),
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  return [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: summary,
+      },
+    },
+    {
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          action_id: CRON_VIEW_DETAILS_ACTION,
+          text: { type: "plain_text", text: "View details" },
+          value: job.id,
+        },
+        {
+          type: "button",
+          action_id: CRON_RUN_NOW_ACTION,
+          text: { type: "plain_text", text: "Run now" },
+          value: job.id,
+          style: "primary",
+        },
+      ],
+    },
+    { type: "divider" },
+  ];
+}
+
+export function buildCronJobsLauncherBlocks(
+  channelId: string,
+  jobs: CronJobRecord[]
+): any[] {
+  if (jobs.length === 0) {
+    return [
+      {
+        type: "section",
+        text: {
+          type: "mrkdwn",
+          text: `No cron jobs configured for this channel (\`${channelId}\`).\nCreate one with \`ode cron create --schedule "<cron>" --channel ${channelId} --message "..."\`.`,
+        },
+      },
+    ];
+  }
+
+  const header: any[] = [
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*Cron jobs for this channel* (${jobs.length})`,
+      },
+    },
+    { type: "divider" },
+  ];
+
+  const rows: any[] = [];
+  for (const job of jobs) {
+    rows.push(...buildJobRowBlocks(job));
+  }
+
+  return [...header, ...rows];
+}
+
+export function buildCronJobDetailBlocks(job: CronJobRecord): any[] {
+  const lines = [
+    `*${job.title || "Cron job"}*`,
+    `• *id:* \`${job.id}\``,
+    `• *schedule:* \`${job.cronExpression}\``,
+    `• *enabled:* ${job.enabled ? "yes" : "no"}`,
+    `• *platform:* ${job.platform}`,
+    `• *workspace:* ${job.workspaceName || job.workspaceId || "-"}`,
+    `• *channel:* ${job.channelName || job.channelId} (\`${job.channelId}\`)`,
+    `• *last status:* ${job.lastRunStatus}`,
+    `• *last triggered:* ${formatTimestamp(job.lastTriggeredAt)}`,
+    `• *last completed:* ${formatTimestamp(job.lastCompletedAt)}`,
+    `• *created:* ${formatTimestamp(job.createdAt)}`,
+    `• *updated:* ${formatTimestamp(job.updatedAt)}`,
+  ];
+  if (job.lastError) {
+    lines.push(`• *last error:* \`${truncate(job.lastError, 400)}\``);
+  }
+
+  const blocks: any[] = [
+    {
+      type: "section",
+      text: { type: "mrkdwn", text: lines.join("\n") },
+    },
+    {
+      type: "section",
+      text: {
+        type: "mrkdwn",
+        text: `*Prompt:*\n\`\`\`${truncate(job.messageText, 2500)}\`\`\``,
+      },
+    },
+    {
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          action_id: CRON_RUN_NOW_ACTION,
+          text: { type: "plain_text", text: "Run now" },
+          value: job.id,
+          style: "primary",
+        },
+      ],
+    },
+  ];
+
+  return blocks;
+}
+
+export async function postSlackChannelCronLauncher(
+  channelId: string,
+  userId: string,
+  client: WebClient
+): Promise<void> {
+  const jobs = listCronJobsForChannel(channelId);
+  await client.chat.postEphemeral({
+    channel: channelId,
+    user: userId,
+    text: jobs.length === 0 ? "No cron jobs for this channel." : "Cron jobs for this channel",
+    blocks: buildCronJobsLauncherBlocks(channelId, jobs),
+  });
+}
+
+export function getCronJobForChannel(
+  channelId: string,
+  jobId: string
+): CronJobRecord | null {
+  const job = getCronJobById(jobId);
+  if (!job) return null;
+  if (job.channelId !== channelId) return null;
+  return job;
+}

--- a/packages/ims/slack/message-router.test.ts
+++ b/packages/ims/slack/message-router.test.ts
@@ -17,6 +17,7 @@ function createDeps(overrides: Partial<Parameters<typeof registerSlackMessageRou
     isThreadOwner: () => false,
     isThreadActive: () => false,
     postGeneralSettingsLauncher: async () => {},
+    postCronLauncher: async () => {},
     describeSettingsIssues: () => [],
     handleInboundEvent,
     ...overrides,

--- a/packages/ims/slack/message-router.ts
+++ b/packages/ims/slack/message-router.ts
@@ -32,6 +32,7 @@ type RouterDeps = {
   isThreadOwner: (channelId: string, threadId: string, userId: string) => boolean;
   isThreadActive: (channelId: string, threadId: string, botId: string) => boolean;
   postGeneralSettingsLauncher: (channelId: string, userId: string, client: any) => Promise<void>;
+  postCronLauncher: (channelId: string, userId: string, client: any) => Promise<void>;
   describeSettingsIssues: (channelId: string) => string[];
   handleInboundEvent: (event: RawInboundEvent) => Promise<void>;
 };
@@ -201,6 +202,23 @@ async function maybeHandleLauncherCommand(params: {
       await handleStatsCommand({ channelId, threadId, say });
     } else {
       log.debug("Slack stats command ignored because bot was not mentioned", {
+        channelId,
+        userId,
+        cleanText,
+      });
+    }
+    return true;
+  }
+  if (command === "cron") {
+    if (isMention) {
+      log.info("Slack cron launcher command matched", {
+        channelId,
+        userId,
+        cleanText,
+      });
+      await deps.postCronLauncher(channelId, userId, client);
+    } else {
+      log.debug("Slack cron command ignored because bot was not mentioned", {
         channelId,
         userId,
         cleanText,


### PR DESCRIPTION
## Summary
- `@ode /cron` now replies with an ephemeral message listing all cron jobs scoped to the current channel, each row exposing *View details* and *Run now* buttons.
- *View details* renders a full detail block (schedule, enabled flag, last run metadata, prompt, last error) as an ephemeral follow-up.
- *Run now* reuses `beginTriggerCronJobNow` (same entry point as `POST /api/cron-jobs/:id/run`) with already-running / not-found handling. Both handlers validate `job.channelId === currentChannel` so users cannot trigger cron jobs from other channels.

## Changes
- `packages/ims/shared/incoming-message-processor.ts` — extend `IncomingCommand` with `"cron"` and add the `/cron|crons` regex.
- `packages/ims/slack/cron.ts` *(new)* — Block Kit builders for the launcher and detail views, plus `postSlackChannelCronLauncher` and `getCronJobForChannel`.
- `packages/ims/slack/message-router.ts` — new `postCronLauncher` dep and dispatch branch for the `cron` command.
- `packages/ims/slack/client.ts` — inject `postSlackChannelCronLauncher` when wiring the router.
- `packages/ims/slack/commands.ts` — register Bolt action handlers for `cron_view_details` and `cron_run_now`.

## Tests
- `bun test packages/ims/slack/ packages/ims/shared/` → 45 pass / 0 fail.
- Added parser unit cases for `/cron`, `cron`, `crons`, `／cron` (Japanese fullwidth slash).
- `bun run typecheck` clean for `packages/ims` and `packages/core` (pre-existing `web-ui` svelte/tailwind resolver errors are untouched).

## Behavior notes
- Responses are all ephemeral (only visible to the invoking user) to avoid noise in the channel.
- Like `/settings` and `/stats`, the command only fires when the bot is actually @-mentioned; non-mention usage is ignored.