### PR TITLE
feat(pr-tracker): simplify config to use source channel defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ode",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "description": "Coding anywhere with your coding agents connected",
   "module": "packages/core/index.ts",
   "type": "module",

--- a/packages/config/local/pr-trackers.test.ts
+++ b/packages/config/local/pr-trackers.test.ts
@@ -7,7 +7,6 @@ import type { GitHubRepo } from "@/utils/git-remote";
 import {
   clearPrTrackersForTests,
   closePrTrackerDatabaseForTests,
-  DEFAULT_PR_AGENT_PROVIDER,
   DEFAULT_PR_POLL_INTERVAL_SEC,
   DEFAULT_PR_PROMPT_TEMPLATE,
   deletePrTracker,
@@ -111,7 +110,6 @@ describe("pr-trackers settings", () => {
   test("returns defaults on first access", () => {
     const settings = getPrTrackerSettings();
     expect(settings.defaultPollIntervalSec).toBe(DEFAULT_PR_POLL_INTERVAL_SEC);
-    expect(settings.defaultAgentProvider).toBe(DEFAULT_PR_AGENT_PROVIDER);
     expect(settings.defaultPromptTemplate).toBe(DEFAULT_PR_PROMPT_TEMPLATE);
     expect(settings.defaultGithubToken).toBe("");
   });
@@ -119,23 +117,15 @@ describe("pr-trackers settings", () => {
   test("updates persist", () => {
     updatePrTrackerSettings({
       defaultPollIntervalSec: 600,
-      defaultAgentProvider: "claudecode",
       defaultGithubToken: " ghp_abc ",
     });
     const settings = getPrTrackerSettings();
     expect(settings.defaultPollIntervalSec).toBe(600);
-    expect(settings.defaultAgentProvider).toBe("claudecode");
     expect(settings.defaultGithubToken).toBe("ghp_abc");
   });
 
   test("rejects too-short poll interval", () => {
     expect(() => updatePrTrackerSettings({ defaultPollIntervalSec: 30 })).toThrow();
-  });
-
-  test("rejects invalid agent provider", () => {
-    expect(() =>
-      updatePrTrackerSettings({ defaultAgentProvider: "bogus" })
-    ).toThrow(/Unsupported agent/);
   });
 });
 
@@ -206,14 +196,13 @@ describe("pr-trackers scan", () => {
 });
 
 describe("pr-trackers enable/update", () => {
-  test("enabling without a target channel throws", () => {
+  test("enabling a scanned tracker does not require any extra config", () => {
     scanPrTrackers(
       makeProbe({ "/tmp/repos/ode": { host: "github.com", owner: "anomalyco", repo: "ode" } })
     );
     const tracker = listPrTrackers()[0]!;
-    expect(() => updatePrTracker(tracker.id, { enabled: true })).toThrow(
-      /target channel/
-    );
+    const updated = updatePrTracker(tracker.id, { enabled: true });
+    expect(updated.enabled).toBe(true);
   });
 
   test("first enable snaps last_polled_at to now so we don't backfill", () => {
@@ -226,12 +215,10 @@ describe("pr-trackers enable/update", () => {
     const before = Date.now();
     const updated = updatePrTracker(tracker.id, {
       enabled: true,
-      targetChannelId: "C_WEB",
     });
     const after = Date.now();
 
     expect(updated.enabled).toBe(true);
-    expect(updated.targetChannelId).toBe("C_WEB");
     expect(updated.lastPolledAt).not.toBeNull();
     expect(updated.lastPolledAt!).toBeGreaterThanOrEqual(before);
     expect(updated.lastPolledAt!).toBeLessThanOrEqual(after);
@@ -242,7 +229,7 @@ describe("pr-trackers enable/update", () => {
       makeProbe({ "/tmp/repos/ode": { host: "github.com", owner: "anomalyco", repo: "ode" } })
     );
     const id = listPrTrackers()[0]!.id;
-    const enabled = updatePrTracker(id, { enabled: true, targetChannelId: "C_DEV" });
+    const enabled = updatePrTracker(id, { enabled: true });
     const originalCursor = enabled.lastPolledAt!;
 
     updatePrTracker(id, { enabled: false });
@@ -251,7 +238,7 @@ describe("pr-trackers enable/update", () => {
     const afterPoll = getPrTrackerById(id)!;
     expect(afterPoll.lastPolledAt).toBe(originalCursor + 10_000);
 
-    const reEnabled = updatePrTracker(id, { enabled: true, targetChannelId: "C_DEV" });
+    const reEnabled = updatePrTracker(id, { enabled: true });
     expect(reEnabled.lastPolledAt).toBe(originalCursor + 10_000);
   });
 
@@ -262,7 +249,7 @@ describe("pr-trackers enable/update", () => {
     scanPrTrackers(makeProbe({}));
     const id = listPrTrackers()[0]!.id;
     expect(() =>
-      updatePrTracker(id, { enabled: true, targetChannelId: "C_DEV" })
+      updatePrTracker(id, { enabled: true })
     ).toThrow(/missing/);
   });
 
@@ -289,7 +276,7 @@ describe("pr-trackers due selection", () => {
       makeProbe({ "/tmp/repos/ode": { host: "github.com", owner: "anomalyco", repo: "ode" } })
     );
     const id = listPrTrackers()[0]!.id;
-    updatePrTracker(id, { enabled: true, targetChannelId: "C_DEV", pollIntervalSec: 60 });
+    updatePrTracker(id, { enabled: true, pollIntervalSec: 60 });
     // Simulate a very old last-poll timestamp.
     markPrTrackerPolled(id, { success: true, pollCompletedAt: 0 });
     const due = listDuePrTrackers(Date.now());
@@ -301,7 +288,7 @@ describe("pr-trackers due selection", () => {
       makeProbe({ "/tmp/repos/ode": { host: "github.com", owner: "anomalyco", repo: "ode" } })
     );
     const id = listPrTrackers()[0]!.id;
-    updatePrTracker(id, { enabled: true, targetChannelId: "C_DEV", pollIntervalSec: 1800 });
+    updatePrTracker(id, { enabled: true, pollIntervalSec: 1800 });
     markPrTrackerPolled(id, { success: true });
     expect(listDuePrTrackers(Date.now())).toHaveLength(0);
   });

--- a/packages/config/local/pr-trackers.ts
+++ b/packages/config/local/pr-trackers.ts
@@ -2,7 +2,6 @@ import { Database } from "bun:sqlite";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { AGENT_PROVIDERS, isAgentProviderId } from "@/shared/agent-provider";
 import { getGitHubRepoFromCwd, type GitHubRepo } from "@/utils/git-remote";
 import { loadOdeConfig } from "./ode-store";
 
@@ -25,7 +24,7 @@ export type PrTrackerPlatform = "slack" | "discord" | "lark";
 
 export type PrTrackerRecord = {
   id: string;
-  /** Source channel: where the working directory comes from. */
+  /** Source channel: where the working directory comes from and where poll results are posted back. */
   sourceWorkspaceId: string;
   sourceWorkspaceName: string | null;
   sourceChannelId: string;
@@ -37,18 +36,11 @@ export type PrTrackerRecord = {
   repoHost: string;
   enabled: boolean;
   /** Null = use global default. */
-  agentProvider: string | null;
-  /** Null = use global default. */
   promptTemplate: string | null;
   /** Null = use global default. */
   pollIntervalSec: number | null;
   /** Null = use global default token / gh CLI fallback. */
   githubToken: string | null;
-  /** Where the agent result is posted. Required to be set before enable. */
-  targetWorkspaceId: string | null;
-  targetChannelId: string | null;
-  targetChannelName: string | null;
-  targetPlatform: PrTrackerPlatform | null;
   /**
    * Cursor: last successful poll completion. The next poll asks GitHub for
    * comments/reviews `since` this timestamp. Set to `now` when the tracker
@@ -86,7 +78,6 @@ export type PrTrackerEventRecord = {
 
 export type PrTrackerSettings = {
   defaultPollIntervalSec: number;
-  defaultAgentProvider: string;
   defaultPromptTemplate: string;
   /** Optional global GitHub token. Empty string = fall back to `gh auth token`. */
   defaultGithubToken: string;
@@ -94,7 +85,6 @@ export type PrTrackerSettings = {
 };
 
 export const DEFAULT_PR_POLL_INTERVAL_SEC = 30 * 60; // 30 minutes
-export const DEFAULT_PR_AGENT_PROVIDER = "opencode";
 export const DEFAULT_PR_PROMPT_TEMPLATE = `A pull request in {{repo_full_name}} has new activity:
 PR #{{pr_number}}: {{pr_title}} by {{pr_author}}
 URL: {{pr_url}}
@@ -197,7 +187,7 @@ function initializeDatabase(db: Database): void {
     CREATE TABLE IF NOT EXISTS pr_tracker_settings (
       id INTEGER PRIMARY KEY CHECK (id = 1),
       default_poll_interval_sec INTEGER NOT NULL,
-      default_agent_provider TEXT NOT NULL,
+      default_agent_provider TEXT NOT NULL DEFAULT 'opencode',
       default_prompt_template TEXT NOT NULL,
       default_github_token TEXT NOT NULL DEFAULT '',
       updated_at INTEGER NOT NULL
@@ -242,14 +232,11 @@ type PrTrackerRow = {
   repo_name: string;
   repo_host: string;
   enabled: number;
-  agent_provider: string | null;
+  // Legacy columns (`agent_provider`, `target_*`) are kept on disk for
+  // backwards compatibility with existing DBs but are no longer read.
   prompt_template: string | null;
   poll_interval_sec: number | null;
   github_token: string | null;
-  target_workspace_id: string | null;
-  target_channel_id: string | null;
-  target_channel_name: string | null;
-  target_platform: PrTrackerPlatform | null;
   last_polled_at: number | null;
   last_success_at: number | null;
   last_error: string | null;
@@ -271,14 +258,9 @@ function mapTrackerRow(row: PrTrackerRow): PrTrackerRecord {
     repoName: row.repo_name,
     repoHost: row.repo_host,
     enabled: row.enabled === 1,
-    agentProvider: row.agent_provider,
     promptTemplate: row.prompt_template,
     pollIntervalSec: row.poll_interval_sec,
     githubToken: row.github_token,
-    targetWorkspaceId: row.target_workspace_id,
-    targetChannelId: row.target_channel_id,
-    targetChannelName: row.target_channel_name,
-    targetPlatform: row.target_platform,
     lastPolledAt: row.last_polled_at,
     lastSuccessAt: row.last_success_at,
     lastError: row.last_error,
@@ -332,10 +314,9 @@ function ensureSettingsRow(db: Database): void {
       default_prompt_template,
       default_github_token,
       updated_at
-    ) VALUES (1, ?, ?, ?, '', ?)
+    ) VALUES (1, ?, 'opencode', ?, '', ?)
   `).run(
     DEFAULT_PR_POLL_INTERVAL_SEC,
-    DEFAULT_PR_AGENT_PROVIDER,
     DEFAULT_PR_PROMPT_TEMPLATE,
     now
   );
@@ -348,7 +329,6 @@ export function getPrTrackerSettings(): PrTrackerSettings {
     .query(`
       SELECT
         default_poll_interval_sec,
-        default_agent_provider,
         default_prompt_template,
         default_github_token,
         updated_at
@@ -357,14 +337,12 @@ export function getPrTrackerSettings(): PrTrackerSettings {
     `)
     .get() as {
       default_poll_interval_sec: number;
-      default_agent_provider: string;
       default_prompt_template: string;
       default_github_token: string;
       updated_at: number;
     };
   return {
     defaultPollIntervalSec: row.default_poll_interval_sec,
-    defaultAgentProvider: row.default_agent_provider,
     defaultPromptTemplate: row.default_prompt_template,
     defaultGithubToken: row.default_github_token,
     updatedAt: row.updated_at,
@@ -373,7 +351,6 @@ export function getPrTrackerSettings(): PrTrackerSettings {
 
 export type UpdatePrTrackerSettingsParams = Partial<{
   defaultPollIntervalSec: number;
-  defaultAgentProvider: string;
   defaultPromptTemplate: string;
   defaultGithubToken: string;
 }>;
@@ -389,10 +366,6 @@ export function updatePrTrackerSettings(
     params.defaultPollIntervalSec !== undefined
       ? normalizePollInterval(params.defaultPollIntervalSec)
       : current.defaultPollIntervalSec;
-  const agentProvider =
-    params.defaultAgentProvider !== undefined
-      ? normalizeRequiredAgent(params.defaultAgentProvider)
-      : current.defaultAgentProvider;
   const promptTemplate =
     params.defaultPromptTemplate !== undefined
       ? normalizeRequiredText(params.defaultPromptTemplate, "promptTemplate")
@@ -407,12 +380,11 @@ export function updatePrTrackerSettings(
     UPDATE pr_tracker_settings
     SET
       default_poll_interval_sec = ?,
-      default_agent_provider = ?,
       default_prompt_template = ?,
       default_github_token = ?,
       updated_at = ?
     WHERE id = 1
-  `).run(pollInterval, agentProvider, promptTemplate, githubToken, now);
+  `).run(pollInterval, promptTemplate, githubToken, now);
 
   return getPrTrackerSettings();
 }
@@ -428,80 +400,10 @@ function normalizePollInterval(value: number): number {
   return Math.floor(value);
 }
 
-function normalizeOptionalAgent(value: string | null | undefined): string | null {
-  if (value === null || value === undefined) return null;
-  const trimmed = value.trim().toLowerCase();
-  if (trimmed.length === 0) return null;
-  if (!isAgentProviderId(trimmed)) {
-    throw new Error(
-      `Unsupported agent "${value}". Expected one of: ${AGENT_PROVIDERS.join(", ")}`
-    );
-  }
-  return trimmed;
-}
-
-function normalizeRequiredAgent(value: string): string {
-  const out = normalizeOptionalAgent(value);
-  if (!out) throw new Error("agentProvider is required");
-  return out;
-}
-
 function normalizeRequiredText(value: string, field: string): string {
   const trimmed = value.trim();
   if (!trimmed) throw new Error(`${field} cannot be empty`);
   return trimmed;
-}
-
-function resolveConfigChannelId(channelId: string): string {
-  const trimmed = channelId.trim();
-  if (!trimmed) return trimmed;
-  const delimiter = "::";
-  const index = trimmed.lastIndexOf(delimiter);
-  if (index < 0) return trimmed;
-  const raw = trimmed.slice(index + delimiter.length).trim();
-  return raw || trimmed;
-}
-
-type ChannelSnapshot = {
-  platform: PrTrackerPlatform;
-  workspaceId: string;
-  workspaceName: string;
-  channelId: string;
-  channelName: string;
-  workingDirectory: string;
-};
-
-function getChannelSnapshot(channelId: string): ChannelSnapshot {
-  const resolved = resolveConfigChannelId(channelId);
-  const config = loadOdeConfig();
-  for (const workspace of config.workspaces) {
-    const channel = workspace.channelDetails.find((item) => item.id === resolved);
-    if (!channel) continue;
-    return {
-      platform: workspace.type,
-      workspaceId: workspace.id,
-      workspaceName: workspace.name || workspace.id,
-      channelId: channel.id,
-      channelName: channel.name || channel.id,
-      workingDirectory: channel.workingDirectory?.trim() || "",
-    };
-  }
-  throw new Error(`Channel ${channelId} not found in configured workspaces`);
-}
-
-function getChannelSnapshotForTarget(channelId: string): {
-  platform: PrTrackerPlatform;
-  workspaceId: string;
-  channelId: string;
-  channelName: string;
-} {
-  const snap = getChannelSnapshot(channelId);
-  return {
-    platform: snap.platform,
-    workspaceId: snap.workspaceId,
-    channelId: snap.channelId,
-    channelName: snap.channelName,
-  };
 }
 
 // ---------------------------------------------------------------------------
@@ -713,11 +615,9 @@ export function listDuePrTrackers(nowMs: number = Date.now()): PrTrackerRecord[]
 
 export type UpdatePrTrackerParams = Partial<{
   enabled: boolean;
-  agentProvider: string | null;
   promptTemplate: string | null;
   pollIntervalSec: number | null;
   githubToken: string | null;
-  targetChannelId: string | null;
 }>;
 
 export function updatePrTracker(id: string, params: UpdatePrTrackerParams): PrTrackerRecord {
@@ -731,11 +631,6 @@ export function updatePrTracker(id: string, params: UpdatePrTrackerParams): PrTr
   const now = Date.now();
 
   const enabled = params.enabled !== undefined ? (params.enabled ? 1 : 0) : existing.enabled ? 1 : 0;
-
-  const agentProvider =
-    params.agentProvider !== undefined
-      ? normalizeOptionalAgent(params.agentProvider)
-      : existing.agentProvider;
 
   const promptTemplate =
     params.promptTemplate !== undefined
@@ -758,31 +653,6 @@ export function updatePrTracker(id: string, params: UpdatePrTrackerParams): PrTr
         : params.githubToken.trim()
       : existing.githubToken;
 
-  let targetWorkspaceId = existing.targetWorkspaceId;
-  let targetChannelId = existing.targetChannelId;
-  let targetChannelName = existing.targetChannelName;
-  let targetPlatform = existing.targetPlatform;
-
-  if (params.targetChannelId !== undefined) {
-    if (params.targetChannelId === null || params.targetChannelId.trim() === "") {
-      targetWorkspaceId = null;
-      targetChannelId = null;
-      targetChannelName = null;
-      targetPlatform = null;
-    } else {
-      const snap = getChannelSnapshotForTarget(params.targetChannelId);
-      targetWorkspaceId = snap.workspaceId;
-      targetChannelId = snap.channelId;
-      targetChannelName = snap.channelName;
-      targetPlatform = snap.platform;
-    }
-  }
-
-  // Enforce: enabling requires a target channel.
-  if (enabled === 1 && !targetChannelId) {
-    throw new Error("Cannot enable a tracker without a target channel");
-  }
-
   // First-enable bookkeeping: when transitioning from disabled→enabled and
   // there's no prior poll cursor, set last_polled_at to "now" so we don't
   // backfill historical events. Re-enabling later keeps the existing cursor.
@@ -795,27 +665,17 @@ export function updatePrTracker(id: string, params: UpdatePrTrackerParams): PrTr
     UPDATE pr_trackers
     SET
       enabled = ?,
-      agent_provider = ?,
       prompt_template = ?,
       poll_interval_sec = ?,
       github_token = ?,
-      target_workspace_id = ?,
-      target_channel_id = ?,
-      target_channel_name = ?,
-      target_platform = ?,
       last_polled_at = ?,
       updated_at = ?
     WHERE id = ?
   `).run(
     enabled,
-    agentProvider,
     promptTemplate,
     pollIntervalSec,
     githubToken,
-    targetWorkspaceId,
-    targetChannelId,
-    targetChannelName,
-    targetPlatform,
     nextLastPolledAt,
     now,
     id

--- a/packages/core/cli-handlers/pr-tracker.ts
+++ b/packages/core/cli-handlers/pr-tracker.ts
@@ -103,16 +103,12 @@ function printTrackerRow(tracker: PrTrackerRecord): void {
       ? "enabled"
       : "disabled";
   const source = `${tracker.sourceWorkspaceName || tracker.sourceWorkspaceId}/${tracker.sourceChannelName || tracker.sourceChannelId}`;
-  const target = tracker.targetChannelId
-    ? `${tracker.targetChannelName || tracker.targetChannelId}`
-    : "(none)";
   console.log(
     [
       tracker.id,
       state.padEnd(9),
       `${tracker.repoOwner}/${tracker.repoName}`.padEnd(32),
-      `from=${source}`,
-      `to=${target}`,
+      `channel=${source}`,
       `lastPoll=${formatTimestamp(tracker.lastPolledAt)}`,
     ].join("  "),
   );
@@ -124,15 +120,9 @@ function printTrackerDetail(tracker: PrTrackerRecord, settings?: PrTrackerSettin
   console.log(`enabled:          ${tracker.enabled}`);
   console.log(`missingSince:     ${formatTimestamp(tracker.missingSince)}`);
   console.log(
-    `sourceChannel:    ${tracker.sourceWorkspaceName || tracker.sourceWorkspaceId} / ${tracker.sourceChannelName || tracker.sourceChannelId} (${tracker.sourceChannelId})`,
+    `channel:          ${tracker.sourceWorkspaceName || tracker.sourceWorkspaceId} / ${tracker.sourceChannelName || tracker.sourceChannelId} (${tracker.sourceChannelId})`,
   );
   console.log(`workingDirectory: ${tracker.workingDirectory}`);
-  console.log(
-    `targetChannel:    ${tracker.targetChannelId ? `${tracker.targetChannelName || tracker.targetChannelId} (${tracker.targetChannelId})` : "(none)"}`,
-  );
-  console.log(
-    `agent:            ${tracker.agentProvider ?? `(default: ${settings?.defaultAgentProvider ?? "opencode"})`}`,
-  );
   console.log(
     `pollIntervalSec:  ${tracker.pollIntervalSec ?? `(default: ${settings?.defaultPollIntervalSec ?? "-"})`}`,
   );
@@ -170,21 +160,22 @@ function printHelp(): void {
       "  ode pr-tracker list [--enabled | --disabled | --missing] [--json]",
       "  ode pr-tracker show <id> [--json]",
       "  ode pr-tracker scan [--json]",
-      "  ode pr-tracker enable <id> [--target-channel <channelId>]",
+      "  ode pr-tracker enable <id>",
       "  ode pr-tracker disable <id>",
-      "  ode pr-tracker update <id> [--agent <provider>] [--prompt <text>] [--prompt-file <path>]",
-      "                             [--interval <seconds>] [--token <token>] [--target-channel <channelId>]",
+      "  ode pr-tracker update <id> [--prompt <text>] [--prompt-file <path>]",
+      "                             [--interval <seconds>] [--token <token>]",
       "  ode pr-tracker run <id>",
       "  ode pr-tracker delete <id>",
       "  ode pr-tracker events <id> [--limit N] [--json]",
-      "  ode pr-tracker settings [--show | --set-interval <seconds> | --set-agent <provider>",
+      "  ode pr-tracker settings [--show | --set-interval <seconds>",
       "                           --set-prompt-file <path> | --set-token <token>]",
       "",
       "Notes:",
       "  Tracker rows are populated by `ode pr-tracker scan`, which walks every",
       "  configured channel's workingDirectory and extracts GitHub repos from",
       "  the origin remote. Each tracker is disabled by default.",
-      "  Enabling a tracker requires a --target-channel (where the agent posts results).",
+      "  Poll results are posted back to the source channel using its configured",
+      "  default agent.",
     ].join("\n"),
   );
 }
@@ -195,7 +186,6 @@ function printHelp(): void {
 
 type ListPayload = {
   trackers: PrTrackerRecord[];
-  channels: Array<{ value: string; label: string }>;
   settings: PrTrackerSettings;
 };
 
@@ -258,21 +248,15 @@ async function handleScan(args: CliArgs): Promise<void> {
 
 async function handleUpdate(args: CliArgs, idFromCmd?: string): Promise<PrTrackerRecord> {
   const { flags, positional } = parseFlags(args, {
-    agent: true,
     prompt: true,
     "prompt-file": true,
     interval: true,
     token: true,
-    "target-channel": true,
   });
   const id = idFromCmd ?? positional[0];
   if (!id) throw new Error("Tracker id is required");
 
   const body: Record<string, unknown> = {};
-  if (flags.agent !== undefined) {
-    const raw = (flags.agent as string).trim().toLowerCase();
-    body.agentProvider = raw === "default" ? null : raw;
-  }
   if (flags["prompt-file"] !== undefined) {
     const file = Bun.file(flags["prompt-file"] as string);
     body.promptTemplate = (await file.text()).trim();
@@ -288,10 +272,6 @@ async function handleUpdate(args: CliArgs, idFromCmd?: string): Promise<PrTracke
   if (flags.token !== undefined) {
     body.githubToken = (flags.token as string) || null;
   }
-  if (flags["target-channel"] !== undefined) {
-    const raw = (flags["target-channel"] as string).trim();
-    body.targetChannelId = raw.length === 0 ? null : raw;
-  }
 
   const result = await apiFetch<{ tracker: PrTrackerRecord; settings: PrTrackerSettings }>(
     `/api/pr-trackers/${encodeURIComponent(id)}`,
@@ -305,19 +285,15 @@ async function handleUpdate(args: CliArgs, idFromCmd?: string): Promise<PrTracke
 }
 
 async function handleEnable(args: CliArgs): Promise<void> {
-  const { flags, positional } = parseFlags(args, { "target-channel": true });
+  const { positional } = parseFlags(args, {});
   const id = positional[0];
   if (!id) throw new Error("Tracker id is required: ode pr-tracker enable <id>");
-  const body: Record<string, unknown> = { enabled: true };
-  if (flags["target-channel"] !== undefined) {
-    body.targetChannelId = (flags["target-channel"] as string).trim() || null;
-  }
   const result = await apiFetch<{ tracker: PrTrackerRecord }>(
     `/api/pr-trackers/${encodeURIComponent(id)}`,
     {
       method: "PUT",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify(body),
+      body: JSON.stringify({ enabled: true }),
     },
   );
   console.log(`Tracker ${id} enabled.`);
@@ -383,14 +359,12 @@ async function handleSettings(args: CliArgs): Promise<void> {
   const { flags } = parseFlags(args, {
     show: false,
     "set-interval": true,
-    "set-agent": true,
     "set-prompt-file": true,
     "set-token": true,
   });
 
   const mutates =
     flags["set-interval"] !== undefined ||
-    flags["set-agent"] !== undefined ||
     flags["set-prompt-file"] !== undefined ||
     flags["set-token"] !== undefined;
 
@@ -400,9 +374,6 @@ async function handleSettings(args: CliArgs): Promise<void> {
       const n = Number(flags["set-interval"]);
       if (!Number.isFinite(n)) throw new Error("--set-interval must be a number");
       body.defaultPollIntervalSec = n;
-    }
-    if (flags["set-agent"] !== undefined) {
-      body.defaultAgentProvider = (flags["set-agent"] as string).trim();
     }
     if (flags["set-prompt-file"] !== undefined) {
       const file = Bun.file(flags["set-prompt-file"] as string);

--- a/packages/core/pr-tracker/scheduler.ts
+++ b/packages/core/pr-tracker/scheduler.ts
@@ -3,13 +3,11 @@ import type { OpenCodeMessageContext } from "@/agents";
 import {
   getChannelAgentProvider,
   getChannelBaseBranch,
-  getChannelModel,
   getChannelSystemMessage,
   getUserGeneralSettings,
   resolveChannelCwd,
 } from "@/config";
 import {
-  DEFAULT_PR_AGENT_PROVIDER,
   DEFAULT_PR_PROMPT_TEMPLATE,
   getPrTrackerById,
   getPrTrackerSettings,
@@ -32,7 +30,6 @@ import { sendChannelMessage as sendLarkChannelMessage } from "@/ims/lark/client"
 import { sendChannelMessage as sendSlackChannelMessage } from "@/ims/slack/client";
 import {
   type AgentProviderId,
-  isAgentProviderId,
 } from "@/shared/agent-provider";
 import { log } from "@/utils";
 import {
@@ -117,12 +114,9 @@ let prTrackerTimer: ReturnType<typeof setInterval> | null = null;
 const runningTrackerIds = new Set<string>();
 
 function resolveAgentProvider(tracker: PrTrackerRecord): AgentProviderId {
-  const override = tracker.agentProvider?.trim();
-  if (override && isAgentProviderId(override)) return override;
-  const fallback = getPrTrackerSettings().defaultAgentProvider;
-  if (isAgentProviderId(fallback)) return fallback;
-  if (isAgentProviderId(DEFAULT_PR_AGENT_PROVIDER)) return DEFAULT_PR_AGENT_PROVIDER;
-  // Last resort: take the tracker's source channel default.
+  // Tracker poll runs use the source channel's configured default agent.
+  // No tracker-level override; per-channel agent already lives in the channel
+  // settings.
   return getChannelAgentProvider(tracker.sourceChannelId);
 }
 
@@ -141,27 +135,19 @@ function resolveToken(tracker: PrTrackerRecord): string | null {
   });
 }
 
-function resolveTargetPlatform(tracker: PrTrackerRecord): "slack" | "discord" | "lark" {
-  return (tracker.targetPlatform ?? tracker.sourcePlatform) as
-    | "slack"
-    | "discord"
-    | "lark";
-}
-
-async function sendToTargetChannel(
+async function sendToSourceChannel(
   tracker: PrTrackerRecord,
   text: string,
 ): Promise<string | undefined> {
-  if (!tracker.targetChannelId) return undefined;
-  const platform = resolveTargetPlatform(tracker);
+  const platform = tracker.sourcePlatform;
   if (platform === "slack") {
     // Per spec: post as a top-level channel message, not threaded.
-    return await sendSlackChannelMessage(tracker.targetChannelId, text);
+    return await sendSlackChannelMessage(tracker.sourceChannelId, text);
   }
   if (platform === "discord") {
-    return await sendDiscordChannelMessage(tracker.targetChannelId, text);
+    return await sendDiscordChannelMessage(tracker.sourceChannelId, text);
   }
-  return await sendLarkChannelMessage(tracker.targetChannelId, text);
+  return await sendLarkChannelMessage(tracker.sourceChannelId, text);
 }
 
 function syntheticThreadIdForPr(trackerId: string, prNumber: number, ts: number): string {
@@ -307,10 +293,10 @@ async function runForPr(tracker: PrTrackerRecord, summary: PrSummary): Promise<v
     )}> in ${repoFullName}`;
     // Slack-only mrkdwn link; Discord/Lark receive the URL inline.
     const bodyHeader =
-      tracker.targetPlatform === "slack"
+      tracker.sourcePlatform === "slack"
         ? header
         : `PR update: #${summary.prNumber} ${summary.title} (${summary.url}) in ${repoFullName}`;
-    await sendToTargetChannel(tracker, `${bodyHeader}\n\n${finalText}`);
+    await sendToSourceChannel(tracker, `${bodyHeader}\n\n${finalText}`);
 
     // Record per-event dedupe rows + an aggregate row.
     for (const event of summary.events) {
@@ -422,19 +408,6 @@ export async function pollTracker(trackerId: string): Promise<PrPollOutcome> {
       prsHandled: 0,
       prsSkipped: 0,
       error: "tracker disabled",
-    };
-  }
-  if (!tracker.targetChannelId) {
-    markPrTrackerPolled(tracker.id, {
-      success: false,
-      errorMessage: "target channel not configured",
-    });
-    return {
-      trackerId,
-      prsScanned: 0,
-      prsHandled: 0,
-      prsSkipped: 0,
-      error: "no target channel",
     };
   }
 

--- a/packages/core/web/routes/pr-trackers.ts
+++ b/packages/core/web/routes/pr-trackers.ts
@@ -11,7 +11,6 @@ import {
   type UpdatePrTrackerParams,
   type UpdatePrTrackerSettingsParams,
 } from "@/config/local/pr-trackers";
-import { listTaskChannelOptions } from "@/config/local/tasks";
 import { triggerPrTrackerNow } from "@/core/pr-tracker/scheduler";
 import { log } from "@/utils";
 import { jsonResponse, readJsonBody, runRoute } from "../http";
@@ -77,10 +76,6 @@ function parseTrackerUpdate(payload: Record<string, unknown>): UpdatePrTrackerPa
   const update: UpdatePrTrackerParams = {};
   const enabled = getBoolean(payload, "enabled");
   if (enabled !== undefined) update.enabled = enabled;
-  if ("agentProvider" in payload) {
-    const raw = getOptionalString(payload, "agentProvider");
-    update.agentProvider = raw === undefined ? null : raw;
-  }
   if ("promptTemplate" in payload) {
     const raw = getOptionalString(payload, "promptTemplate");
     update.promptTemplate = raw === undefined ? null : raw;
@@ -93,10 +88,6 @@ function parseTrackerUpdate(payload: Record<string, unknown>): UpdatePrTrackerPa
     const raw = getOptionalString(payload, "githubToken");
     update.githubToken = raw === undefined ? null : raw;
   }
-  if ("targetChannelId" in payload) {
-    const raw = getOptionalString(payload, "targetChannelId");
-    update.targetChannelId = raw === undefined ? null : raw;
-  }
   return update;
 }
 
@@ -106,8 +97,6 @@ function parseSettingsUpdate(
   const update: UpdatePrTrackerSettingsParams = {};
   const interval = getNumber(payload, "defaultPollIntervalSec");
   if (interval !== undefined) update.defaultPollIntervalSec = interval;
-  const agent = getOptionalString(payload, "defaultAgentProvider");
-  if (agent !== undefined) update.defaultAgentProvider = agent ?? "";
   const prompt = getOptionalString(payload, "defaultPromptTemplate");
   if (prompt !== undefined) update.defaultPromptTemplate = prompt ?? "";
   const token = getOptionalString(payload, "defaultGithubToken");
@@ -118,7 +107,6 @@ function parseSettingsUpdate(
 function buildListPayload() {
   return {
     trackers: listPrTrackers(),
-    channels: listTaskChannelOptions(),
     settings: getPrTrackerSettings(),
   };
 }
@@ -142,7 +130,6 @@ export function registerPrTrackerRoutes(app: Elysia): void {
         return {
           tracker,
           events: listPrTrackerEvents(id, 100),
-          channels: listTaskChannelOptions(),
           settings: getPrTrackerSettings(),
         };
       },
@@ -185,7 +172,6 @@ export function registerPrTrackerRoutes(app: Elysia): void {
         resolveStatus: (message) => {
           if (message === "Missing tracker id") return 400;
           if (message === "PR tracker not found") return 404;
-          if (message.includes("target channel")) return 400;
           if (message.includes("missing")) return 409;
           return 400;
         },

--- a/packages/web-ui/src/lib/components/ui/index.ts
+++ b/packages/web-ui/src/lib/components/ui/index.ts
@@ -6,4 +6,5 @@ export { default as Textarea } from "./textarea.svelte";
 export { default as Select } from "./select.svelte";
 export { default as Badge } from "./badge.svelte";
 export { default as Separator } from "./separator.svelte";
+export { default as Switch } from "./switch.svelte";
 export { default as ToggleGroup } from "./toggle-group.svelte";

--- a/packages/web-ui/src/lib/components/ui/switch.svelte
+++ b/packages/web-ui/src/lib/components/ui/switch.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { cn } from "$lib/utils";
+
+  // A simple two-state toggle that mirrors the shadcn/Radix "Switch" look.
+  // Uses a real <button role="switch"> so it picks up keyboard + a11y for
+  // free; consumers bind a boolean via `checked`.
+  export let checked = false;
+  export let disabled = false;
+  export let className = "";
+  export let id: string | undefined = undefined;
+  export let ariaLabel: string | undefined = undefined;
+
+  function toggle(): void {
+    if (disabled) return;
+    checked = !checked;
+  }
+</script>
+
+<button
+  type="button"
+  role="switch"
+  aria-checked={checked}
+  aria-label={ariaLabel}
+  {id}
+  {disabled}
+  class={cn(
+    "peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--ring))] focus-visible:ring-offset-2 focus-visible:ring-offset-[hsl(var(--background))]",
+    "disabled:cursor-not-allowed disabled:opacity-50",
+    checked
+      ? "bg-[hsl(var(--primary))]"
+      : "bg-[hsl(var(--muted))] border-[hsl(var(--border))]",
+    className
+  )}
+  on:click={toggle}
+>
+  <span
+    class={cn(
+      "pointer-events-none block h-5 w-5 rounded-full bg-[hsl(var(--background))] shadow ring-0 transition-transform",
+      checked ? "translate-x-5" : "translate-x-0"
+    )}
+  ></span>
+</button>

--- a/packages/web-ui/src/lib/components/ui/switch.svelte
+++ b/packages/web-ui/src/lib/components/ui/switch.svelte
@@ -1,18 +1,23 @@
 <script lang="ts">
+  import { createEventDispatcher } from "svelte";
   import { cn } from "$lib/utils";
 
   // A simple two-state toggle that mirrors the shadcn/Radix "Switch" look.
   // Uses a real <button role="switch"> so it picks up keyboard + a11y for
-  // free; consumers bind a boolean via `checked`.
+  // free; consumers bind a boolean via `checked` and/or listen to the
+  // `change` event (detail = next checked value).
   export let checked = false;
   export let disabled = false;
   export let className = "";
   export let id: string | undefined = undefined;
   export let ariaLabel: string | undefined = undefined;
 
+  const dispatch = createEventDispatcher<{ change: boolean }>();
+
   function toggle(): void {
     if (disabled) return;
     checked = !checked;
+    dispatch("change", checked);
   }
 </script>
 

--- a/packages/web-ui/src/routes/(settings)/pr-tracker/+page.svelte
+++ b/packages/web-ui/src/routes/(settings)/pr-tracker/+page.svelte
@@ -450,7 +450,7 @@
                     checked={tracker.enabled}
                     disabled={isSaving || tracker.missingSince !== null}
                     ariaLabel={tracker.enabled ? t("Disable", "停用") : t("Enable", "启用")}
-                    on:click={() => void toggleEnabled(tracker)}
+                    on:change={() => void toggleEnabled(tracker)}
                   />
                   <Button
                     type="button"

--- a/packages/web-ui/src/routes/(settings)/pr-tracker/+page.svelte
+++ b/packages/web-ui/src/routes/(settings)/pr-tracker/+page.svelte
@@ -1,13 +1,8 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { ChevronDown, ChevronRight, Play, RefreshCw, Trash2 } from "lucide-svelte";
-  import { Badge, Button, Card, Input, Label, Select, Textarea } from "$lib/components/ui";
+  import { Badge, Button, Card, Input, Label, Switch, Textarea } from "$lib/components/ui";
   import { locale } from "$lib/i18n";
-  import {
-    AGENT_PROVIDERS,
-    AGENT_PROVIDER_LABELS,
-    type AgentProviderId,
-  } from "@/shared/agent-provider";
 
   type PrTrackerPlatform = "slack" | "discord" | "lark";
 
@@ -23,14 +18,9 @@
     repoName: string;
     repoHost: string;
     enabled: boolean;
-    agentProvider: string | null;
     promptTemplate: string | null;
     pollIntervalSec: number | null;
     githubToken: string | null;
-    targetWorkspaceId: string | null;
-    targetChannelId: string | null;
-    targetChannelName: string | null;
-    targetPlatform: PrTrackerPlatform | null;
     lastPolledAt: number | null;
     lastSuccessAt: number | null;
     lastError: string | null;
@@ -39,18 +29,8 @@
     updatedAt: number;
   };
 
-  type ChannelOption = {
-    value: string;
-    label: string;
-    channelId: string;
-    channelName: string;
-    workspaceId: string;
-    workspaceName: string;
-  };
-
   type PrTrackerSettings = {
     defaultPollIntervalSec: number;
-    defaultAgentProvider: string;
     defaultPromptTemplate: string;
     defaultGithubToken: string;
     updatedAt: number;
@@ -58,12 +38,10 @@
 
   type ListPayload = {
     trackers: PrTrackerRecord[];
-    channels: ChannelOption[];
     settings: PrTrackerSettings;
   };
 
   let trackers = $state<PrTrackerRecord[]>([]);
-  let channels = $state<ChannelOption[]>([]);
   let settings = $state<PrTrackerSettings | null>(null);
   let isLoading = $state(false);
   let isSaving = $state(false);
@@ -72,9 +50,9 @@
   let runningIds = $state<Set<string>>(new Set());
   let expandedIds = $state<Set<string>>(new Set());
 
-  // Settings form.
-  let formDefaultInterval = $state(1800);
-  let formDefaultAgent = $state("");
+  // Settings form. Interval is exposed in minutes for a nicer UI; the API still
+  // stores seconds, so we multiply by 60 on submit and divide on load.
+  let formDefaultIntervalMin = $state(30);
   let formDefaultPrompt = $state("");
   let formDefaultToken = $state("");
   let isSettingsOpen = $state(false);
@@ -99,6 +77,11 @@
     return `${Math.floor(hours / 24)}${t("d ago", " 天前")}`;
   }
 
+  function secondsToMinutes(sec: number | null | undefined): number {
+    if (!sec || !Number.isFinite(sec)) return 0;
+    return Math.max(1, Math.round(sec / 60));
+  }
+
   async function loadTrackers(): Promise<void> {
     isLoading = true;
     message = "";
@@ -109,10 +92,8 @@
         throw new Error(payload.error || `HTTP ${res.status}`);
       }
       trackers = payload.result.trackers;
-      channels = payload.result.channels;
       settings = payload.result.settings;
-      formDefaultInterval = settings.defaultPollIntervalSec;
-      formDefaultAgent = settings.defaultAgentProvider;
+      formDefaultIntervalMin = secondsToMinutes(settings.defaultPollIntervalSec);
       formDefaultPrompt = settings.defaultPromptTemplate;
       formDefaultToken = settings.defaultGithubToken;
     } catch (error) {
@@ -136,7 +117,6 @@
         throw new Error(payload.error || `HTTP ${res.status}`);
       }
       trackers = payload.result.trackers;
-      channels = payload.result.channels;
       settings = payload.result.settings;
       const s = payload.result.scan;
       message = t(
@@ -156,11 +136,9 @@
     try {
       const body: Record<string, unknown> = {};
       if ("enabled" in patch) body.enabled = patch.enabled;
-      if ("agentProvider" in patch) body.agentProvider = patch.agentProvider;
       if ("promptTemplate" in patch) body.promptTemplate = patch.promptTemplate;
       if ("pollIntervalSec" in patch) body.pollIntervalSec = patch.pollIntervalSec;
       if ("githubToken" in patch) body.githubToken = patch.githubToken;
-      if ("targetChannelId" in patch) body.targetChannelId = patch.targetChannelId;
       const res = await fetch(`/api/pr-trackers/${encodeURIComponent(tracker.id)}`, {
         method: "PUT",
         headers: { "content-type": "application/json" },
@@ -183,14 +161,6 @@
   }
 
   async function toggleEnabled(tracker: PrTrackerRecord): Promise<void> {
-    if (!tracker.enabled && !tracker.targetChannelId) {
-      message = t(
-        "Pick a target channel before enabling this tracker.",
-        "启用前请先选择目标频道。",
-      );
-      expandedIds = new Set([...expandedIds, tracker.id]);
-      return;
-    }
     await saveTracker(tracker, { enabled: !tracker.enabled });
   }
 
@@ -243,12 +213,16 @@
     isSaving = true;
     message = "";
     try {
+      const intervalMin = Number(formDefaultIntervalMin);
+      if (!Number.isFinite(intervalMin) || intervalMin < 1) {
+        message = t("Poll interval must be at least 1 minute.", "轮询间隔至少 1 分钟。");
+        return;
+      }
       const res = await fetch("/api/pr-trackers/settings", {
         method: "PUT",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
-          defaultPollIntervalSec: formDefaultInterval,
-          defaultAgentProvider: formDefaultAgent,
+          defaultPollIntervalSec: Math.round(intervalMin * 60),
           defaultPromptTemplate: formDefaultPrompt,
           defaultGithubToken: formDefaultToken,
         }),
@@ -258,6 +232,7 @@
         throw new Error(payload.error || `HTTP ${res.status}`);
       }
       settings = payload.result.settings;
+      formDefaultIntervalMin = secondsToMinutes(settings.defaultPollIntervalSec);
       message = t("Settings saved.", "设置已保存。");
     } catch (error) {
       message = t("Save failed: ", "保存失败：") + String(error);
@@ -274,40 +249,40 @@
   }
 
   // Local editable copies keyed by tracker id, so edits don't flicker while typing.
+  // `pollIntervalMin` stores the minutes the user typed; blank means "use default".
   const drafts = $state<Record<string, {
-    agentProvider: string;
     promptTemplate: string;
-    pollIntervalSec: string;
+    pollIntervalMin: string;
     githubToken: string;
-    targetChannelId: string;
   }>>({});
 
   function ensureDraft(tracker: PrTrackerRecord): void {
     if (drafts[tracker.id]) return;
     drafts[tracker.id] = {
-      agentProvider: tracker.agentProvider ?? "",
       promptTemplate: tracker.promptTemplate ?? "",
-      pollIntervalSec: tracker.pollIntervalSec != null ? String(tracker.pollIntervalSec) : "",
+      pollIntervalMin:
+        tracker.pollIntervalSec != null ? String(secondsToMinutes(tracker.pollIntervalSec)) : "",
       githubToken: tracker.githubToken ?? "",
-      targetChannelId: tracker.targetChannelId ?? "",
     };
   }
 
   async function applyDraft(tracker: PrTrackerRecord): Promise<void> {
     const draft = drafts[tracker.id];
     if (!draft) return;
-    const intervalTrim = draft.pollIntervalSec.trim();
-    const interval = intervalTrim === "" ? null : Number(intervalTrim);
-    if (interval !== null && (!Number.isFinite(interval) || interval < 60)) {
-      message = t("Poll interval must be a number ≥ 60.", "轮询间隔必须是 ≥ 60 的数字。");
-      return;
+    const minTrim = draft.pollIntervalMin.trim();
+    let intervalSec: number | null = null;
+    if (minTrim !== "") {
+      const minutes = Number(minTrim);
+      if (!Number.isFinite(minutes) || minutes < 1) {
+        message = t("Poll interval must be ≥ 1 minute.", "轮询间隔必须 ≥ 1 分钟。");
+        return;
+      }
+      intervalSec = Math.round(minutes * 60);
     }
     await saveTracker(tracker, {
-      agentProvider: draft.agentProvider.trim() || null,
       promptTemplate: draft.promptTemplate.trim() === "" ? null : draft.promptTemplate,
-      pollIntervalSec: interval,
+      pollIntervalSec: intervalSec,
       githubToken: draft.githubToken.trim() === "" ? null : draft.githubToken,
-      targetChannelId: draft.targetChannelId.trim() === "" ? null : draft.targetChannelId,
     });
   }
 
@@ -339,8 +314,8 @@
       <h2 class="text-xl font-semibold tracking-tight">{t("PR Tracker", "PR 追踪")}</h2>
       <p class="mt-1 text-sm text-[hsl(var(--muted-foreground))]">
         {t(
-          "Watch GitHub repos discovered from each channel's working directory. When enabled, new PR activity triggers an agent run in the target channel.",
-          "基于每个频道的工作目录自动发现 GitHub 仓库。启用后，PR 新活动会触发目标频道里的一次 agent 调用。",
+          "Watch GitHub repos discovered from each channel's working directory. When enabled, new PR activity triggers an agent run in that channel.",
+          "基于每个频道的工作目录自动发现 GitHub 仓库。启用后，PR 新活动会触发该频道里的一次 agent 调用。",
         )}
       </p>
     </div>
@@ -378,8 +353,7 @@
       </div>
       {#if settings}
         <span class="text-xs text-[hsl(var(--muted-foreground))]">
-          {t("Interval", "间隔")}: {settings.defaultPollIntervalSec}s ·
-          {t("Agent", "Agent")}: {settings.defaultAgentProvider} ·
+          {t("Interval", "间隔")}: {secondsToMinutes(settings.defaultPollIntervalSec)} {t("min", "分钟")} ·
           {t("Token", "Token")}: {settings.defaultGithubToken ? t("set", "已配置") : t("gh CLI fallback", "回退 gh CLI")}
         </span>
       {/if}
@@ -387,22 +361,14 @@
     {#if isSettingsOpen}
       <div class="mt-4 grid gap-3">
         <div class="grid gap-1">
-          <Label for="pt-default-interval">{t("Default poll interval (seconds)", "默认轮询间隔（秒）")}</Label>
+          <Label for="pt-default-interval">{t("Default poll interval (minutes)", "默认轮询间隔（分钟）")}</Label>
           <Input
             id="pt-default-interval"
             type="number"
-            min="60"
-            step="60"
-            bind:value={formDefaultInterval}
+            min="1"
+            step="1"
+            bind:value={formDefaultIntervalMin}
           />
-        </div>
-        <div class="grid gap-1">
-          <Label for="pt-default-agent">{t("Default agent", "默认 Agent")}</Label>
-          <Select id="pt-default-agent" bind:value={formDefaultAgent}>
-            {#each AGENT_PROVIDERS as provider (provider)}
-              <option value={provider}>{AGENT_PROVIDER_LABELS[provider as AgentProviderId]}</option>
-            {/each}
-          </Select>
         </div>
         <div class="grid gap-1">
           <Label for="pt-default-token">{t("Default GitHub token (blank = fall back to `gh auth token`)", "默认 GitHub Token（留空则回退到 `gh auth token`）")}</Label>
@@ -420,6 +386,12 @@
             {t(
               "Available variables: {{repo_full_name}}, {{pr_number}}, {{pr_title}}, {{pr_url}}, {{pr_author}}, {{pr_state}}, {{pr_head_ref}}, {{pr_base_ref}}, {{new_events_summary}}",
               "可用变量：{{repo_full_name}}、{{pr_number}}、{{pr_title}}、{{pr_url}}、{{pr_author}}、{{pr_state}}、{{pr_head_ref}}、{{pr_base_ref}}、{{new_events_summary}}",
+            )}
+          </p>
+          <p class="text-xs text-[hsl(var(--muted-foreground))]">
+            {t(
+              "Each channel can override this prompt to match the repo's conventions.",
+              "每个频道可以单独覆盖这个 Prompt，以匹配各自仓库的习惯。",
             )}
           </p>
         </div>
@@ -466,52 +438,54 @@
                   <div class="mt-1 text-xs text-[hsl(var(--muted-foreground))]">
                     <div>{t("cwd", "工作目录")}: <code>{tracker.workingDirectory}</code></div>
                     <div>
-                      {t("target", "目标频道")}:
-                      {#if tracker.targetChannelId}
-                        <code>{tracker.targetChannelName || tracker.targetChannelId}</code>
-                      {:else}
-                        <span class="text-[hsl(var(--destructive))]">{t("(not set)", "（未配置）")}</span>
-                      {/if}
-                      · {t("last poll", "最近轮询")}: {formatRelative(tracker.lastPolledAt)}
+                      {t("last poll", "最近轮询")}: {formatRelative(tracker.lastPolledAt)}
                       {#if tracker.lastError}
                         · <span class="text-[hsl(var(--destructive))]">{tracker.lastError}</span>
                       {/if}
                     </div>
                   </div>
                 </div>
-                <div class="flex shrink-0 items-center gap-1">
+                <div class="flex shrink-0 items-center gap-2">
+                  <Switch
+                    checked={tracker.enabled}
+                    disabled={isSaving || tracker.missingSince !== null}
+                    ariaLabel={tracker.enabled ? t("Disable", "停用") : t("Enable", "启用")}
+                    on:click={() => void toggleEnabled(tracker)}
+                  />
                   <Button
                     type="button"
                     variant="outline"
+                    size="sm"
+                    className="h-8 w-8 p-0"
                     on:click={() => void runNow(tracker)}
                     disabled={!tracker.enabled || runningIds.has(tracker.id) || tracker.missingSince !== null}
                     title={t("Poll now", "立即轮询")}
                   >
-                    <Play class="h-4 w-4" />
+                    <Play class="h-3.5 w-3.5" />
                   </Button>
                   <Button
                     type="button"
-                    variant={tracker.enabled ? "secondary" : "default"}
-                    on:click={() => void toggleEnabled(tracker)}
-                    disabled={isSaving || tracker.missingSince !== null}
+                    variant="outline"
+                    size="sm"
+                    className="h-8 w-8 p-0"
+                    on:click={() => toggleExpanded(tracker.id)}
                   >
-                    {tracker.enabled ? t("Disable", "停用") : t("Enable", "启用")}
-                  </Button>
-                  <Button type="button" variant="outline" on:click={() => toggleExpanded(tracker.id)}>
                     {#if expandedIds.has(tracker.id)}
-                      <ChevronDown class="h-4 w-4" />
+                      <ChevronDown class="h-3.5 w-3.5" />
                     {:else}
-                      <ChevronRight class="h-4 w-4" />
+                      <ChevronRight class="h-3.5 w-3.5" />
                     {/if}
                   </Button>
                   <Button
                     type="button"
                     variant="destructive"
+                    size="sm"
+                    className="h-8 w-8 p-0"
                     on:click={() => void deleteTracker(tracker)}
                     disabled={isSaving}
                     title={t("Delete tracker", "删除追踪器")}
                   >
-                    <Trash2 class="h-4 w-4" />
+                    <Trash2 class="h-3.5 w-3.5" />
                   </Button>
                 </div>
               </div>
@@ -519,31 +493,13 @@
               {#if expandedIds.has(tracker.id) && drafts[tracker.id]}
                 <div class="mt-4 grid gap-3 border-t border-[hsl(var(--border)/0.7)] pt-4">
                   <div class="grid gap-1">
-                    <Label for={`pt-target-${tracker.id}`}>{t("Target channel", "目标频道")}</Label>
-                    <Select id={`pt-target-${tracker.id}`} bind:value={drafts[tracker.id]!.targetChannelId}>
-                      <option value="">{t("(not set)", "（未配置）")}</option>
-                      {#each channels as channel (channel.value)}
-                        <option value={channel.value}>{channel.label}</option>
-                      {/each}
-                    </Select>
-                  </div>
-                  <div class="grid gap-1">
-                    <Label for={`pt-agent-${tracker.id}`}>{t("Agent", "Agent")}</Label>
-                    <Select id={`pt-agent-${tracker.id}`} bind:value={drafts[tracker.id]!.agentProvider}>
-                      <option value="">{t("(use default)", "（使用默认）")}</option>
-                      {#each AGENT_PROVIDERS as provider (provider)}
-                        <option value={provider}>{AGENT_PROVIDER_LABELS[provider as AgentProviderId]}</option>
-                      {/each}
-                    </Select>
-                  </div>
-                  <div class="grid gap-1">
-                    <Label for={`pt-interval-${tracker.id}`}>{t("Poll interval (seconds, blank = default)", "轮询间隔（秒，留空用默认）")}</Label>
+                    <Label for={`pt-interval-${tracker.id}`}>{t("Poll interval (minutes, blank = default)", "轮询间隔（分钟，留空用默认）")}</Label>
                     <Input
                       id={`pt-interval-${tracker.id}`}
                       type="number"
-                      min="60"
-                      step="60"
-                      bind:value={drafts[tracker.id]!.pollIntervalSec}
+                      min="1"
+                      step="1"
+                      bind:value={drafts[tracker.id]!.pollIntervalMin}
                     />
                   </div>
                   <div class="grid gap-1">


### PR DESCRIPTION
## Summary
- Drop the *target channel* concept; PR tracker polls now post back to the same channel they were scanned from (workspace is already derived from that channel).
- Drop tracker-level agent override and the global default agent picker. The scheduler now uses the source channel's configured default agent (`getChannelAgentProvider`), so each channel's agent choice applies uniformly.
- Poll interval UI switches to minutes (defaults to 30 min). The DB column stays in seconds, so existing installs keep working without a migration.
- New `Switch` component replaces the Enable/Disable button per tracker; the three action buttons (Poll now / expand / delete) are shrunk to 32 px squares for a tighter row.
- Legacy DB columns (`agent_provider`, `target_*`, `default_agent_provider`) are intentionally retained on disk so old rows still load; they're just no longer read or written.

## Notes
- `parseTrackerUpdate` / `parseSettingsUpdate` no longer accept `agentProvider`, `defaultAgentProvider`, or `targetChannelId`. Existing clients sending those fields are tolerated (fields are ignored).
- `ode pr-tracker` CLI loses `--target-channel`, `--agent`, and `--set-agent`; help + rendering updated.
- Bumps version to `0.1.36`.

## Tests
- `bun test` → 372 pass, 1 skip, 0 fail
- `packages/web-ui` `svelte-check` → 0 errors