### PR TITLE
fix(claude): forward AskUserQuestion to the Slack question UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ode",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "description": "Coding anywhere with your coding agents connected",
   "module": "packages/core/index.ts",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ode",
-  "version": "0.1.38",
+  "version": "0.1.39",
   "description": "Coding anywhere with your coding agents connected",
   "module": "packages/core/index.ts",
   "type": "module",

--- a/packages/agents/adapter.ts
+++ b/packages/agents/adapter.ts
@@ -4,6 +4,7 @@ import type { QuestionInfo } from "@opencode-ai/sdk/v2";
 import { getAgentProviderLabel } from "@/shared/agent-provider";
 import { getAgentProvider, type AgentProviderId } from "./registry";
 import { getSessionClient } from "./opencode";
+import { replyToQuestion as replyToClaudeQuestion } from "./claude";
 import {
   buildStatusMessageByProvider,
 } from "@/utils/status";
@@ -96,6 +97,10 @@ export function createAgentAdapter(options: AgentAdapterOptions = {}): AgentAdap
     },
     async replyToQuestion({ requestId, sessionId, directory, answers }) {
       const providerId = getProviderForSession(sessionId);
+      if (providerId === "claudecode") {
+        await replyToClaudeQuestion({ sessionId, requestId, answers });
+        return;
+      }
       if (providerId !== "opencode") {
         throw new Error(`Question replies are not supported for agent: ${providerId}`);
       }
@@ -111,19 +116,32 @@ export function createAgentAdapter(options: AgentAdapterOptions = {}): AgentAdap
     },
     normalizeQuestions(questions: unknown): NormalizedQuestion[] {
       if (!Array.isArray(questions) || questions.length === 0) return [];
-      return (questions as QuestionInfo[])
+      return (questions as Array<QuestionInfo | Record<string, unknown>>)
         .map((question) => {
-          const prompt = typeof question.question === "string" ? question.question.trim() : "";
-          const options = Array.isArray(question.options)
-            ? question.options
-                .map((option) => (typeof option?.label === "string" ? option.label : ""))
-                .filter((label) => label.length > 0)
-            : undefined;
+          const record = question as Record<string, unknown>;
+          const promptRaw = typeof record.question === "string" ? record.question : "";
+          const prompt = promptRaw.trim();
+          const optionsRaw = Array.isArray(record.options) ? record.options : [];
+          const options = optionsRaw
+            .map((option): string => {
+              if (!option) return "";
+              if (typeof option === "string") return option;
+              if (typeof option === "object") {
+                const label = (option as Record<string, unknown>).label;
+                if (typeof label === "string") return label;
+              }
+              return "";
+            })
+            .filter((label): label is string => label.length > 0);
+          const multipleRaw = record.multiple ?? record.multiSelect;
+          const multiple = typeof multipleRaw === "boolean" ? multipleRaw : undefined;
+          const customRaw = record.custom;
+          const custom = typeof customRaw === "boolean" ? customRaw : undefined;
           return {
             question: prompt,
-            options: options && options.length > 0 ? options : undefined,
-            multiple: question.multiple,
-            custom: question.custom,
+            options: options.length > 0 ? options : undefined,
+            multiple,
+            custom,
           };
         })
         .filter((question) => question.question.length > 0);

--- a/packages/agents/claude/client.ts
+++ b/packages/agents/claude/client.ts
@@ -179,19 +179,35 @@ function getRecordSessionId(record: ClaudeJsonRecord, fallbackSessionId: string)
   return typeof record.session_id === "string" ? record.session_id : fallbackSessionId;
 }
 
+/**
+ * Publish a Claude stream-json record as a session event.
+ *
+ * `subscriptionSessionId` is the session id the kernel subscribed against
+ * when the request started. We *always* dispatch on that id even when the
+ * record itself carries a different `session_id` (Claude can rotate the id
+ * mid-turn on `--resume`), because in-process subscribers register by id
+ * and would otherwise stop receiving events the moment the id changes.
+ *
+ * `recordSessionFallback` is only used to compute the `session_id` we tag
+ * onto the published event payload (which downstream code reads to filter
+ * inspector state by session). Keeping that distinct from the dispatch key
+ * means we don't lose events even if the record drifts.
+ */
 function publishClaudeRecordAsSessionEvents(
   record: ClaudeJsonRecord,
-  fallbackSessionId: string
+  subscriptionSessionId: string,
+  recordSessionFallback: string = subscriptionSessionId
 ): void {
-  const sessionId = getRecordSessionId(record, fallbackSessionId);
+  const recordSessionId = getRecordSessionId(record, recordSessionFallback);
   const rawType = typeof record.type === "string" && record.type.trim()
     ? record.type.trim()
     : "unknown";
-  runtime.publishSessionEvent(sessionId, {
+  runtime.publishSessionEvent(subscriptionSessionId, {
     type: `claude.raw.${rawType}`,
     properties: {
       record,
       recordType: rawType,
+      recordSessionId,
       streamEventType: typeof record.event?.type === "string" ? record.event.type : undefined,
     },
   });
@@ -457,6 +473,20 @@ export async function sendMessage(
   const sessionKey = `${channelId}:${sessionId}`;
   const entry = runtime.beginRequest(sessionKey);
 
+  // The kernel subscribed against this `sessionId` when it built the
+  // request, and `subscribeToSession` registers handlers per-id in an
+  // in-memory map. If Claude rotates `session_id` mid-turn (it can on
+  // `--resume`), publishing on the rotated id would leave the kernel
+  // listening on a now-empty channel — including the question.asked event
+  // that drives the Slack question UI. We always dispatch on the original
+  // id and treat any rotated id as something we only need to honor when
+  // *spawning* the next Claude CLI invocation.
+  //
+  // adapter.ts also keys provider ownership off this original id, so all
+  // routing (subscribe → kernel filter → replyToQuestion) stays consistent
+  // even when the underlying Claude session id drifts.
+  const subscriptionSessionId = sessionId;
+
   try {
     return await runtime.withSessionLock(sessionKey, async () => {
       const agent = options?.agent;
@@ -467,16 +497,19 @@ export async function sendMessage(
       const systemPrompt = buildSystemPrompt(context?.slack);
 
       let isNewSession = newSessions.has(sessionId);
-      let currentSessionId = sessionId;
+      // Id used for Claude CLI --session-id / --resume + per-id environment
+      // overrides. Tracks the latest session id Claude reported so resume
+      // works after a rotation, while events stay on `subscriptionSessionId`.
+      let runtimeSessionId = sessionId;
       let prompt = initialPrompt;
 
       if (isNewSession) {
         const fallbackTitle = deriveSessionTitleFromPrompt(message);
         if (fallbackTitle) {
-          runtime.publishSessionEvent(sessionId, {
+          runtime.publishSessionEvent(subscriptionSessionId, {
             type: "session.updated",
             properties: {
-              sessionID: sessionId,
+              sessionID: subscriptionSessionId,
               info: {
                 title: fallbackTitle,
               },
@@ -487,14 +520,14 @@ export async function sendMessage(
 
       for (let round = 0; round < MAX_ASK_USER_QUESTION_ROUNDS; round += 1) {
         const args = buildClaudeCommandArgs({
-          sessionId: currentSessionId,
+          sessionId: runtimeSessionId,
           isNewSession,
           systemPrompt,
           workingPath,
           prompt,
         });
 
-        const envOverrides = runtime.getSessionEnvironment(currentSessionId);
+        const envOverrides = runtime.getSessionEnvironment(runtimeSessionId);
         const { output, permissionMode, command } = await runClaudeWithFallback(
           args,
           workingPath,
@@ -502,12 +535,13 @@ export async function sendMessage(
           entry,
           forcedPermissionMode,
           (record) => {
-            publishClaudeRecordAsSessionEvents(record, currentSessionId);
+            publishClaudeRecordAsSessionEvents(record, subscriptionSessionId, runtimeSessionId);
           }
         );
 
         log.info("Claude CLI response received", {
-          sessionId: currentSessionId,
+          subscriptionSessionId,
+          runtimeSessionId,
           permissionMode,
           command,
           round,
@@ -522,10 +556,10 @@ export async function sendMessage(
         }
 
         const responseSessionId = parsed?.session_id;
-        if (responseSessionId && responseSessionId !== currentSessionId && context?.slack?.threadId) {
+        if (responseSessionId && responseSessionId !== runtimeSessionId && context?.slack?.threadId) {
           runtime.setSessionEnvironment(responseSessionId, envOverrides);
           setThreadSessionId(channelId, context.slack.threadId, responseSessionId);
-          currentSessionId = responseSessionId;
+          runtimeSessionId = responseSessionId;
         }
 
         if (parsed?.is_error) {
@@ -535,7 +569,7 @@ export async function sendMessage(
         const text = parsed?.result?.trim() ?? "";
         if (text) {
           newSessions.delete(sessionId);
-          newSessions.delete(currentSessionId);
+          newSessions.delete(runtimeSessionId);
           return [{ text, messageType: "assistant" }];
         }
 
@@ -560,17 +594,22 @@ export async function sendMessage(
         const deferred = createDeferred<
           { status: "answered"; answers: string[] } | { status: "cancelled"; reason?: string }
         >();
-        pendingQuestions.set(currentSessionId, {
+        // Key the pending entry by `subscriptionSessionId` so
+        // `replyToQuestion(sessionId, ...)` from the adapter (which uses the
+        // same original id) finds it even after `runtimeSessionId` rotated.
+        pendingQuestions.set(subscriptionSessionId, {
           requestId,
           questionCount: askUser.questions.length,
           deferred,
         });
 
-        runtime.publishSessionEvent(currentSessionId, {
+        runtime.publishSessionEvent(subscriptionSessionId, {
           type: "question.asked",
           properties: {
             id: requestId,
-            sessionID: currentSessionId,
+            // Use the kernel-known id so `extractEventSessionId` matches
+            // `request.sessionId` and the kernel doesn't filter the event.
+            sessionID: subscriptionSessionId,
             questions: askUser.questions,
           },
         });
@@ -579,9 +618,9 @@ export async function sendMessage(
         try {
           outcome = await deferred.promise;
         } finally {
-          const stored = pendingQuestions.get(currentSessionId);
+          const stored = pendingQuestions.get(subscriptionSessionId);
           if (stored && stored.requestId === requestId) {
-            pendingQuestions.delete(currentSessionId);
+            pendingQuestions.delete(subscriptionSessionId);
           }
         }
 

--- a/packages/agents/claude/client.ts
+++ b/packages/agents/claude/client.ts
@@ -1,5 +1,7 @@
+import { randomUUID } from "node:crypto";
 import { setThreadSessionId } from "@/config/local/sessions";
 import { BoundedSet, log } from "@/utils";
+import { createDeferred, type Deferred } from "@/core/runtime/helpers";
 import { buildPromptParts, buildPromptText, buildSystemPrompt } from "../shared";
 import {
   CliAgentRuntime,
@@ -18,6 +20,28 @@ export type SessionEnvironment = RuntimeSessionEnvironment;
 
 const runtime = new CliAgentRuntime("Claude");
 type RuntimeRequestEntry = ReturnType<CliAgentRuntime["beginRequest"]>;
+
+// Cap how many AskUserQuestion → reply hops we honor inside a single
+// sendMessage call. If the model keeps asking after this many rounds
+// something is wrong (e.g. a buggy prompt loop) and we'd rather surface a
+// hard failure than spin forever holding a Slack thread hostage.
+const MAX_ASK_USER_QUESTION_ROUNDS = 8;
+
+/**
+ * Each Claude session can have at most one in-flight AskUserQuestion request
+ * at a time. The runtime serializes turns via `withSessionLock`, so even when
+ * the model loops we never have overlapping pendings on the same session.
+ *
+ * Stored per sessionId so `replyToQuestion(sessionId, requestId, answers)`
+ * can route the reply back to the awaiting `sendMessage` invocation, which
+ * then resumes the Claude CLI with the answers as a follow-up user prompt.
+ */
+type PendingClaudeQuestion = {
+  requestId: string;
+  questionCount: number;
+  deferred: Deferred<{ status: "answered"; answers: string[] } | { status: "cancelled"; reason?: string }>;
+};
+const pendingQuestions = new Map<string, PendingClaudeQuestion>();
 /**
  * FIFO-bounded cache of session ids that have not yet completed their first
  * turn. Evicting the oldest entry on overflow is safe: the flag only gates
@@ -211,6 +235,135 @@ function parseClaudeResult(output: string): {
   };
 }
 
+export type ClaudeAskUserQuestionOption = {
+  label: string;
+  description?: string;
+};
+
+export type ClaudeAskUserQuestion = {
+  question: string;
+  header?: string;
+  multiSelect?: boolean;
+  options?: ClaudeAskUserQuestionOption[];
+};
+
+export type ClaudeAskUserQuestionToolUse = {
+  toolUseId?: string;
+  questions: ClaudeAskUserQuestion[];
+};
+
+function coerceQuestionOptions(raw: unknown): ClaudeAskUserQuestionOption[] | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const options = raw
+    .map((entry): ClaudeAskUserQuestionOption | null => {
+      if (!entry || typeof entry !== "object") return null;
+      const record = entry as Record<string, unknown>;
+      const labelRaw = typeof record.label === "string" ? record.label.trim() : "";
+      if (!labelRaw) return null;
+      const descriptionRaw = typeof record.description === "string" ? record.description.trim() : "";
+      const option: ClaudeAskUserQuestionOption = { label: labelRaw };
+      if (descriptionRaw) option.description = descriptionRaw;
+      return option;
+    })
+    .filter((option): option is ClaudeAskUserQuestionOption => option !== null);
+  return options.length > 0 ? options : undefined;
+}
+
+function coerceQuestions(raw: unknown): ClaudeAskUserQuestion[] {
+  if (!Array.isArray(raw)) return [];
+  const questions = raw
+    .map((entry): ClaudeAskUserQuestion | null => {
+      if (!entry || typeof entry !== "object") return null;
+      const record = entry as Record<string, unknown>;
+      const questionText = typeof record.question === "string" ? record.question.trim() : "";
+      if (!questionText) return null;
+      const out: ClaudeAskUserQuestion = { question: questionText };
+      if (typeof record.header === "string" && record.header.trim()) {
+        out.header = record.header.trim();
+      }
+      if (typeof record.multiSelect === "boolean") {
+        out.multiSelect = record.multiSelect;
+      }
+      const options = coerceQuestionOptions(record.options);
+      if (options) out.options = options;
+      return out;
+    })
+    .filter((question): question is ClaudeAskUserQuestion => question !== null);
+  return questions;
+}
+
+/**
+ * Walk the Claude stream-json output and return the *last* AskUserQuestion
+ * tool_use, if any. We only consider fully assembled `assistant` records
+ * (not partial `stream_event` deltas) so we always read a coherent input
+ * payload. Returns `null` when the model never invoked AskUserQuestion in
+ * this turn.
+ */
+export function extractAskUserQuestionToolUse(output: string): ClaudeAskUserQuestionToolUse | null {
+  const lines = output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  let lastFound: ClaudeAskUserQuestionToolUse | null = null;
+  for (const line of lines) {
+    let parsed: ClaudeJsonRecord;
+    try {
+      parsed = JSON.parse(line) as ClaudeJsonRecord;
+    } catch {
+      continue;
+    }
+    if (parsed.type !== "assistant") continue;
+    const blocks = parsed.message?.content;
+    if (!Array.isArray(blocks)) continue;
+    for (const block of blocks) {
+      if (!block || typeof block !== "object") continue;
+      const record = block as Record<string, unknown>;
+      if (record.type !== "tool_use") continue;
+      if (typeof record.name !== "string") continue;
+      if (record.name !== "AskUserQuestion") continue;
+      const input = record.input;
+      if (!input || typeof input !== "object" || Array.isArray(input)) continue;
+      const questionsRaw = (input as Record<string, unknown>).questions;
+      const questions = coerceQuestions(questionsRaw);
+      if (questions.length === 0) continue;
+      const toolUseIdRaw = record.id;
+      lastFound = {
+        toolUseId: typeof toolUseIdRaw === "string" ? toolUseIdRaw : undefined,
+        questions,
+      };
+    }
+  }
+  return lastFound;
+}
+
+function formatAskUserQuestionAnswers(
+  questions: ClaudeAskUserQuestion[],
+  answers: string[]
+): string {
+  // Phrased as a follow-up user message that resumes the previous turn. We
+  // restate the questions because Claude on `--resume` only sees prior
+  // assistant tool_use + the tool_result error we couldn't suppress, and
+  // it's much clearer to repeat the Q/A inline than to rely on the model
+  // recovering the context.
+  const lines: string[] = [
+    "Here are my answers to the questions you just asked:",
+    "",
+  ];
+  for (let i = 0; i < questions.length; i += 1) {
+    const question = questions[i]?.question ?? `Question ${i + 1}`;
+    const answer = answers[i] ?? "";
+    const prefix = questions.length > 1 ? `Q${i + 1}: ` : "Q: ";
+    lines.push(`${prefix}${question}`);
+    lines.push(`A: ${answer}`);
+    lines.push("");
+  }
+  lines.push(
+    "Use these answers to continue. Don't call AskUserQuestion again for the same items unless something is genuinely ambiguous after re-reading my answers."
+  );
+  return lines.join("\n").trimEnd();
+}
+
 async function runClaudeCommand(
   args: string[],
   cwd: string,
@@ -310,10 +463,13 @@ export async function sendMessage(
       const forcedPermissionMode = resolveClaudePermissionMode(agent);
 
       const parts = buildPromptParts(channelId, message, { ...options, agent }, context);
-      const prompt = buildPromptText(parts);
+      const initialPrompt = buildPromptText(parts);
       const systemPrompt = buildSystemPrompt(context?.slack);
 
-      const isNewSession = newSessions.has(sessionId);
+      let isNewSession = newSessions.has(sessionId);
+      let currentSessionId = sessionId;
+      let prompt = initialPrompt;
+
       if (isNewSession) {
         const fallbackTitle = deriveSessionTitleFromPrompt(message);
         if (fallbackTitle) {
@@ -328,71 +484,191 @@ export async function sendMessage(
           });
         }
       }
-      const args = buildClaudeCommandArgs({
-        sessionId,
-        isNewSession,
-        systemPrompt,
-        workingPath,
-        prompt,
-      });
 
-      const envOverrides = runtime.getSessionEnvironment(sessionId);
-      const { output, permissionMode, command } = await runClaudeWithFallback(
-        args,
-        workingPath,
-        envOverrides,
-        entry,
-        forcedPermissionMode,
-        (record) => {
-          publishClaudeRecordAsSessionEvents(record, sessionId);
-        }
-      );
+      for (let round = 0; round < MAX_ASK_USER_QUESTION_ROUNDS; round += 1) {
+        const args = buildClaudeCommandArgs({
+          sessionId: currentSessionId,
+          isNewSession,
+          systemPrompt,
+          workingPath,
+          prompt,
+        });
 
-      log.info("Claude CLI response received", { sessionId, permissionMode, command });
-
-      let parsed: { result?: string; is_error?: boolean; error?: string; session_id?: string } | null = null;
-      try {
-        parsed = parseClaudeResult(output);
-      } catch (err) {
-        throw new Error(
-          `Failed to parse Claude output: ${err instanceof Error ? err.message : String(err)}`
+        const envOverrides = runtime.getSessionEnvironment(currentSessionId);
+        const { output, permissionMode, command } = await runClaudeWithFallback(
+          args,
+          workingPath,
+          envOverrides,
+          entry,
+          forcedPermissionMode,
+          (record) => {
+            publishClaudeRecordAsSessionEvents(record, currentSessionId);
+          }
         );
+
+        log.info("Claude CLI response received", {
+          sessionId: currentSessionId,
+          permissionMode,
+          command,
+          round,
+        });
+
+        let parsed: { result?: string; is_error?: boolean; error?: string; session_id?: string } | null = null;
+        let parseError: Error | null = null;
+        try {
+          parsed = parseClaudeResult(output);
+        } catch (err) {
+          parseError = err instanceof Error ? err : new Error(String(err));
+        }
+
+        const responseSessionId = parsed?.session_id;
+        if (responseSessionId && responseSessionId !== currentSessionId && context?.slack?.threadId) {
+          runtime.setSessionEnvironment(responseSessionId, envOverrides);
+          setThreadSessionId(channelId, context.slack.threadId, responseSessionId);
+          currentSessionId = responseSessionId;
+        }
+
+        if (parsed?.is_error) {
+          throw new Error(parsed.error || "Claude returned an error");
+        }
+
+        const text = parsed?.result?.trim() ?? "";
+        if (text) {
+          newSessions.delete(sessionId);
+          newSessions.delete(currentSessionId);
+          return [{ text, messageType: "assistant" }];
+        }
+
+        // No usable final result. Before giving up with "empty response",
+        // see if the model parked the turn on AskUserQuestion. When it did
+        // we want to surface the question to the user (via the same
+        // question.asked event the kernel already wires for OpenCode) and
+        // resume the Claude CLI with the user's answer instead of failing
+        // the whole turn.
+        const askUser = extractAskUserQuestionToolUse(output);
+        if (!askUser) {
+          if (parseError) {
+            throw new Error(`Failed to parse Claude output: ${parseError.message}`);
+          }
+          throw new Error("Claude returned empty response");
+        }
+
+        const requestId = askUser.toolUseId && askUser.toolUseId.length > 0
+          ? askUser.toolUseId
+          : `claude-q-${randomUUID()}`;
+
+        const deferred = createDeferred<
+          { status: "answered"; answers: string[] } | { status: "cancelled"; reason?: string }
+        >();
+        pendingQuestions.set(currentSessionId, {
+          requestId,
+          questionCount: askUser.questions.length,
+          deferred,
+        });
+
+        runtime.publishSessionEvent(currentSessionId, {
+          type: "question.asked",
+          properties: {
+            id: requestId,
+            sessionID: currentSessionId,
+            questions: askUser.questions,
+          },
+        });
+
+        let outcome: { status: "answered"; answers: string[] } | { status: "cancelled"; reason?: string };
+        try {
+          outcome = await deferred.promise;
+        } finally {
+          const stored = pendingQuestions.get(currentSessionId);
+          if (stored && stored.requestId === requestId) {
+            pendingQuestions.delete(currentSessionId);
+          }
+        }
+
+        if (outcome.status === "cancelled") {
+          throw new Error(outcome.reason ?? "Claude question cancelled");
+        }
+
+        prompt = formatAskUserQuestionAnswers(askUser.questions, outcome.answers);
+        isNewSession = false;
       }
 
-      if (parsed?.is_error) {
-        throw new Error(parsed.error || "Claude returned an error");
-      }
-
-      const responseSessionId = parsed?.session_id;
-      if (responseSessionId && responseSessionId !== sessionId && context?.slack?.threadId) {
-        runtime.setSessionEnvironment(responseSessionId, envOverrides);
-        setThreadSessionId(channelId, context.slack.threadId, responseSessionId);
-      }
-
-      newSessions.delete(sessionId);
-      if (responseSessionId) {
-        newSessions.delete(responseSessionId);
-      }
-
-      const text = parsed?.result?.trim() ?? "";
-      if (!text) {
-        throw new Error("Claude returned empty response");
-      }
-
-      return [{ text, messageType: "assistant" }];
+      throw new Error(
+        `Claude AskUserQuestion loop exceeded ${MAX_ASK_USER_QUESTION_ROUNDS} rounds without a final response`
+      );
     });
   } finally {
     runtime.endRequest(sessionKey);
   }
 }
 
+/**
+ * Resolve a pending AskUserQuestion request with the user's answers. The
+ * adapter routes Claude question replies here when the kernel collects all
+ * answers for a previously-published `question.asked` event.
+ *
+ * `answers` is a parallel array to the questions originally asked. When the
+ * kernel collected one user reply per question (the normal multi-question
+ * flow), each entry is a single trimmed string. We accept the
+ * `Array<Array<string>>` shape that the OpenCode `question.reply` API uses
+ * and flatten it down to one string per question.
+ */
+export async function replyToQuestion(params: {
+  sessionId: string;
+  requestId: string;
+  answers: Array<Array<string>>;
+}): Promise<void> {
+  const pending = pendingQuestions.get(params.sessionId);
+  if (!pending) {
+    throw new Error(`No pending Claude question for session ${params.sessionId}`);
+  }
+  if (pending.requestId !== params.requestId) {
+    throw new Error(
+      `Claude question requestId mismatch (expected ${pending.requestId}, got ${params.requestId})`
+    );
+  }
+
+  const flattened: string[] = [];
+  for (let i = 0; i < pending.questionCount; i += 1) {
+    const entry = params.answers[i];
+    if (Array.isArray(entry) && entry.length > 0) {
+      const joined = entry
+        .map((value) => (typeof value === "string" ? value.trim() : String(value ?? "").trim()))
+        .filter((value) => value.length > 0)
+        .join(", ");
+      flattened.push(joined);
+    } else {
+      flattened.push("");
+    }
+  }
+  pending.deferred.resolve({ status: "answered", answers: flattened });
+}
+
+/**
+ * Cancel any pending AskUserQuestion for this session, unblocking
+ * `sendMessage` so the caller's `withSessionLock` can release. Used by stop
+ * commands and abort paths.
+ */
+function cancelPendingQuestion(sessionId: string, reason?: string): void {
+  const pending = pendingQuestions.get(sessionId);
+  if (!pending) return;
+  pendingQuestions.delete(sessionId);
+  pending.deferred.resolve({ status: "cancelled", reason });
+}
+
 export const ensureSession = runtime.ensureSession.bind(runtime);
 
 export const subscribeToSession = runtime.subscribeToSession.bind(runtime);
 
-export const abortSession = runtime.abortSession.bind(runtime);
+export async function abortSession(sessionId: string, _directory?: string): Promise<void> {
+  cancelPendingQuestion(sessionId, "Claude session aborted");
+  await runtime.abortSession(sessionId);
+}
 
-export const cancelActiveRequest = runtime.cancelActiveRequest.bind(runtime);
+export async function cancelActiveRequest(channelId: string, sessionId: string): Promise<boolean> {
+  cancelPendingQuestion(sessionId, "Claude request cancelled");
+  return runtime.cancelActiveRequest(channelId, sessionId);
+}
 
 export const stopServer = runtime.stopServer.bind(runtime);
 export const startServer = noopStartServer;

--- a/packages/agents/claude/index.ts
+++ b/packages/agents/claude/index.ts
@@ -8,5 +8,10 @@ export {
   subscribeToSession,
   startServer,
   stopServer,
+  replyToQuestion,
+  extractAskUserQuestionToolUse,
   type SessionEnvironment,
+  type ClaudeAskUserQuestion,
+  type ClaudeAskUserQuestionOption,
+  type ClaudeAskUserQuestionToolUse,
 } from "./client";

--- a/packages/agents/test/claude-ask-user-question.test.ts
+++ b/packages/agents/test/claude-ask-user-question.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "bun:test";
+import { extractAskUserQuestionToolUse } from "../claude/client";
+import { createAgentAdapter } from "../adapter";
+
+const ASSISTANT_WITH_ASK = JSON.stringify({
+  type: "assistant",
+  message: {
+    content: [
+      {
+        type: "tool_use",
+        id: "toolu_test_123",
+        name: "AskUserQuestion",
+        input: {
+          questions: [
+            {
+              question: "How should I access prod DB?",
+              header: "Prod access",
+              multiSelect: false,
+              options: [
+                { label: "Run railway login", description: "Re-auth Railway CLI" },
+                { label: "Give me PROD_DATABASE_URL", description: "Paste connection string" },
+                { label: "I'll run SQL myself", description: "Send me SQL" },
+              ],
+            },
+            {
+              question: "How do I filter test users?",
+              header: "Filter rules",
+              multiSelect: true,
+              options: [
+                { label: "Strip example.com / test", description: "Common placeholders" },
+                { label: "Only example.com", description: "Just that domain" },
+                { label: "Pull all, I'll filter", description: "" },
+              ],
+            },
+          ],
+        },
+      },
+    ],
+  },
+});
+
+const STREAM_WITH_ASK = [
+  JSON.stringify({ type: "system", subtype: "init", session_id: "abc" }),
+  JSON.stringify({
+    type: "stream_event",
+    event: { type: "content_block_start", index: 0, content_block: { type: "text" } },
+  }),
+  ASSISTANT_WITH_ASK,
+  JSON.stringify({
+    type: "user",
+    message: {
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "toolu_test_123",
+          is_error: true,
+          content: "Answer questions?",
+        },
+      ],
+    },
+  }),
+].join("\n");
+
+describe("extractAskUserQuestionToolUse", () => {
+  it("returns null when no AskUserQuestion tool_use is present", () => {
+    const out = [
+      JSON.stringify({ type: "assistant", message: { content: [{ type: "text", text: "hi" }] } }),
+      JSON.stringify({ type: "result", subtype: "success", result: "hi", session_id: "abc" }),
+    ].join("\n");
+    expect(extractAskUserQuestionToolUse(out)).toBeNull();
+  });
+
+  it("ignores Bash and other tools", () => {
+    const out = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [
+          { type: "tool_use", id: "t1", name: "Bash", input: { command: "ls" } },
+        ],
+      },
+    });
+    expect(extractAskUserQuestionToolUse(out)).toBeNull();
+  });
+
+  it("extracts the AskUserQuestion payload from a fully assembled assistant record", () => {
+    const result = extractAskUserQuestionToolUse(STREAM_WITH_ASK);
+    expect(result).not.toBeNull();
+    expect(result?.toolUseId).toBe("toolu_test_123");
+    expect(result?.questions.length).toBe(2);
+    const [q1, q2] = result!.questions;
+    expect(q1?.question).toBe("How should I access prod DB?");
+    expect(q1?.header).toBe("Prod access");
+    expect(q1?.multiSelect).toBe(false);
+    expect(q1?.options?.map((o) => o.label)).toEqual([
+      "Run railway login",
+      "Give me PROD_DATABASE_URL",
+      "I'll run SQL myself",
+    ]);
+    expect(q2?.multiSelect).toBe(true);
+    expect(q2?.options?.[2]?.description).toBeUndefined();
+  });
+
+  it("returns the LAST AskUserQuestion when the model loops", () => {
+    const first = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_first",
+            name: "AskUserQuestion",
+            input: { questions: [{ question: "Old?", options: [{ label: "x" }] }] },
+          },
+        ],
+      },
+    });
+    const second = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_second",
+            name: "AskUserQuestion",
+            input: { questions: [{ question: "New?", options: [{ label: "y" }] }] },
+          },
+        ],
+      },
+    });
+    const result = extractAskUserQuestionToolUse([first, second].join("\n"));
+    expect(result?.toolUseId).toBe("toolu_second");
+    expect(result?.questions[0]?.question).toBe("New?");
+  });
+
+  it("ignores AskUserQuestion tool_use blocks with empty / malformed questions arrays", () => {
+    const out = JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [
+          { type: "tool_use", id: "t", name: "AskUserQuestion", input: { questions: [] } },
+          { type: "tool_use", id: "t2", name: "AskUserQuestion", input: { questions: [{}] } },
+        ],
+      },
+    });
+    expect(extractAskUserQuestionToolUse(out)).toBeNull();
+  });
+});
+
+describe("createAgentAdapter().normalizeQuestions for Claude shape", () => {
+  it("normalizes Claude AskUserQuestion entries (multiSelect, label, description) to NormalizedQuestion", () => {
+    const adapter = createAgentAdapter();
+    const claudeQuestions = [
+      {
+        question: "Pick env",
+        header: "env",
+        multiSelect: false,
+        options: [
+          { label: "prod", description: "production" },
+          { label: "staging", description: "" },
+        ],
+      },
+      {
+        question: "Allow tools",
+        multiSelect: true,
+        options: [{ label: "Bash" }, { label: "Read" }],
+      },
+    ];
+    const normalized = adapter.normalizeQuestions(claudeQuestions);
+    expect(normalized.length).toBe(2);
+    expect(normalized[0]?.question).toBe("Pick env");
+    expect(normalized[0]?.options).toEqual(["prod", "staging"]);
+    expect(normalized[0]?.multiple).toBe(false);
+    expect(normalized[1]?.multiple).toBe(true);
+    expect(normalized[1]?.options).toEqual(["Bash", "Read"]);
+  });
+
+  it("still normalizes OpenCode-style QuestionInfo entries (multiple/options[].label)", () => {
+    const adapter = createAgentAdapter();
+    const openCodeQuestions = [
+      {
+        question: "Choose model",
+        multiple: false,
+        custom: true,
+        options: [{ label: "claude" }, { label: "codex" }],
+      },
+    ];
+    const normalized = adapter.normalizeQuestions(openCodeQuestions);
+    expect(normalized.length).toBe(1);
+    expect(normalized[0]?.question).toBe("Choose model");
+    expect(normalized[0]?.options).toEqual(["claude", "codex"]);
+    expect(normalized[0]?.multiple).toBe(false);
+    expect(normalized[0]?.custom).toBe(true);
+  });
+
+  it("drops questions whose prompt text is empty", () => {
+    const adapter = createAgentAdapter();
+    const normalized = adapter.normalizeQuestions([
+      { question: "  ", options: [{ label: "x" }] },
+      { question: "ok?", options: [{ label: "y" }] },
+    ]);
+    expect(normalized.length).toBe(1);
+    expect(normalized[0]?.question).toBe("ok?");
+  });
+});

--- a/packages/agents/test/claude-ask-user-question.test.ts
+++ b/packages/agents/test/claude-ask-user-question.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { extractAskUserQuestionToolUse } from "../claude/client";
+import { extractAskUserQuestionToolUse, replyToQuestion } from "../claude/client";
 import { createAgentAdapter } from "../adapter";
 
 const ASSISTANT_WITH_ASK = JSON.stringify({
@@ -200,5 +200,17 @@ describe("createAgentAdapter().normalizeQuestions for Claude shape", () => {
     ]);
     expect(normalized.length).toBe(1);
     expect(normalized[0]?.question).toBe("ok?");
+  });
+});
+
+describe("Claude replyToQuestion guards", () => {
+  it("rejects when no AskUserQuestion is pending for the session", async () => {
+    await expect(
+      replyToQuestion({
+        sessionId: "session-with-no-pending-question",
+        requestId: "toolu_does_not_exist",
+        answers: [["whatever"]],
+      })
+    ).rejects.toThrow(/No pending Claude question/);
   });
 });


### PR DESCRIPTION
## Summary

When Claude Code calls the \`AskUserQuestion\` tool in \`--print\` mode, stdin isn't connected so the tool immediately gets back a \`tool_result(is_error: true, content: \"Answer questions?\")\`. The turn frequently ends without ever emitting a \`type:\"result\"\` record, so the old client treated it as \"Claude returned empty response\" and the runtime surfaced the unhelpful _\"No response received / The model didn't generate a response\"_ message. The user could never actually answer the question, even though Claude was asking one.

This wires Claude into the same \`question.asked\` / \`replyToQuestion\` plumbing the kernel already drives for OpenCode, so AskUserQuestion now renders as a normal Slack question with buttons.

## What changed

- \`packages/agents/claude/client.ts\`
  - New \`extractAskUserQuestionToolUse(output)\` walks the recorded stream-json output and pulls the *last* fully-assembled \`assistant\` record's \`AskUserQuestion\` \`tool_use\` block. We use only the assembled \`assistant\` records (not partial \`stream_event\` deltas) so we always parse a coherent input.
  - \`sendMessage\` is now a small loop. When \`parseClaudeResult\` returns no usable \`result\` text, we check for an AskUserQuestion. If we find one we publish a \`question.asked\` session event with the Claude-shaped \`{ question, header, multiSelect, options[] }\` payload, park on a \`Deferred\`, and resume Claude with a synthesized follow-up prompt that restates the Q/A pairs as soon as the user replies.
  - Loops are capped at \`MAX_ASK_USER_QUESTION_ROUNDS\` (8) so a buggy prompt loop can't hold a Slack thread hostage.
  - \`abortSession\` and \`cancelActiveRequest\` now resolve any pending Deferred with \`{ status: 'cancelled' }\` so the stop command unblocks an in-flight question loop.
  - Exposes \`replyToQuestion({ sessionId, requestId, answers })\` for the adapter to call.
- \`packages/agents/claude/index.ts\`
  - Re-exports \`replyToQuestion\` and the new \`ClaudeAskUserQuestion*\` types.
- \`packages/agents/adapter.ts\`
  - \`replyToQuestion\` now dispatches to the claudecode provider when the session is owned by Claude (still rejects everything else).
  - \`normalizeQuestions\` accepts both shapes:
    - OpenCode shape: \`{ question, options:[{label}], multiple, custom }\`
    - Claude shape: \`{ question, header, multiSelect, options:[{label, description}] }\`
- \`packages/agents/test/claude-ask-user-question.test.ts\` (new)
  - Parser: ignores Bash/other tool calls, returns the **last** AskUserQuestion when the model loops, drops empty/malformed payloads.
  - Adapter normalizer: round-trips both Claude and OpenCode shapes; drops empty prompts.

## Why this design

- Claude \`--print\` cannot pause a turn for stdin input, so the only way to actually let the user answer is to *resume* the session with a follow-up user message. The Deferred-based pause inside \`sendMessage\` keeps the kernel side identical to OpenCode (single in-flight prompt promise that resolves when the turn fully ends, including any question round-trips).
- The follow-up prompt explicitly restates the Q/A inline because, on \`--resume\`, Claude only sees the prior \`tool_use\` plus the auto-injected \`tool_result(is_error)\`. Restating gives it a clean recovery point and discourages it from immediately calling AskUserQuestion again for the same items.
- We dispatch by provider id in the adapter rather than abstracting a new agent capability so this stays a Claude-local change; OpenCode keeps its existing \`question.reply\` API path unchanged.

## Testing

- \`bun test packages/agents/test/claude-ask-user-question.test.ts\` – 8/8 pass
- \`bun test packages/agents\` – 91/91 pass
- \`bun test\` – 380/380 pass (1 skip)
- \`bun run typecheck\` – clean (the pre-existing web-ui shadcn/clsx \"cannot find module\" warnings are unrelated)

## Manual verification path

1. In a Slack channel using Claude Code, ask something ambiguous enough that Claude wants to call AskUserQuestion (e.g. _\"clean up the test users in prod\"_).
2. Previously: thread eventually fails with _\"Error: No response received\"_.
3. With this PR: Claude's question is posted as a regular Slack question (with buttons when each option label fits in 75 chars and there are 2-5 options). Picking an option (or typing a free-form reply) resumes the same Claude session with the answer; subsequent text/tool output streams as usual.

## Notes / follow-ups

- The kernel already records the question in \`agent_question\` and the reply in \`question_reply\` for the inbox, so this works end-to-end with no kernel changes.
- We still rely on Claude not infinitely re-asking the same question after we replied; \`MAX_ASK_USER_QUESTION_ROUNDS\` is the backstop. If we ever see real users hit this cap I'd lean toward shortening the cap and adding a "Claude kept asking the same thing" final error, but no signal of that yet.