### PR TITLE
fix(claude): retry once on upstream 5xx and session-id race

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ode",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "description": "Coding anywhere with your coding agents connected",
   "module": "packages/core/index.ts",
   "type": "module",

--- a/packages/agents/claude/client.ts
+++ b/packages/agents/claude/client.ts
@@ -175,6 +175,42 @@ function resolveClaudePermissionMode(agent?: string): string | undefined {
   return undefined;
 }
 
+/**
+ * Detects transient failure modes where retrying the same Claude CLI
+ * invocation has a good chance of succeeding:
+ *
+ *   - Anthropic / proxy upstream 5xx ("API Error: 5xx", Cloudflare 524, etc.).
+ *     The `claude` CLI surfaces these in the stdout `result` text and exits 1
+ *     with empty stderr.
+ *   - "Session ID … is already in use" emitted on stderr when an earlier
+ *     subprocess for the same session hadn't fully released the session lock.
+ *
+ * Errors are matched by message text because that's all we have once
+ * runCliJsonCommand normalises everything into Error.message.
+ */
+export function isTransientClaudeError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  if (!message) return false;
+  const lower = message.toLowerCase();
+
+  // Anthropic / Cloudflare upstream 5xx-style transient errors.
+  if (/api error:\s*5\d\d/i.test(message)) return true;
+  if (lower.includes("origin_response_timeout")) return true;
+  if (lower.includes('"retryable":true')) return true;
+  if (lower.includes("cloudflare_error")) return true;
+
+  // claude CLI's "session in use" race when we replace an in-flight request.
+  if (lower.includes("session id") && lower.includes("already in use")) return true;
+
+  return false;
+}
+
+const TRANSIENT_RETRY_DELAY_MS = 3000;
+
+async function delay(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 function getRecordSessionId(record: ClaudeJsonRecord, fallbackSessionId: string): string {
   return typeof record.session_id === "string" ? record.session_id : fallbackSessionId;
 }
@@ -518,26 +554,58 @@ export async function sendMessage(
         }
       }
 
-      for (let round = 0; round < MAX_ASK_USER_QUESTION_ROUNDS; round += 1) {
-        const args = buildClaudeCommandArgs({
-          sessionId: runtimeSessionId,
-          isNewSession,
-          systemPrompt,
-          workingPath,
-          prompt,
-        });
+      const envOverrides = runtime.getSessionEnvironment(runtimeSessionId);
 
-        const envOverrides = runtime.getSessionEnvironment(runtimeSessionId);
-        const { output, permissionMode, command } = await runClaudeWithFallback(
-          args,
-          workingPath,
-          envOverrides,
-          entry,
-          forcedPermissionMode,
-          (record) => {
-            publishClaudeRecordAsSessionEvents(record, subscriptionSessionId, runtimeSessionId);
-          }
-        );
+      for (let round = 0; round < MAX_ASK_USER_QUESTION_ROUNDS; round += 1) {
+        // One CLI turn, with a single transient-error retry. We retry the
+        // whole CLI invocation when the underlying failure looks like an
+        // Anthropic / proxy upstream 5xx (524 with origin_response_timeout,
+        // generic API Error: 5xx) or the "session id is already in use"
+        // race that fires when a previous subprocess hadn't released its
+        // session lock yet. See isTransientClaudeError for the exact set.
+        //
+        // The retry always switches to --resume even if the first attempt
+        // was a brand-new session: if the upstream accepted the session
+        // registration before timing out, reusing --session-id would itself
+        // hit "already in use" on the retry.
+        const runOnce = async (
+          attemptIsNewSession: boolean
+        ): Promise<{ output: string; permissionMode: string; command: string }> => {
+          const attemptArgs = buildClaudeCommandArgs({
+            sessionId: runtimeSessionId,
+            isNewSession: attemptIsNewSession,
+            systemPrompt,
+            workingPath,
+            prompt,
+          });
+          return await runClaudeWithFallback(
+            attemptArgs,
+            workingPath,
+            envOverrides,
+            entry,
+            forcedPermissionMode,
+            (record) => {
+              publishClaudeRecordAsSessionEvents(record, subscriptionSessionId, runtimeSessionId);
+            }
+          );
+        };
+
+        let output: string;
+        let permissionMode: string;
+        let command: string;
+        try {
+          ({ output, permissionMode, command } = await runOnce(isNewSession));
+        } catch (err) {
+          if (!isTransientClaudeError(err)) throw err;
+          log.warn("Retrying Claude CLI after transient error", {
+            sessionId: subscriptionSessionId,
+            runtimeSessionId,
+            error: err instanceof Error ? err.message : String(err),
+            retryDelayMs: TRANSIENT_RETRY_DELAY_MS,
+          });
+          await delay(TRANSIENT_RETRY_DELAY_MS);
+          ({ output, permissionMode, command } = await runOnce(false));
+        }
 
         log.info("Claude CLI response received", {
           subscriptionSessionId,
@@ -563,7 +631,10 @@ export async function sendMessage(
         }
 
         if (parsed?.is_error) {
-          throw new Error(parsed.error || "Claude returned an error");
+          // Surface the upstream error text so isTransientClaudeError (and
+          // categorizeRuntimeError downstream) can recognise 5xx / 524 even
+          // when claude reports the failure in-band via stream-json.
+          throw new Error(parsed.error || parsed.result || "Claude returned an error");
         }
 
         const text = parsed?.result?.trim() ?? "";

--- a/packages/agents/runtime/base.ts
+++ b/packages/agents/runtime/base.ts
@@ -70,6 +70,54 @@ async function waitForPreviousProcessClose(
   });
 }
 
+/**
+ * When a CLI exits non-zero but writes its real error to stdout (as the
+ * `claude` CLI does for upstream 5xx — `code=1`, stderr empty, the
+ * `API Error: 524 …` payload buried in the last stream-json `type:"result"`
+ * line), we still need to surface that text so downstream transient-error
+ * matching can recognise it. This pulls the most useful message out of the
+ * captured stdout in a provider-agnostic way.
+ */
+export function extractErrorFromStdout(stdout: string): string | undefined {
+  if (!stdout) return undefined;
+
+  const lines = stdout.split("\n");
+  // Scan from the end: the terminating record (e.g. `type:"result"`) is
+  // emitted last and carries the most reliable error payload.
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const line = lines[i]?.trim();
+    if (!line || !line.startsWith("{")) continue;
+    try {
+      const parsed = JSON.parse(line) as {
+        is_error?: boolean;
+        error?: unknown;
+        result?: unknown;
+      };
+      if (parsed.is_error === true || typeof parsed.error === "string") {
+        if (typeof parsed.error === "string" && parsed.error.trim().length > 0) {
+          return parsed.error.trim();
+        }
+        if (typeof parsed.result === "string" && parsed.result.trim().length > 0) {
+          return parsed.result.trim();
+        }
+        // Last resort: return the raw record so isTransientClaudeError can
+        // still pattern-match on its body (e.g. `cloudflare_error`).
+        return line;
+      }
+    } catch {
+      // Not a JSON line; keep scanning.
+    }
+  }
+
+  // No structured error found; fall back to the last non-empty line of stdout
+  // (avoids returning multi-MB blobs).
+  for (let i = lines.length - 1; i >= 0; i -= 1) {
+    const line = lines[i]?.trim();
+    if (line) return line.length > 500 ? `${line.slice(0, 500)}…` : line;
+  }
+  return undefined;
+}
+
 export async function runCliJsonCommand<TRecord>(params: RunCliJsonCommandParams<TRecord>): Promise<string> {
   const {
     providerName,
@@ -176,7 +224,18 @@ export async function runCliJsonCommand<TRecord>(params: RunCliJsonCommandParams
       log.info(`${providerName} CLI completed`, completionDetails);
 
       if (code !== 0) {
-        reject(new Error(stderr || `${providerName} CLI exited with code ${code}`));
+        // Prefer stderr (CLI's own diagnostics). If stderr is empty — which
+        // is the case for claude on Anthropic upstream 5xx — fall back to
+        // mining stdout for a structured error record so downstream code can
+        // recognise transient failures like API Error: 524 and retry.
+        const stdoutError = stderr ? undefined : extractErrorFromStdout(stdout);
+        reject(
+          new Error(
+            stderr ||
+              stdoutError ||
+              `${providerName} CLI exited with code ${code}`
+          )
+        );
         return;
       }
 

--- a/packages/agents/runtime/base.ts
+++ b/packages/agents/runtime/base.ts
@@ -8,6 +8,12 @@ type SessionHandler = (event: unknown) => void;
 type ActiveRequestEntry = {
   controller: AbortController;
   process?: ChildProcess;
+  /**
+   * If this entry replaced an in-flight request, the previous process is kept
+   * here so the next CLI invocation can wait for it to fully exit (and release
+   * any session-level lock) before spawning a replacement.
+   */
+  previousProcess?: ChildProcess;
 };
 
 type RunCliJsonCommandParams<TRecord> = {
@@ -24,6 +30,46 @@ type RunCliJsonCommandParams<TRecord> = {
   logRawOutput?: boolean;
 };
 
+/**
+ * How long to wait for a previously-spawned CLI subprocess to fully exit
+ * before spawning the next one for the same session. Several CLIs (notably
+ * `claude`) hold an in-flight session lock until the process actually exits,
+ * so spawning a replacement too eagerly produces "Session ID … is already in
+ * use".
+ */
+const PROCESS_CLOSE_TIMEOUT_MS = 2000;
+
+async function waitForPreviousProcessClose(
+  providerName: string,
+  entry: ActiveRequestEntry
+): Promise<void> {
+  const previous = entry.previousProcess;
+  if (!previous) return;
+  // Drop the reference unconditionally so we don't hold the previous process
+  // forever, even if it has already exited.
+  entry.previousProcess = undefined;
+  if (previous.exitCode !== null || previous.signalCode !== null) return;
+
+  await new Promise<void>((resolve) => {
+    let settled = false;
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve();
+    };
+    const timer = setTimeout(() => {
+      log.warn(`${providerName} previous process did not close in time`, {
+        pid: previous.pid,
+        timeoutMs: PROCESS_CLOSE_TIMEOUT_MS,
+      });
+      finish();
+    }, PROCESS_CLOSE_TIMEOUT_MS);
+    previous.once("close", finish);
+    previous.once("exit", finish);
+  });
+}
+
 export async function runCliJsonCommand<TRecord>(params: RunCliJsonCommandParams<TRecord>): Promise<string> {
   const {
     providerName,
@@ -38,6 +84,12 @@ export async function runCliJsonCommand<TRecord>(params: RunCliJsonCommandParams
     onExit,
     logRawOutput = false,
   } = params;
+
+  // If a previous child process for the same session was just SIGTERM'd, give
+  // it a brief window to actually exit (and release any server-side session
+  // lock) before we spawn the next one. Bounded by PROCESS_CLOSE_TIMEOUT_MS,
+  // so a stuck child can never block us indefinitely.
+  await waitForPreviousProcessClose(providerName, entry);
 
   return new Promise((resolve, reject) => {
     const child = spawn(binary, args, {
@@ -249,7 +301,10 @@ export class CliAgentRuntime extends BaseAgentRuntime {
       existingEntry.process?.kill("SIGTERM");
     }
 
-    const entry: ActiveRequestEntry = { controller: new AbortController() };
+    const entry: ActiveRequestEntry = {
+      controller: new AbortController(),
+      previousProcess: existingEntry?.process,
+    };
     this.activeRequests.set(sessionKey, entry);
     return entry;
   }

--- a/packages/agents/test/claude-transient-error.test.ts
+++ b/packages/agents/test/claude-transient-error.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "bun:test";
+import { isTransientClaudeError } from "../claude/client";
+
+describe("isTransientClaudeError", () => {
+  it("matches Cloudflare 524 origin timeouts", () => {
+    const message =
+      'API Error: 524 {"title":"Error 524: A timeout occurred","status":524,"error_name":"origin_response_timeout","cloudflare_error":true,"retryable":true}';
+    expect(isTransientClaudeError(new Error(message))).toBe(true);
+  });
+
+  it("matches generic Anthropic 5xx", () => {
+    expect(isTransientClaudeError(new Error("API Error: 503 service unavailable"))).toBe(true);
+    expect(isTransientClaudeError(new Error("API Error: 502 bad gateway"))).toBe(true);
+  });
+
+  it("matches the Claude CLI 'session already in use' race", () => {
+    const message =
+      "Error: Session ID a1c4b262-cb3d-4281-b1c0-6b0128dda381 is already in use.";
+    expect(isTransientClaudeError(new Error(message))).toBe(true);
+  });
+
+  it("does not match unrelated errors", () => {
+    expect(isTransientClaudeError(new Error("Claude returned empty response"))).toBe(false);
+    expect(isTransientClaudeError(new Error("API Error: 400 bad request"))).toBe(false);
+    expect(isTransientClaudeError(new Error("Permission denied"))).toBe(false);
+    expect(isTransientClaudeError(undefined)).toBe(false);
+    expect(isTransientClaudeError(null)).toBe(false);
+    expect(isTransientClaudeError("")).toBe(false);
+  });
+});

--- a/packages/agents/test/runtime-base.test.ts
+++ b/packages/agents/test/runtime-base.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+import { extractErrorFromStdout } from "../runtime/base";
+
+describe("extractErrorFromStdout", () => {
+  it("returns undefined for empty input", () => {
+    expect(extractErrorFromStdout("")).toBeUndefined();
+    expect(extractErrorFromStdout("   ")).toBeUndefined();
+  });
+
+  it("extracts the `error` field from the last result record", () => {
+    const stdout = [
+      '{"type":"system","subtype":"init","session_id":"s1"}',
+      '{"type":"stream_event","event":{"type":"message_start"}}',
+      '{"type":"result","is_error":true,"error":"API Error: 524 origin_response_timeout"}',
+    ].join("\n");
+    expect(extractErrorFromStdout(stdout)).toBe("API Error: 524 origin_response_timeout");
+  });
+
+  it("falls back to the `result` field when `error` is absent", () => {
+    const stdout = [
+      '{"type":"system","subtype":"init"}',
+      '{"type":"result","is_error":true,"result":"API Error: 524 timeout occurred"}',
+    ].join("\n");
+    expect(extractErrorFromStdout(stdout)).toBe("API Error: 524 timeout occurred");
+  });
+
+  it("returns the raw record body when only is_error:true is present", () => {
+    const stdout = '{"type":"result","is_error":true,"cloudflare_error":true}';
+    expect(extractErrorFromStdout(stdout)).toContain("cloudflare_error");
+  });
+
+  it("ignores non-JSON noise and prefers the latest structured error", () => {
+    const stdout = [
+      "warning: something printed by a shell wrapper",
+      '{"type":"result","is_error":false,"result":"earlier ok turn"}',
+      "bun: trace line",
+      '{"type":"result","is_error":true,"error":"API Error: 503"}',
+    ].join("\n");
+    expect(extractErrorFromStdout(stdout)).toBe("API Error: 503");
+  });
+
+  it("falls back to the last non-empty line when no structured error exists", () => {
+    const stdout = "hello\nworld\n   \n";
+    expect(extractErrorFromStdout(stdout)).toBe("world");
+  });
+
+  it("truncates very long fallback lines", () => {
+    const long = "x".repeat(2000);
+    const result = extractErrorFromStdout(long);
+    expect(result?.length).toBeLessThanOrEqual(501);
+    expect(result?.endsWith("…")).toBe(true);
+  });
+});

--- a/packages/core/runtime/helpers.ts
+++ b/packages/core/runtime/helpers.ts
@@ -26,6 +26,33 @@ export function categorizeRuntimeError(
 ): { message: string; suggestion: string } {
   const errorStr = err instanceof Error ? err.message : String(err);
 
+  // Check upstream / session errors BEFORE the generic "timeout" rule below,
+  // because 524 payloads also contain the word "timeout".
+
+  // Anthropic / proxy 5xx upstream timeouts. We retry once internally; if the
+  // retry also failed, surface a clearer message than "start a new thread".
+  if (
+    /API Error:\s*5\d\d/i.test(errorStr) ||
+    errorStr.includes("origin_response_timeout") ||
+    errorStr.includes("cloudflare_error") ||
+    (errorStr.includes("524") && errorStr.toLowerCase().includes("origin"))
+  ) {
+    return {
+      message: "Anthropic upstream timeout",
+      suggestion: "The model provider was slow to respond and we already retried once. Please try again in a minute.",
+    };
+  }
+
+  // Claude CLI's "Session ID … is already in use" race. We retry once
+  // internally as well; if it still failed the previous subprocess likely
+  // didn't release the lock in time.
+  if (/session id [^"]+ is already in use/i.test(errorStr)) {
+    return {
+      message: "Session is busy",
+      suggestion: "A previous request hasn't finished releasing this session. Wait a moment and try again.",
+    };
+  }
+
   if (errorStr.includes("timeout") || errorStr.includes("timed out") || errorStr.includes("ETIMEDOUT")) {
     return {
       message: "Request timed out",

--- a/packages/core/test/runtime-helpers.test.ts
+++ b/packages/core/test/runtime-helpers.test.ts
@@ -76,6 +76,29 @@ describe("runtime helpers", () => {
     expect(result.message).toBe("Request timed out");
   });
 
+  it("categorizes Anthropic upstream 5xx as upstream timeout", () => {
+    const result = categorizeRuntimeError(
+      new Error('API Error: 524 {"title":"Error 524: A timeout occurred","cloudflare_error":true}')
+    );
+    expect(result.message).toBe("Anthropic upstream timeout");
+    expect(result.suggestion).toContain("retried once");
+  });
+
+  it("categorizes origin_response_timeout as upstream timeout", () => {
+    const result = categorizeRuntimeError(
+      new Error('something happened with "error_name":"origin_response_timeout"')
+    );
+    expect(result.message).toBe("Anthropic upstream timeout");
+  });
+
+  it("categorizes 'Session ID already in use' as session busy", () => {
+    const result = categorizeRuntimeError(
+      new Error("Error: Session ID a1c4b262-cb3d-4281-b1c0-6b0128dda381 is already in use.")
+    );
+    expect(result.message).toBe("Session is busy");
+    expect(result.suggestion).toContain("Wait a moment");
+  });
+
   describe("hasSimpleOptions", () => {
     it("accepts 2-5 short options", () => {
       expect(hasSimpleOptions(["yes", "no"])).toBe(true);


### PR DESCRIPTION
## Summary

Two recent recurring Slack failures (`Error: Claude CLI exited with code 1` followed by "try starting a new thread") traced back to transient conditions the runtime wasn't recognising:

- *Anthropic / proxy upstream timeouts*: Cloudflare 524 (`origin_response_timeout`) on `ai-relay.chainbot.io`. The `claude` CLI exits 1 with empty stderr, dropping the real error into stdout's `result` payload.
- *Session-id race*: when a new request supersedes an in-flight one we SIGTERM the old child and spawn a new one for the same `--resume <sessionId>`. The old subprocess hadn't released the session lock yet, so the new one stderr'd `Session ID … is already in use.`

## Changes

- `packages/agents/runtime/base.ts`: track the previous `ChildProcess` on `ActiveRequestEntry`. `runCliJsonCommand` now awaits its `close`/`exit` (bounded at 2s) before spawning the replacement, fixing the session race at the source.
- `packages/agents/claude/client.ts`: new `isTransientClaudeError` (matches `API Error: 5xx`, `origin_response_timeout`, `cloudflare_error`, `retryable":true`, and "session in use"). The send loop now retries the whole Claude turn *once* after 3s. Retries always switch to `--resume` so a partially-registered new session can't trigger "already in use" on the retry.
- `packages/core/runtime/helpers.ts`: classify upstream timeouts and session-busy with accurate user-facing messages, placed *before* the generic timeout rule (524 payloads contain the word "timeout").
- Bump root version `0.1.36 → 0.1.37`.

## Tests

- New `packages/agents/test/claude-transient-error.test.ts` covers 524, generic 5xx, session-in-use, and non-matches.
- Extends `packages/core/test/runtime-helpers.test.ts` with upstream-timeout / origin_response_timeout / session-busy categorization.
- `bun test packages/agents/test packages/core/test`: *158 pass / 0 fail*.

## User-visible effect

- 524/5xx blip → invisible to the user (auto-retried). Persistent 5xx → Slack shows `Anthropic upstream timeout — already retried, try again in a minute` instead of the misleading "start a new thread" suggestion.
- Session race → mostly gone (we wait for old process close). If it still slips through → auto-retry, and on persistent failure surface `Session is busy — wait a moment`.