### PR TITLE
fix(scheduler): swallow transient SQLite I/O errors in tick loops

### DIFF
--- a/packages/core/cron/scheduler.ts
+++ b/packages/core/cron/scheduler.ts
@@ -429,13 +429,34 @@ async function tickCronJobs(): Promise<void> {
     0
   ).getTime();
 
-  const jobs = listEnabledCronJobs();
+  // The poll loop runs every CRON_POLL_INTERVAL_MS; transient SQLite I/O
+  // failures (e.g. a flaky disk, fs sync, or inbox.db checkpoint contention)
+  // used to surface as unhandled promise rejections to Sentry because the
+  // synchronous throw from `listEnabledCronJobs` / `markCronJobTriggered`
+  // had no catcher in the async entrypoint. Swallowing the error here is
+  // the right behaviour: the scheduler is best-effort and retries next tick.
+  let jobs: ReturnType<typeof listEnabledCronJobs>;
+  try {
+    jobs = listEnabledCronJobs();
+  } catch (error) {
+    log.warn("Cron scheduler tick failed to read enabled jobs", {
+      error: String(error),
+    });
+    return;
+  }
   for (const job of jobs) {
     if (runningJobIds.has(job.id)) continue;
     try {
       if (!matchesCronExpression(job.cronExpression, now)) continue;
     } catch (error) {
-      markCronJobFailed(job.id, error instanceof Error ? error.message : String(error));
+      try {
+        markCronJobFailed(job.id, error instanceof Error ? error.message : String(error));
+      } catch (markError) {
+        log.warn("Failed to mark cron job with invalid expression as failed", {
+          cronJobId: job.id,
+          error: String(markError),
+        });
+      }
       log.warn("Skipping cron job with invalid cron expression", {
         cronJobId: job.id,
         cronExpression: job.cronExpression,
@@ -444,7 +465,16 @@ async function tickCronJobs(): Promise<void> {
       continue;
     }
 
-    const claimed = markCronJobTriggered(job.id, minuteStartMs);
+    let claimed = false;
+    try {
+      claimed = markCronJobTriggered(job.id, minuteStartMs);
+    } catch (error) {
+      log.warn("Failed to claim cron job for execution", {
+        cronJobId: job.id,
+        error: String(error),
+      });
+      continue;
+    }
     if (!claimed) continue;
 
     runningJobIds.add(job.id);

--- a/packages/core/pr-tracker/scheduler.ts
+++ b/packages/core/pr-tracker/scheduler.ts
@@ -530,7 +530,20 @@ function earliestEventTimestamp(summaries: PrSummary[]): number {
 }
 
 async function tick(): Promise<void> {
-  const due = listDuePrTrackers();
+  // Transient SQLite I/O failures during the tick (reading
+  // `pr_tracker_settings` / `pr_trackers`) used to surface as unhandled
+  // promise rejections in Sentry because the synchronous throw from
+  // `listDuePrTrackers` had no catcher inside this async entrypoint.
+  // Swallow the error and retry on the next interval.
+  let due: ReturnType<typeof listDuePrTrackers>;
+  try {
+    due = listDuePrTrackers();
+  } catch (error) {
+    log.warn("PR tracker scheduler tick failed to read due trackers", {
+      error: String(error),
+    });
+    return;
+  }
   for (const tracker of due) {
     if (runningTrackerIds.has(tracker.id)) continue;
     runningTrackerIds.add(tracker.id);

--- a/packages/core/tasks/scheduler.ts
+++ b/packages/core/tasks/scheduler.ts
@@ -490,15 +490,47 @@ async function runTask(task: TaskRecord): Promise<void> {
 }
 
 async function tickTasks(): Promise<void> {
-  const now = Date.now();
-  const due = listDueTasks(now);
+  // The poll loop runs every TASK_POLL_INTERVAL_MS; transient SQLite I/O
+  // failures (e.g. a flaky disk, fs sync, or an inbox.db checkpoint
+  // contending with another writer) used to surface as unhandled promise
+  // rejections to Sentry because the synchronous throw from
+  // `listDueTasks` / `markTaskTriggered` had no catcher in the async
+  // entrypoint. Swallowing the error here is the right behaviour: the
+  // scheduler is best-effort and will retry on the next tick.
+  let due: ReturnType<typeof listDueTasks>;
+  try {
+    const now = Date.now();
+    due = listDueTasks(now);
+  } catch (error) {
+    log.warn("Task scheduler tick failed to read due tasks", {
+      error: String(error),
+    });
+    return;
+  }
   for (const task of due) {
     if (runningTaskIds.has(task.id)) continue;
-    if (!markTaskTriggered(task.id)) continue;
+    try {
+      if (!markTaskTriggered(task.id)) continue;
+    } catch (error) {
+      log.warn("Failed to claim task for execution", {
+        taskId: task.id,
+        error: String(error),
+      });
+      continue;
+    }
     runningTaskIds.add(task.id);
     // Re-read after the atomic claim so `triggeredAt` is populated for the
     // inbox message id.
-    const claimed = getTaskById(task.id) ?? task;
+    let claimed: typeof task;
+    try {
+      claimed = getTaskById(task.id) ?? task;
+    } catch (error) {
+      log.warn("Failed to re-read claimed task", {
+        taskId: task.id,
+        error: String(error),
+      });
+      claimed = task;
+    }
     void runTask(claimed).finally(() => {
       runningTaskIds.delete(task.id);
     });


### PR DESCRIPTION
## Summary
Three top Sentry issues for `ode-deamon` are unhandled-rejection variants of the same root cause:

| Sentry | Function | Events |
|---|---|---|
| ODE-DEAMON-8 | `listDueTasks` (task scheduler) | 368 |
| ODE-DEAMON-9 | `listEnabledCronJobs` (cron scheduler) | 257 |
| ODE-DEAMON-A | `ensureSettingsRow` via `getPrTrackerSettings` (PR-tracker) | 78 |

All three are `SQLiteError: disk I/O error` thrown from the synchronous storage call at the top of each scheduler's async `tick()` and propagated as an unhandled promise rejection (`auto.node.onunhandledrejection`) because `setInterval(() => void tick())` has no catcher.

Schedulers are best-effort polling loops that retry on the next interval, so swallowing the transient error and warn-logging is the correct fix. This also handles the per-row claim writes (`markTaskTriggered` / `markCronJobTriggered`) that traverse the same DB.

## Changes
- `packages/core/tasks/scheduler.ts`: wrap `listDueTasks`, `markTaskTriggered`, and `getTaskById` in `tickTasks`.
- `packages/core/cron/scheduler.ts`: wrap `listEnabledCronJobs`, `markCronJobFailed`, and `markCronJobTriggered` in `tickCronJobs`.
- `packages/core/pr-tracker/scheduler.ts`: wrap `listDuePrTrackers` in `tick` (which transitively calls `getPrTrackerSettings` -> `ensureSettingsRow`).

## Verification
- `bun test packages/core/tasks/scheduler.test.ts packages/config/local/tasks.test.ts packages/config/local/cron-jobs.test.ts` -> 32 pass / 0 fail
- typecheck clean for the touched packages