### PR TITLE
fix(observability): include threadId in Slack send failure Sentry events

### DIFF
--- a/packages/core/observability/sentry.ts
+++ b/packages/core/observability/sentry.ts
@@ -178,10 +178,18 @@ function captureDeliveryFailure(failure: FailureRecord): void {
       if (failure.processorId) {
         scope.setTag("processor_id", failure.processorId);
       }
+      if (failure.threadId) {
+        // Tag the thread id so issues triggered by a malformed / synthetic
+        // thread (e.g. `invalid_thread_ts` when the caller hands Slack a
+        // non-`ts` string like `task:<uuid>`) are diagnosable from Sentry
+        // alone, without having to correlate with local logs.
+        scope.setTag("thread_id", failure.threadId);
+      }
       scope.setContext("delivery", {
         platform: failure.platform,
         op: failure.op,
         channelId: failure.channelId,
+        threadId: failure.threadId,
         processorId: failure.processorId,
         messageTs: failure.messageTs,
         rateLimited: failure.rateLimited,

--- a/packages/ims/shared/delivery-stats.test.ts
+++ b/packages/ims/shared/delivery-stats.test.ts
@@ -110,6 +110,24 @@ describe("DeliveryStats", () => {
     expect(failure.error).toBe("boom");
   });
 
+  test("failure record includes threadId when provided", () => {
+    const stats = new DeliveryStats();
+    const received: unknown[] = [];
+    stats.setFailureHook((failure) => {
+      received.push(failure);
+    });
+    stats.recordFailure({
+      platform: "slack",
+      channelId: "C1",
+      op: "send",
+      error: new Error("invalid_thread_ts"),
+      threadId: "task:abc-123",
+    });
+    expect(received).toHaveLength(1);
+    const failure = received[0] as { threadId?: string };
+    expect(failure.threadId).toBe("task:abc-123");
+  });
+
   test("failure hook errors do not break recording", () => {
     const stats = new DeliveryStats();
     stats.setFailureHook(() => {

--- a/packages/ims/shared/delivery-stats.ts
+++ b/packages/ims/shared/delivery-stats.ts
@@ -49,6 +49,14 @@ export type FailureRecord = {
   platform: DeliveryPlatform;
   processorId?: string;
   channelId: string;
+  /**
+   * The thread identifier the adapter tried to post into, if the op was a
+   * threaded send. Useful for diagnosing `invalid_thread_ts` / routing bugs
+   * where the caller hands the adapter a synthetic or malformed thread id.
+   * Only set when the op actually targets a thread; top-level channel sends
+   * and update/delete ops leave this undefined.
+   */
+  threadId?: string;
   op: DeliveryOp;
   error: string;
   rateLimited: boolean;
@@ -142,6 +150,7 @@ export class DeliveryStats {
     rateLimited?: boolean;
     processorId?: string;
     messageTs?: string;
+    threadId?: string;
   }): void {
     const channel = this.ensureChannel(params.platform, params.channelId, params.processorId);
     const errorText = stringifyError(params.error);
@@ -159,6 +168,7 @@ export class DeliveryStats {
       platform: params.platform,
       processorId: params.processorId,
       channelId: params.channelId,
+      threadId: params.threadId,
       op: params.op,
       error: errorText,
       rateLimited: Boolean(params.rateLimited),

--- a/packages/ims/slack/client.ts
+++ b/packages/ims/slack/client.ts
@@ -360,6 +360,7 @@ export async function sendMessage(
         error: err,
         rateLimited,
         processorId,
+        threadId,
       });
       deliveryStats.logThrottledWarn(
         `slack-send:${rawChannelId}`,


### PR DESCRIPTION
## Summary
- Enrich Slack `send` delivery failures with the target `threadId` so Sentry events like `ODE-DEAMON-7` (`IM slack send failed: invalid_thread_ts`) are diagnosable without having to correlate with local logs.
- Only affects the observability path; no behavior change in delivery.

## Context
- `ODE-DEAMON-7` only captured `channel_id`, `platform`, `op` — the offending thread id (Slack complained the value was `9223372036854775807`, a value never produced by us directly) was lost.
- With this change, `thread_id` appears as both a Sentry tag and under the `delivery` context, so the next occurrence tells us exactly which thread id was passed in.

## Changes
- `FailureRecord.threadId` added; `deliveryStats.recordFailure()` accepts an optional `threadId`.
- Slack `sendMessage` now passes the thread id on failure (other ops / other adapters unchanged — update/delete target a `messageTs`, not a thread).
- `captureDeliveryFailure` surfaces `thread_id` as a tag plus delivery-context field.
- Added a delivery-stats unit test covering the new field.

## Testing
- `bun test packages/ims/shared/delivery-stats.test.ts` → 11 pass
- `bun test packages/core/observability/sentry.test.ts` → 6 pass
- `bunx tsc --noEmit` → no new errors (pre-existing web-ui missing-module warnings only)