### PR TITLE
feat(slack): live status via chat.startStream/appendStream/stopStream

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ ODE is a project that connects many AI coding agents with IM message apps. When 
 - SDK/CLI event loops handle permission or question flows where supported; OpenCode and Claude question replies are wired through the adapter.
 - When capturing screenshots, save images to the system temp folder and upload them with `ode send file` to the current thread as soon as possible.
 - When merging PRs, do not delete the branch if the current worktree is on that branch.
+- Developer-only Web UI surfaces must be hidden from end users by default. The `/dev` page and Dev Tools navigation are only visible when the daemon is started with `ODE_DEV=1` (also accepts `true`, `yes`, or `on`); do not add a persistent Web UI setting for this.
 
 ## Supported Integrations
 - IM apps: Slack, Discord, Lark/Feishu.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,29 +1,54 @@
 # Ode - Agent Notes
 
-Ode is a Slack bot that bridges messages to OpenCode for AI-assisted coding.
+ODE is a project that connects many AI coding agents with IM message apps. When developing or validating end-to-end behavior, test the full flow from the IM app: send a real message in Slack, Discord, or Lark, let Ode receive it, route it to the selected coding agent, and verify the reply/status/file upload back in the same IM thread.
 
 ## Architecture
-- Entry: `src/index.ts`
-- Config: `src/config/` (Zod env validation)
-- Slack: `src/slack/` (Bolt app, commands, OAuth, formatting)
-- OpenCode: `src/agents/opencode/` (SDK client)
-- Storage: `src/storage/` (settings, sessions, active requests)
+- Runtime entry: `packages/core/index.ts`
+- CLI entry: `packages/core/cli.ts`
+- Config: `packages/config/` (Zod env/config validation, local `ode.json`, channel settings)
+- Core orchestration: `packages/core/` (daemon, kernel, runtime, tasks, cron, PR tracker, Web/API server)
+- IM adapters: `packages/ims/` (`slack`, `discord`, `lark`, shared inbound/delivery/runtime helpers)
+- Agent adapters: `packages/agents/` (`opencode`, `claude`, `codex`, `kimi`, `kiro`, `kilo`, `qwen`, `goose`, `gemini`)
+- Shared utilities: `packages/shared/` and `packages/utils/`
+- Web UI: `packages/web-ui/` (settings, sessions, local config views)
+- Live status harness: `packages/live-status-harness/`
 
 ## Runtime behavior
-- SDK event loop handles permission auto-approval
-- Per-channel agents stored in `~/.config/ode/agents/{channelId}.md`
-- Settings: `~/.config/ode/settings.json`
-- Sessions: `~/.config/ode/sessions/`
-- Bot replies in threads once mentioned
-- Status updates include phases, tool progress, and elapsed time
-- Status messages are preserved as an operation record
-- When capturing screenshots, save images to the system temp folder and upload them with `ode send file` to the current thread as soon as possible
-- When merging PRs, do not delete the branch if the current worktree is on that branch
+- Ode runs as a local daemon with a settings UI, starts configured IM runtimes, and watches config changes.
+- Local config lives at `~/.config/ode/ode.json`.
+- SQLite state lives at `~/.config/ode/inbox.db` for tasks, cron jobs, PR trackers, and related scheduler data.
+- Sessions live under `~/.config/ode/sessions/`.
+- Channel details include agent provider, model when supported, working directory, base branch, and system message.
+- Bot replies and status updates should stay in the originating IM thread.
+- Status updates include phases, tool progress, elapsed time, and are preserved as an operation record.
+- SDK/CLI event loops handle permission or question flows where supported; OpenCode and Claude question replies are wired through the adapter.
+- When capturing screenshots, save images to the system temp folder and upload them with `ode send file` to the current thread as soon as possible.
+- When merging PRs, do not delete the branch if the current worktree is on that branch.
+
+## Supported Integrations
+- IM apps: Slack, Discord, Lark/Feishu.
+- Agent providers: `opencode`, `claude`/`claudecode`, `codex`, `kimi`, `kiro`, `kilo`, `qwen`, `goose`, `gemini`.
+- Model selection is currently provider-specific; OpenCode, Codex, and Kilo have configured model lists.
 
 ## Commands
-- Dev: `bun run dev`
-- Prod: `./start.sh`
-- User: `@ode <message>` and `stop`
+- Install deps: `bun run setup`
+- Dev runtime: `bun run dev`
+- Dev runtime + Web UI dev server: `bun run web:dev`
+- Prod/local start from repo: `bun run start`
+- Installed CLI start: `ode` or `ode start`
+- Foreground CLI start: `ode --foreground`
+- Status/logs: `ode status`, `ode log [--info|--error] [--tail [N]]`
+- Restart/stop: `ode restart`, `ode stop`
+- Onboarding/config: `ode onboard`, `ode onboarding`, `ode config`
+- Build embedded Web UI: `bun run build:web`
+- Typecheck: `bun run typecheck`
+- Tests: `bun test`
+
+## IM Usage
+- Users talk to Ode from an IM app, usually by mentioning the bot in a channel/thread.
+- Slack supports `/setting` style configuration from the bot interaction surface.
+- Discord and Lark should follow the same normalized inbound/outbound thread semantics through `packages/ims/shared/`.
+- For end-to-end QA, prefer a real configured workspace/channel over direct adapter calls; direct unit tests are useful but do not prove the IM flow.
 
 ## One-time Tasks (`ode task`)
 - A Task is a one-shot scheduled prompt: the scheduler fires it exactly once at an absolute time, then posts the agent result back to the channel (or thread, if anchored).
@@ -32,9 +57,9 @@ Ode is a Slack bot that bridges messages to OpenCode for AI-assisted coding.
   - `ode task list [--status pending|running|success|failed|cancelled] [--json]`
   - `ode task show <id>` / `ode task cancel <id>` / `ode task delete <id>` / `ode task run <id>`
 - When `--thread` is set, the scheduler reuses the existing thread's session so the agent wakes up with full context. When `--thread` is omitted, the task posts as a new channel message under a synthetic thread (`task:{id}`).
-- Agents should prefer scheduling a Task instead of blocking on long waits (deploys, overnight builds, approvals): schedule the follow-up and return.
+- Agents should prefer scheduling a Task instead of blocking on long waits such as deploys, overnight builds, or approvals.
 - Persistence: SQLite at `~/.config/ode/inbox.db` (table `tasks`); scheduler polls every 10s and uses `UPDATE ... WHERE status='pending'` for cross-process idempotency.
-- HTTP API mirrors the CLI under `/api/tasks*`; the Web UI lives at Settings → Tasks.
+- HTTP API mirrors the CLI under `/api/tasks*`; the Web UI lives at Settings -> Tasks.
 
 ## Recurring Cron Jobs (`ode cron`)
 - A cron job is a recurring scheduled prompt (5-field cron expression) that re-runs the same prompt as a fresh agent turn on schedule.
@@ -45,16 +70,29 @@ Ode is a Slack bot that bridges messages to OpenCode for AI-assisted coding.
   - `ode cron enable <id>` / `ode cron disable <id>` / `ode cron run <id>` / `ode cron delete <id>`
 - Every run creates a fresh session + worktree (see `packages/core/cron/scheduler.ts`) so jobs start clean.
 - Persistence: same `~/.config/ode/inbox.db` (table `cron_jobs`); scheduler polls every 15s and claims runs at the SQL level.
-- HTTP API mirrors the CLI under `/api/cron-jobs*`; the Web UI lives at Settings → Cron.
+- HTTP API mirrors the CLI under `/api/cron-jobs*`; the Web UI lives at Settings -> Cron.
+
+## PR Trackers (`ode pr-tracker`)
+- PR trackers watch GitHub PR activity for repos discovered from configured channel working directories.
+- CLI:
+  - `ode pr-tracker scan [--json]`
+  - `ode pr-tracker list [--enabled | --disabled | --missing] [--json]`
+  - `ode pr-tracker show <id> [--json]`
+  - `ode pr-tracker enable <id>` / `ode pr-tracker disable <id>`
+  - `ode pr-tracker update <id> [--prompt <text>] [--prompt-file <path>] [--interval <seconds>] [--token <token>]`
+  - `ode pr-tracker run <id>` / `ode pr-tracker delete <id>`
+  - `ode pr-tracker events <id> [--limit N] [--json]`
+  - `ode pr-tracker settings [--show | --set-interval <seconds> | --set-prompt-file <path> | --set-token <token>]`
+- Tracker rows are created by `ode pr-tracker scan`; they are disabled by default and post results back to the source channel with its configured default agent.
 
 ## Sending Files / Images (`ode send`)
 - `ode send file <path> --channel <channelId> [--thread <threadId>] [--filename <name>] [--title <title>] [--comment <text>]` uploads any file to a chat channel.
-- The command resolves platform (Slack / Discord / Lark) from the channel's configured workspace; agents don't need to know the underlying SDK.
+- The command resolves platform (Slack / Discord / Lark) from the channel's configured workspace; agents do not need to know the underlying SDK.
 - Visual testing workflows should save screenshots to `os.tmpdir()` and upload them directly into the current thread.
 
 ## Fetching Messages (`ode messages`)
 - `ode messages get <threadId> --channel <channelId> [--limit N] [--json]` returns the replies in a thread.
-- Use it to re-read the current thread (for example, to pick up a follow-up comment posted while you were running tools) or to inspect another thread by its root id.
+- Use it to re-read the current thread, pick up a follow-up comment posted while tools were running, or inspect another thread by root id.
 
 ## Reactions (`ode reaction`)
 - `ode reaction add <messageId> --channel <channelId> --emoji <thumbsup|eyes|ok_hand> [--thread <threadId>]` reacts to a message.
@@ -62,24 +100,25 @@ Ode is a Slack bot that bridges messages to OpenCode for AI-assisted coding.
 
 ## Platform APIs
 - Ode no longer exposes a generic `/api/action` bridge; agents must use the dedicated `ode <verb>` CLIs above instead of calling Slack/Discord/Lark APIs directly.
-- Adding a new platform-facing capability means adding (or extending) an `ode` subcommand plus a matching daemon route.
+- Adding a new platform-facing capability means adding or extending an `ode` subcommand plus a matching daemon route.
 
-## Bun conventions
-- Use Bun instead of Node.js
-- Run: `bun run src/index.ts`
-- Tests: `bun test`
-- Prefer `Bun.file` over `node:fs`
+## Bun Conventions
+- Use Bun instead of Node.js.
+- Run TypeScript with `bun run <file>` or package scripts.
+- Prefer `Bun.file` over `node:fs` for new file IO where practical, while respecting existing local style.
 
 ## Skills
-- Available skills: `agent-browser`, `slack-developer-researcher`, `opencode-developer-researcher`, `qwen-code-skill`, `goose-cli-skill`
-- Use `agent-browser` for any browser automation tasks.
-- If you discover new Slack/OpenCode updates during development, update the matching skill doc under `.agents/skills/` (mirrored via `.claude/skills/`).
+- Available repo skills include `agent-browser`, `slack-developer-researcher`, `opencode-developer-researcher`, `codex-cli-reference`, `qwen-code-skill`, `goose-cli-skill`, `kimi-cli-skill`, `kiro-cli-skill`, and `kilo-cli-skill`.
+- Use `agent-browser` for browser automation tasks.
+- Use the matching CLI skill when changing or debugging an agent provider integration.
+- If you discover new Slack/OpenCode/CLI-agent updates during development, update the matching skill doc under `.agents/skills/` (mirrored via `.claude/skills/` when present).
 
-## Agent live status workflow
+## Agent Live Status Workflow
 - Use `packages/live-status-harness/fixed-prompt.md` as the baseline stream-capture prompt.
 - Capture stream events with `bun run live-status:capture --provider <opencode|claudecode|codex|kimi|kiro|kilo|qwen|goose|gemini>`.
 - Store raw ordered events in Redis under the harness keyspace (`harness:live_status:*`).
 - Render status outputs from captured events with `bun run live-status:render --run-id <runId>`.
+- Generate combined reports with `bun run live-status:report`.
 - Keep harness scripts in `packages/live-status-harness/` so stream capture/testing stays decoupled from the normal Ode runtime.
 - Before changing live status parsing/formatting, replay a captured run and verify output changes intentionally.
 - For new agent integrations, add at least one harness fixture and one deterministic render test.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ode",
-  "version": "0.1.40",
+  "version": "0.1.41",
   "description": "Coding anywhere with your coding agents connected",
   "module": "packages/core/index.ts",
   "type": "module",

--- a/packages/agents/claude/client.ts
+++ b/packages/agents/claude/client.ts
@@ -136,14 +136,16 @@ export function buildClaudeCommandArgs(params: {
   const sessionArgs = params.isNewSession
     ? ["--session-id", params.sessionId]
     : ["--resume", params.sessionId];
+  const systemPromptArgs = params.systemPrompt.trim()
+    ? ["--append-system-prompt", params.systemPrompt.trim()]
+    : [];
   return [
     "--print",
     "--verbose",
     "--output-format",
     "stream-json",
     "--include-partial-messages",
-    "--append-system-prompt",
-    params.systemPrompt,
+    ...systemPromptArgs,
     ...sessionArgs,
     "--add-dir",
     params.workingPath,

--- a/packages/agents/opencode/client.ts
+++ b/packages/agents/opencode/client.ts
@@ -264,8 +264,13 @@ export async function sendMessage(
 
       // Build system prompt with Slack context
       const system = buildSystemPrompt(context?.slack);
-      const payload = { directory: workingPath, parts, agent, model, system };
-      // const payload = { directory: workingPath, parts, agent, model };
+      const payload = {
+        directory: workingPath,
+        parts,
+        agent,
+        model,
+        ...(system ? { system } : {}),
+      };
       const serverUrl = getSessionServerUrl(activeSessionId);
       const command = serverUrl
         ? buildOpenCodeCommand(serverUrl, activeSessionId, payload)

--- a/packages/agents/shared.ts
+++ b/packages/agents/shared.ts
@@ -8,17 +8,6 @@ export function buildSystemPrompt(slack?: SlackContext): string {
       : "slack";
   const platformLabel = platform === "discord" ? "Discord" : platform === "lark" ? "Lark" : "Slack";
   const lines = [
-    "COMMUNICATION STYLE:",
-    "- Be concise and conversational - this is chat, not documentation",
-    "- Use short paragraphs, avoid walls of text",
-    "- Get straight to the point",
-    "- Do not truncate final answers for brevity; include complete results when details matter",
-    "",
-    "PROGRESS CHECKLIST:",
-    "- Share a short checklist of what you're doing",
-    "- Mention searches once with a result count if known",
-    "- List edits with the file path and a brief why",
-    "",
     "GIT AUTHORING:",
     "- If GIT_AUTHOR_NAME and GIT_AUTHOR_EMAIL are set, use them explicitly in commit commands.",
     "- Prefer: git commit --author=\"$GIT_AUTHOR_NAME <$GIT_AUTHOR_EMAIL>\" -m \"...\"",
@@ -41,22 +30,6 @@ export function buildSystemPrompt(slack?: SlackContext): string {
     lines.push("");
     lines.push(`IMPORTANT: Your text output is automatically posted to ${platformLabel}.`);
     lines.push("- Only output text OR use a messaging tool, never both.");
-    lines.push("");
-    lines.push("FORMATTING:");
-    lines.push(
-      platform === "discord"
-        ? "- Discord supports markdown like **bold**, _italic_, and code fences."
-        : platform === "lark"
-          ? "- Lark output should be plain text for now; do not rely on markdown styling."
-        : "- Slack uses *bold* and _italic_ (not **bold** or *italic*)"
-    );
-    lines.push("- Use ` for inline code and ``` for code blocks");
-    lines.push("- Keep responses readable on mobile screens");
-    lines.push("");
-    lines.push("TASK LISTS:");
-    lines.push("- When sharing tasks, put each item on its own line");
-    lines.push("- Use four states: * not started, ♻️ in progress, ✅ done, 🚫 cancelled");
-    lines.push("- If you include a task list, keep the tasks you have done at the top of the response");
     lines.push("");
     lines.push("ODE CLI:");
     lines.push("- The `ode` binary is how you interact with this chat platform outside of plain text output.");

--- a/packages/agents/shared.ts
+++ b/packages/agents/shared.ts
@@ -1,83 +1,7 @@
 import type { OpenCodeMessageContext, OpenCodeOptions, PromptPart, SlackContext } from "./types";
 
 export function buildSystemPrompt(slack?: SlackContext): string {
-  const platform = slack?.platform === "discord"
-    ? "discord"
-    : slack?.platform === "lark"
-      ? "lark"
-      : "slack";
-  const platformLabel = platform === "discord" ? "Discord" : platform === "lark" ? "Lark" : "Slack";
-  const lines = [
-    "GIT AUTHORING:",
-    "- If GIT_AUTHOR_NAME and GIT_AUTHOR_EMAIL are set, use them explicitly in commit commands.",
-    "- Prefer: git commit --author=\"$GIT_AUTHOR_NAME <$GIT_AUTHOR_EMAIL>\" -m \"...\"",
-    "- Use GH_TOKEN for gh commands when available; fall back to git commands when GH_TOKEN is not set.",
-    "- Before creating any pull request, make sure the current branch name is meaningful.",
-    "- If the branch looks like a thread/worktree ID (for example `ode_<threadId>`), rename it first.",
-    "- Preferred branch format before PR: `feat/<short-slug>-<threadShortId>` (slug from the PR topic, short thread suffix for uniqueness).",
-    "",
-  ];
-
-  if (slack) {
-    lines.push(`${platformLabel.toUpperCase()} CONTEXT:`);
-    lines.push(`- Channel: ${slack.channelId}`);
-    lines.push(`- Thread: ${slack.threadId}`);
-    lines.push(`- User: <@${slack.userId}>`);
-    if (slack.hasGitHubToken !== undefined) {
-      lines.push(`- GitHub token available: ${slack.hasGitHubToken ? "yes" : "no"}`);
-    }
-
-    lines.push("");
-    lines.push(`IMPORTANT: Your text output is automatically posted to ${platformLabel}.`);
-    lines.push("- Only output text OR use a messaging tool, never both.");
-    lines.push("");
-    lines.push("ODE CLI:");
-    lines.push("- The `ode` binary is how you interact with this chat platform outside of plain text output.");
-    lines.push("- All commands below auto-detect platform (Slack / Discord / Lark) from the `--channel` value;");
-    lines.push("  you never need to call Slack/Discord/Lark APIs directly.");
-    lines.push("- `--channel` accepts either a raw channel id or a `workspaceId::channelId` pair for disambiguation.");
-    lines.push("");
-    lines.push("ODE CLI - one-time scheduled tasks (`ode task`):");
-    lines.push("- Use when you need to wait on something that takes minutes / hours / days (deploys, nightly builds,");
-    lines.push("  external approvals). Schedule the follow-up and return instead of blocking the conversation.");
-    lines.push("- `ode task create --time <ISO8601> --channel <channelId> [--thread <threadId>] --message \"<prompt>\" [--agent <agentId>] [--run-now]`");
-    lines.push("- Manage: `ode task list`, `ode task show <id>`, `ode task cancel <id>`, `ode task run <id>`, `ode task delete <id>`.");
-    lines.push("- Pass the current `--thread` so the task wakes up inside the same conversation; omit it to post as a fresh channel message.");
-    lines.push("");
-    lines.push("ODE CLI - recurring cron jobs (`ode cron`):");
-    lines.push("- Use for schedules (heartbeats, daily digests, periodic checks). Each run starts a fresh agent session.");
-    lines.push("- `ode cron create --schedule \"<5-field cron>\" --channel <channelId> --message \"<prompt>\" [--title <title>] [--disabled] [--run-now]`");
-    lines.push("- `--schedule` is standard 5-field cron (minute hour day month weekday), e.g. `*/30 * * * *`.");
-    lines.push("- Manage: `ode cron list`, `ode cron show <id>`, `ode cron update <id>`, `ode cron enable|disable <id>`, `ode cron run <id>`, `ode cron delete <id>`.");
-    lines.push("");
-    lines.push("ODE CLI - send files / images (`ode send`):");
-    lines.push("- `ode send file <path> --channel <channelId> [--thread <threadId>] [--comment \"...\"] [--filename <name>] [--title <text>]`");
-    lines.push("- Save files to `$(mktemp -d)` or `os.tmpdir()` first, then upload them with this command.");
-    lines.push(`- Example: \`ode send file /tmp/screenshot.png --channel ${slack.channelId} --thread ${slack.threadId} --comment \"layout after fix\"\`.`);
-    lines.push("");
-    lines.push("ODE CLI - fetch thread messages (`ode messages`):");
-    lines.push("- `ode messages get <threadId> --channel <channelId> [--limit N] [--json]`");
-    lines.push("- Use when you need to re-read prior messages in the current thread or another thread.");
-    lines.push(`- Example: \`ode messages get ${slack.threadId} --channel ${slack.channelId} --limit 40\`.`);
-    lines.push("");
-    lines.push("ODE CLI - react to a message (`ode reaction`):");
-    lines.push("- `ode reaction add <messageId> --channel <channelId> --emoji <thumbsup|eyes|ok_hand> [--thread <threadId>]`");
-    lines.push("- Useful to acknowledge a request (`eyes` = \"I'm on it\", `thumbsup` = \"done\", `ok_hand` = \"ack\").");
-    lines.push("");
-    lines.push("VISUAL TESTING:");
-    lines.push("- Whenever you work on UI / layout / design tasks, capture the result and upload it to the current");
-    lines.push("  thread with `ode send file` so the user can see it immediately.");
-    lines.push("- Prefer real screenshots over describing the UI in text. A single screenshot is usually worth paragraphs.");
-    lines.push("- For before/after comparisons, upload both screenshots with a short `--comment` explaining what changed.");
-
-    const channelSystemMessage = slack.channelSystemMessage?.trim();
-    if (channelSystemMessage) {
-      lines.push("");
-      lines.push(channelSystemMessage);
-    }
-  }
-
-  return lines.join("\n");
+  return slack?.channelSystemMessage?.trim() ?? "";
 }
 
 export function buildPromptParts(
@@ -105,5 +29,7 @@ export function buildPromptText(parts: PromptPart[]): string {
 }
 
 export function buildSystemWrappedPrompt(systemPrompt: string, prompt: string): string {
-  return `<system-prompt>\n${systemPrompt}\n</system-prompt>\n\n${prompt}`;
+  const trimmedSystemPrompt = systemPrompt.trim();
+  if (!trimmedSystemPrompt) return prompt;
+  return `<system-prompt>\n${trimmedSystemPrompt}\n</system-prompt>\n\n${prompt}`;
 }

--- a/packages/agents/test/cli-command.test.ts
+++ b/packages/agents/test/cli-command.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { buildPromptParts, buildPromptText, buildSystemPrompt } from "../shared";
+import { buildPromptParts, buildPromptText, buildSystemPrompt, buildSystemWrappedPrompt } from "../shared";
 import { buildOpenCodeCommand } from "../opencode/client";
 import { buildClaudeCommand, buildClaudeCommandArgs } from "../claude/client";
 import { buildCodexCommand, buildCodexCommandArgs } from "../codex/client";
@@ -35,12 +35,23 @@ describe("agent cli command formatting", () => {
 
     expect(command).toContain("claude");
     expect(command).toContain("--permission-mode dontAsk --");
+    expect(command).not.toContain("--append-system-prompt");
     expect(command).toContain("--session-id session-1");
     expect(command).toContain("--add-dir /tmp/project");
     expect(command).toContain("'hello world'");
   });
 
-  it("appends channel system message into system prompt", () => {
+  it("does not inject an Ode system prompt by default", () => {
+    const systemPrompt = buildSystemPrompt({
+      channelId: "C123",
+      threadId: "T456",
+      userId: "U789",
+    });
+
+    expect(systemPrompt).toBe("");
+  });
+
+  it("uses only the explicit channel system message as system prompt", () => {
     const systemPrompt = buildSystemPrompt({
       channelId: "C123",
       threadId: "T456",
@@ -48,22 +59,21 @@ describe("agent cli command formatting", () => {
       channelSystemMessage: "Always ask for confirmation before destructive file operations.",
     });
 
-    expect(systemPrompt).toContain("Always ask for confirmation before destructive file operations.");
-    expect(systemPrompt).not.toContain("CHANNEL SYSTEM MESSAGE:");
+    expect(systemPrompt).toBe("Always ask for confirmation before destructive file operations.");
   });
 
-  it("includes branch rename guidance before creating pull requests", () => {
+  it("does not inject git or pull request guidance", () => {
     const systemPrompt = buildSystemPrompt({
       channelId: "C123",
       threadId: "1770543888.045599",
       userId: "U789",
     });
 
-    expect(systemPrompt).toContain("Before creating any pull request, make sure the current branch name is meaningful.");
-    expect(systemPrompt).toContain("Preferred branch format before PR: `feat/<short-slug>-<threadShortId>`");
+    expect(systemPrompt).not.toContain("Before creating any pull request");
+    expect(systemPrompt).not.toContain("Preferred branch format before PR");
   });
 
-  it("builds Discord context without platform formatting guidance", () => {
+  it("does not inject Discord context or platform formatting guidance", () => {
     const systemPrompt = buildSystemPrompt({
       platform: "discord",
       channelId: "C123",
@@ -71,15 +81,14 @@ describe("agent cli command formatting", () => {
       userId: "U789",
     });
 
-    expect(systemPrompt).toContain("DISCORD CONTEXT:");
-    expect(systemPrompt).toContain("ODE CLI:");
+    expect(systemPrompt).toBe("");
+    expect(systemPrompt).not.toContain("DISCORD CONTEXT:");
+    expect(systemPrompt).not.toContain("ODE CLI:");
     expect(systemPrompt).not.toContain("FORMATTING:");
     expect(systemPrompt).not.toContain("Discord supports markdown");
-    expect(systemPrompt).not.toContain("DISCORD ACTIONS:");
-    expect(systemPrompt).not.toContain("/api/action");
   });
 
-  it("builds Lark context without platform formatting guidance", () => {
+  it("does not inject Lark context or platform formatting guidance", () => {
     const systemPrompt = buildSystemPrompt({
       platform: "lark",
       channelId: "oc_123",
@@ -87,12 +96,11 @@ describe("agent cli command formatting", () => {
       userId: "ou_789",
     });
 
-    expect(systemPrompt).toContain("LARK CONTEXT:");
-    expect(systemPrompt).toContain("ODE CLI:");
+    expect(systemPrompt).toBe("");
+    expect(systemPrompt).not.toContain("LARK CONTEXT:");
+    expect(systemPrompt).not.toContain("ODE CLI:");
     expect(systemPrompt).not.toContain("FORMATTING:");
     expect(systemPrompt).not.toContain("Lark output should be plain text");
-    expect(systemPrompt).not.toContain("LARK ACTIONS:");
-    expect(systemPrompt).not.toContain("Supported actions:");
   });
 
   it("does not inject chat response style or task-list glyph guidance", () => {
@@ -110,7 +118,7 @@ describe("agent cli command formatting", () => {
     expect(systemPrompt).not.toContain("Use four states");
   });
 
-  it("recommends Ode CLI commands with the current channel/thread baked in", () => {
+  it("does not inject Ode CLI command guidance", () => {
     const systemPrompt = buildSystemPrompt({
       platform: "slack",
       channelId: "C9XXX",
@@ -118,12 +126,20 @@ describe("agent cli command formatting", () => {
       userId: "U42",
     });
 
-    expect(systemPrompt).toContain("ode task create");
-    expect(systemPrompt).toContain("ode cron create");
-    expect(systemPrompt).toContain("ode send file /tmp/screenshot.png --channel C9XXX --thread 1700000000.000001");
-    expect(systemPrompt).toContain("ode messages get 1700000000.000001 --channel C9XXX");
-    expect(systemPrompt).toContain("ode reaction add");
-    expect(systemPrompt).toContain("VISUAL TESTING:");
+    expect(systemPrompt).not.toContain("ode task create");
+    expect(systemPrompt).not.toContain("ode cron create");
+    expect(systemPrompt).not.toContain("ode send file");
+    expect(systemPrompt).not.toContain("ode messages get");
+    expect(systemPrompt).not.toContain("ode reaction add");
+    expect(systemPrompt).not.toContain("VISUAL TESTING:");
+  });
+
+  it("does not wrap prompts when no system prompt is present", () => {
+    expect(buildSystemWrappedPrompt("", "hello")).toBe("hello");
+  });
+
+  it("wraps only explicit system prompts", () => {
+    expect(buildSystemWrappedPrompt("custom rules", "hello")).toBe("<system-prompt>\ncustom rules\n</system-prompt>\n\nhello");
   });
 
   it("builds the OpenCode curl command", () => {

--- a/packages/agents/test/cli-command.test.ts
+++ b/packages/agents/test/cli-command.test.ts
@@ -63,7 +63,7 @@ describe("agent cli command formatting", () => {
     expect(systemPrompt).toContain("Preferred branch format before PR: `feat/<short-slug>-<threadShortId>`");
   });
 
-  it("builds Discord-specific formatting guidance for Discord context", () => {
+  it("builds Discord context without platform formatting guidance", () => {
     const systemPrompt = buildSystemPrompt({
       platform: "discord",
       channelId: "C123",
@@ -72,13 +72,14 @@ describe("agent cli command formatting", () => {
     });
 
     expect(systemPrompt).toContain("DISCORD CONTEXT:");
-    expect(systemPrompt).toContain("Discord supports markdown like **bold**, _italic_, and code fences.");
     expect(systemPrompt).toContain("ODE CLI:");
+    expect(systemPrompt).not.toContain("FORMATTING:");
+    expect(systemPrompt).not.toContain("Discord supports markdown");
     expect(systemPrompt).not.toContain("DISCORD ACTIONS:");
     expect(systemPrompt).not.toContain("/api/action");
   });
 
-  it("builds Lark-specific formatting guidance for Lark context", () => {
+  it("builds Lark context without platform formatting guidance", () => {
     const systemPrompt = buildSystemPrompt({
       platform: "lark",
       channelId: "oc_123",
@@ -87,10 +88,26 @@ describe("agent cli command formatting", () => {
     });
 
     expect(systemPrompt).toContain("LARK CONTEXT:");
-    expect(systemPrompt).toContain("Lark output should be plain text for now; do not rely on markdown styling.");
     expect(systemPrompt).toContain("ODE CLI:");
+    expect(systemPrompt).not.toContain("FORMATTING:");
+    expect(systemPrompt).not.toContain("Lark output should be plain text");
     expect(systemPrompt).not.toContain("LARK ACTIONS:");
     expect(systemPrompt).not.toContain("Supported actions:");
+  });
+
+  it("does not inject chat response style or task-list glyph guidance", () => {
+    const systemPrompt = buildSystemPrompt({
+      platform: "slack",
+      channelId: "C9XXX",
+      threadId: "1700000000.000001",
+      userId: "U42",
+    });
+
+    expect(systemPrompt).not.toContain("COMMUNICATION STYLE:");
+    expect(systemPrompt).not.toContain("PROGRESS CHECKLIST:");
+    expect(systemPrompt).not.toContain("TASK LISTS:");
+    expect(systemPrompt).not.toContain("Slack uses *bold*");
+    expect(systemPrompt).not.toContain("Use four states");
   });
 
   it("recommends Ode CLI commands with the current channel/thread baked in", () => {

--- a/packages/config/local/sessions.ts
+++ b/packages/config/local/sessions.ts
@@ -44,6 +44,8 @@ export interface ActiveRequest {
   tools?: TrackedTool[];
   todos: TrackedTodo[];
   statusFrozen?: boolean;
+  statusStreamActive?: boolean;
+  statusStreamTs?: string;
   state: "processing" | "completed" | "failed";
   finalResponseTs?: string;
   error?: string;
@@ -387,6 +389,7 @@ export function createActiveRequest(
     tools: [],
     todos: [],
     statusFrozen: false,
+    statusStreamActive: false,
     state: "processing",
   };
 }

--- a/packages/core/cron/scheduler.ts
+++ b/packages/core/cron/scheduler.ts
@@ -33,10 +33,10 @@ import {
 import { matchesCronExpression } from "@/core/cron/expression";
 import { buildMessageOptions } from "@/core/runtime/message-options";
 import { buildFinalResponseText, categorizeRuntimeError } from "@/core/runtime/helpers";
+import { sendSlackChannelMessage } from "@/core/runtime/slack-senders";
 import { buildSessionEnvironment, prepareSessionWorkspace } from "@/core/session";
 import { sendChannelMessage as sendDiscordChannelMessage } from "@/ims/discord/client";
 import { sendChannelMessage as sendLarkChannelMessage } from "@/ims/lark/client";
-import { sendChannelMessage as sendSlackChannelMessage } from "@/ims/slack/client";
 import { log } from "@/utils";
 
 const CRON_POLL_INTERVAL_MS = 15_000;

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -368,9 +368,15 @@ async function main(): Promise<void> {
   log.info("Startup ready", { elapsedMs: Date.now() - startupStartedAt });
 
   // Recover interrupted requests after reporting readiness. This cleanup only
-  // updates stale status messages and should not delay normal startup.
+  // updates requests that existed before this process started, so work that
+  // arrives immediately after the ready signal cannot be mistaken for a stale
+  // crash leftover.
+  const recoveryCutoffMs = startupStartedAt;
   setTimeout(() => {
-    void timeStartupStep("pending request recovery", () => recoverPendingRequestsAcrossPlatforms());
+    void timeStartupStep(
+      "pending request recovery",
+      () => recoverPendingRequestsAcrossPlatforms({ startedBeforeMs: recoveryCutoffMs })
+    );
   }, 1000);
 }
 

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -51,6 +51,18 @@ function getLocalSettingsUrl(): string {
   return `http://${host}:${port}/`;
 }
 
+async function timeStartupStep<T>(name: string, run: () => T | Promise<T>): Promise<T> {
+  const startedAt = Date.now();
+  try {
+    const result = await run();
+    log.debug("Startup step complete", { step: name, elapsedMs: Date.now() - startedAt });
+    return result;
+  } catch (error) {
+    log.warn("Startup step failed", { step: name, elapsedMs: Date.now() - startedAt, error: String(error) });
+    throw error;
+  }
+}
+
 let webDevServer: ChildProcess | null = null;
 let slackApps: Array<Awaited<ReturnType<typeof createSlackApp>>> = [];
 let slackAppTokens: string[] = [];
@@ -111,9 +123,7 @@ async function startSlackRuntime(reason: string): Promise<void> {
     slackAppTokens = appTokens;
     setupMessageHandlers();
     setupInteractiveHandlers();
-    for (const app of slackApps) {
-      await app.start();
-    }
+    await Promise.all(slackApps.map((app) => app.start()));
     log.debug("Slack connections ready", { reason, count: slackApps.length });
   } catch (error) {
     log.warn("Slack connection failed", { reason, error: String(error) });
@@ -262,6 +272,7 @@ function startLocalConfigWatcher(): void {
 }
 
 async function main(): Promise<void> {
+  const startupStartedAt = Date.now();
   initSentry({ release: `ode@${CURRENT_VERSION}` });
 
   let defaultCwd: string | null = null;
@@ -272,24 +283,26 @@ async function main(): Promise<void> {
   }
   log.debug("Config loaded", { defaultCwd, mode: "local" });
 
-  loadOdeConfig();
-  await runOnboardingIfNeeded();
+  await timeStartupStep("load config", () => loadOdeConfig());
+  await timeStartupStep("onboarding", () => runOnboardingIfNeeded());
 
   if (isLocalMode()) {
-    startLocalWebServer();
+    await timeStartupStep("local web server", () => startLocalWebServer());
     if (!hasWebUiBuild()) {
       log.info("Web UI build missing; configure via ~/.config/ode/ode.json");
     }
-    startLocalConfigWatcher();
-    updateAutoUpgradeScheduler("startup");
+    await timeStartupStep("config watcher", () => startLocalConfigWatcher());
+    await timeStartupStep("auto-upgrade scheduler", () => updateAutoUpgradeScheduler("startup"));
   }
 
-  await startSlackRuntime("startup");
-  await startDiscordRuntime("startup");
-  await startLarkRuntime("startup");
-  startCronJobScheduler();
-  startTaskScheduler();
-  startPrTrackerScheduler();
+  await timeStartupStep("IM runtimes", () => Promise.all([
+    startSlackRuntime("startup"),
+    startDiscordRuntime("startup"),
+    startLarkRuntime("startup"),
+  ]));
+  await timeStartupStep("cron scheduler", () => startCronJobScheduler());
+  await timeStartupStep("task scheduler", () => startTaskScheduler());
+  await timeStartupStep("pr tracker scheduler", () => startPrTrackerScheduler());
 
   if (slackApps.length > 0) {
     log.debug("Slack app created");
@@ -345,12 +358,6 @@ async function main(): Promise<void> {
   process.on("SIGINT", () => shutdown("SIGINT"));
   process.on("SIGTERM", () => shutdown("SIGTERM"));
 
-  // Give connections time to establish before recovery
-  await new Promise((resolve) => setTimeout(resolve, 1000));
-
-  // Recover any interrupted requests from previous run
-  await recoverPendingRequestsAcrossPlatforms();
-
   if (slackApps.length > 0) {
     log.debug("Bot is running in Socket Mode");
   }
@@ -358,6 +365,13 @@ async function main(): Promise<void> {
   const readyMessage = `Ode is ready! Waiting for messages, setting UI is accessible at ${getLocalSettingsUrl()}`;
   console.log(readyMessage);
   markRuntimeReady(readyMessage, CURRENT_VERSION);
+  log.info("Startup ready", { elapsedMs: Date.now() - startupStartedAt });
+
+  // Recover interrupted requests after reporting readiness. This cleanup only
+  // updates stale status messages and should not delay normal startup.
+  setTimeout(() => {
+    void timeStartupStep("pending request recovery", () => recoverPendingRequestsAcrossPlatforms());
+  }, 1000);
 }
 
 main().catch((err) => {

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -1,12 +1,8 @@
+import * as slackClient from "@/ims/slack/client";
+import { setupInteractiveHandlers } from "@/ims/slack/commands";
+import { stopOAuthServer } from "@/ims/slack/oauth";
 import {
-  createSlackApp,
-  setupMessageHandlers,
-  setupInteractiveHandlers,
-  stopOAuthServer,
   recoverPendingRequestsAcrossPlatforms,
-  initializeWorkspaceAuth,
-  clearSlackAuthState,
-  resetSlackState,
   startDiscordRuntime,
   stopDiscordRuntime,
   startLarkRuntime,
@@ -64,7 +60,7 @@ async function timeStartupStep<T>(name: string, run: () => T | Promise<T>): Prom
 }
 
 let webDevServer: ChildProcess | null = null;
-let slackApps: Array<Awaited<ReturnType<typeof createSlackApp>>> = [];
+let slackApps: Array<Awaited<ReturnType<typeof slackClient.createSlackApp>>> = [];
 let slackAppTokens: string[] = [];
 let slackStarting = false;
 let stopConfigWatcher: (() => void) | null = null;
@@ -93,7 +89,7 @@ async function stopSlackRuntime(reason: string): Promise<void> {
 
   slackApps = [];
   slackAppTokens = [];
-  resetSlackState();
+  slackClient.resetSlackState();
   log.debug("Slack connections stopped", { reason });
 }
 
@@ -113,15 +109,15 @@ async function startSlackRuntime(reason: string): Promise<void> {
     const appTokens = getLocalSlackAppTokens();
     if (appTokens.length === 0) return;
 
-    clearSlackAuthState();
-    await initializeWorkspaceAuth();
+    slackClient.clearSlackAuthState();
+    await slackClient.initializeWorkspaceAuth();
     slackApps = [];
     for (const appToken of appTokens) {
-      const app = await createSlackApp(appToken);
+      const app = await slackClient.createSlackApp(appToken);
       slackApps.push(app);
     }
     slackAppTokens = appTokens;
-    setupMessageHandlers();
+    slackClient.setupMessageHandlers();
     setupInteractiveHandlers();
     await Promise.all(slackApps.map((app) => app.start()));
     log.debug("Slack connections ready", { reason, count: slackApps.length });
@@ -171,8 +167,8 @@ async function refreshSlackRuntime(reason: string): Promise<void> {
     return;
   }
 
-  clearSlackAuthState();
-  await initializeWorkspaceAuth();
+  slackClient.clearSlackAuthState();
+  await slackClient.initializeWorkspaceAuth();
   log.debug("Slack auth refreshed", { reason, appCount: slackApps.length });
 
   await refreshNonSlackRuntimes(reason);

--- a/packages/core/kernel/recovery.ts
+++ b/packages/core/kernel/recovery.ts
@@ -1,6 +1,20 @@
-import { clearActiveRequest, getSessionsWithPendingRequests } from "@/config/local/sessions";
+import { clearActiveRequest, getSessionsWithPendingRequests, type ActiveRequest } from "@/config/local/sessions";
 import type { IMAdapter } from "@/core/types";
 import { log } from "@/utils";
+
+async function stopRecoveredStatusStream(im: IMAdapter, request: ActiveRequest): Promise<void> {
+  if (!request.statusStreamActive || !request.statusStreamTs || !im.stopStatusStream) return;
+
+  try {
+    await im.stopStatusStream(request.channelId, request.statusStreamTs);
+  } catch (err) {
+    log.warn("Failed to stop recovered status stream", {
+      channelId: request.channelId,
+      statusTs: request.statusStreamTs,
+      error: String(err),
+    });
+  }
+}
 
 export async function recoverPendingRequests(
   im: IMAdapter,
@@ -31,6 +45,8 @@ export async function recoverPendingRequests(
     }
 
     const age = Date.now() - request.startedAt;
+    await stopRecoveredStatusStream(im, request);
+
     if (age > 10 * 60 * 1000) {
       log.debug("Clearing stale request", {
         channelId: session.channelId,

--- a/packages/core/kernel/recovery.ts
+++ b/packages/core/kernel/recovery.ts
@@ -4,7 +4,8 @@ import { log } from "@/utils";
 
 export async function recoverPendingRequests(
   im: IMAdapter,
-  platform?: "slack" | "discord" | "lark"
+  platform?: "slack" | "discord" | "lark",
+  options?: { startedBeforeMs?: number }
 ): Promise<void> {
   const pendingSessions = await getSessionsWithPendingRequests(platform);
 
@@ -18,6 +19,16 @@ export async function recoverPendingRequests(
   for (const session of pendingSessions) {
     const request = session.activeRequest;
     if (!request) continue;
+
+    if (typeof options?.startedBeforeMs === "number" && request.startedAt >= options.startedBeforeMs) {
+      log.debug("Skipping request created after recovery cutoff", {
+        channelId: session.channelId,
+        threadId: session.threadId,
+        requestStartedAt: request.startedAt,
+        recoveryCutoffMs: options.startedBeforeMs,
+      });
+      continue;
+    }
 
     const age = Date.now() - request.startedAt;
     if (age > 10 * 60 * 1000) {

--- a/packages/core/kernel/request-run.ts
+++ b/packages/core/kernel/request-run.ts
@@ -559,21 +559,56 @@ export async function runOpenRequest(
   // Streaming-API path is opt-in via env var AND requires the adapter to
   // implement startStatusStream (currently Slack-only). When unavailable
   // we silently fall back to the chat.postMessage + chat.update path.
-  const useStreaming = isStatusStreamingEnabled()
+  const streamingRequested = isStatusStreamingEnabled()
     && typeof deps.im.startStatusStream === "function"
     && typeof deps.im.appendStatusStream === "function";
 
+  // Tracks whether the *current* statusTs is a live stream. Set to true
+  // only after startStatusStream returns a TS; cleared if we fall back to
+  // sendMessage at startup or if a status rotation later replaces the TS
+  // with a chat.postMessage-issued one.
+  let useStreaming = false;
+
   let initialStatusTs: string | undefined;
   try {
-    if (useStreaming && deps.im.startStatusStream) {
-      initialStatusTs = await deps.im.startStatusStream(
-        context.channelId,
-        context.replyThreadId,
-        {
-          recipientUserId: context.userId,
-          seedPlanTitle: `${providerLabel} is running...`,
-        }
-      );
+    if (streamingRequested && deps.im.startStatusStream) {
+      try {
+        initialStatusTs = await deps.im.startStatusStream(
+          context.channelId,
+          context.replyThreadId,
+          {
+            recipientUserId: context.userId,
+            seedPlanTitle: `${providerLabel} is running...`,
+          }
+        );
+      } catch (err) {
+        // startStream itself threw — log and fall through to the
+        // chat.postMessage path below. Common causes: missing
+        // recipient_team_id, the workspace hasn't opted into the streaming
+        // API, network blip on the very first request.
+        log.warn("startStatusStream threw; falling back to chat.postMessage", {
+          channelId: context.channelId,
+          threadId: context.replyThreadId,
+          error: String(err),
+        });
+        initialStatusTs = undefined;
+      }
+      if (initialStatusTs) {
+        useStreaming = true;
+      } else {
+        // Adapter returned undefined (e.g. resolveWorkspaceAuth couldn't
+        // produce a team id). Fall back to plain chat.postMessage instead
+        // of aborting the whole request.
+        log.warn("startStatusStream returned no ts; falling back to chat.postMessage", {
+          channelId: context.channelId,
+          threadId: context.replyThreadId,
+        });
+        initialStatusTs = await deps.im.sendMessage(
+          context.channelId,
+          context.replyThreadId,
+          `${providerLabel} is running...`
+        );
+      }
     } else {
       initialStatusTs = await deps.im.sendMessage(
         context.channelId,
@@ -672,8 +707,8 @@ export async function runOpenRequest(
       // Streaming path: diff state -> chunks -> chat.appendStream.
       // Falls back to plain-text chat.update when the differ produced no
       // chunks (nothing changed) so we don't waste a Tier-4 round-trip.
-      if (streamDiffer && currentState && deps.im.appendStatusStream && !request.statusFrozen) {
-        const chunks = streamDiffer.diff({
+      if (streamDiffer && currentState && deps.im.appendStatusStream && useStreaming && !request.statusFrozen) {
+        const { chunks, commit } = streamDiffer.diff({
           state: currentState,
           workingPath: cwd,
           startedAt: request.startedAt,
@@ -681,12 +716,16 @@ export async function runOpenRequest(
         if (chunks.length > 0) {
           try {
             await deps.im.appendStatusStream(context.channelId, statusTs, chunks);
+            // Only advance the differ's fingerprint cache after the
+            // network call confirms. If commit() is skipped due to a
+            // throw above, the next tick re-emits the same chunks
+            // (idempotent for Slack's task_update / plan_update).
+            commit();
           } catch (err) {
             // appendStream failed (rate limit, streaming_state_conflict,
-            // network blip…). Don't crash the tick — the next tick will
-            // re-diff against the same lastFingerprints and retry only the
-            // still-unchanged delta, so we don't replay the entire history.
-            log.warn("Slack appendStatusStream failed", {
+            // network blip…). Don't crash the tick and don't commit() —
+            // the next tick will re-emit the still-pending delta.
+            log.warn("Slack appendStatusStream failed; will retry next tick", {
               channelId: context.channelId,
               statusTs,
               chunkCount: chunks.length,

--- a/packages/core/kernel/request-run.ts
+++ b/packages/core/kernel/request-run.ts
@@ -720,15 +720,6 @@ export async function runOpenRequest(
       return;
     }
 
-    useStreaming = false;
-    streamingStatusTs = undefined;
-    request.statusStreamActive = false;
-    request.statusStreamTs = undefined;
-    updateActiveRequest(context.channelId, context.threadId, {
-      statusStreamActive: false,
-      statusStreamTs: undefined,
-    }, { immediate: true });
-
     try {
       if (appendChunks && appendChunks.length > 0 && deps.im.appendStatusStream) {
         try {
@@ -743,7 +734,23 @@ export async function runOpenRequest(
         }
       }
       await deps.im.stopStatusStream(context.channelId, streamTs);
+      useStreaming = false;
+      streamingStatusTs = undefined;
+      request.statusStreamActive = false;
+      request.statusStreamTs = undefined;
+      updateActiveRequest(context.channelId, context.threadId, {
+        statusStreamActive: false,
+        statusStreamTs: undefined,
+      }, { immediate: true });
     } catch (err) {
+      useStreaming = true;
+      streamingStatusTs = streamTs;
+      request.statusStreamActive = true;
+      request.statusStreamTs = streamTs;
+      updateActiveRequest(context.channelId, context.threadId, {
+        statusStreamActive: true,
+        statusStreamTs: streamTs,
+      }, { immediate: true });
       log.warn("Slack stopStatusStream failed", {
         reason,
         channelId: context.channelId,

--- a/packages/core/kernel/request-run.ts
+++ b/packages/core/kernel/request-run.ts
@@ -109,7 +109,7 @@ export type RunTrackedRequestParams = {
    * Optional. When the runner used the streaming API for live status, the
    * failure path needs to stop the stream before chat.update would 409 with
    * `streaming_state_conflict`. The kernel passes a closure that knows how
-   * to terminate the stream and emit a one-line error summary.
+   * to terminate the stream and preserve the full markdown error status.
    */
   publishErrorStatus?: (errorStatusText: string) => Promise<void>;
   failureLogLabel: string;
@@ -957,14 +957,28 @@ export async function runOpenRequest(
           }
           // Append the error as a final plan_update chunk so the streamed
           // card surfaces the failure inline, then stop the stream. Chunks-
-          // mode streams can't carry markdown_text on stop, so we can't
-          // pass the error there directly.
+          // mode streams can't carry markdown_text on stop, so we publish
+          // the full error text as a normal message after the stream is no
+          // longer active.
           try {
             await stopTrackedStatusStream("error status", [
               { type: "plan_update", title: `Error: ${errorStatusText.split("\n")[0]?.slice(0, 200) ?? ""}` },
             ]);
+            const errorStatusTs = await deps.im.sendMessage(
+              context.channelId,
+              context.replyThreadId,
+              errorStatusText
+            );
+            if (typeof errorStatusTs === "string" && errorStatusTs.length > 0) {
+              request.statusMessageTs = errorStatusTs;
+              updateActiveRequest(context.channelId, context.threadId, {
+                statusMessageTs: errorStatusTs,
+                statusStreamActive: false,
+                statusStreamTs: undefined,
+              }, { immediate: true });
+            }
           } catch (err) {
-            log.warn("Slack stopStatusStream failed in error path", {
+            log.warn("Streaming error status publish failed; falling back to chat.update", {
               channelId: context.channelId,
               statusTs: request.statusMessageTs,
               error: String(err),

--- a/packages/core/kernel/request-run.ts
+++ b/packages/core/kernel/request-run.ts
@@ -29,13 +29,26 @@ import type { RuntimeRequestContext } from "@/core/kernel/request-context";
 import { formatSingleQuestionPrompt } from "@/core/runtime/helpers";
 import {
   buildSessionMessageState,
+  createStatusStreamDiffer,
   extractEventSessionId,
   getStatusMessageKey,
   truncateEventPayload,
   type SessionEvent,
   type SessionMessageState,
+  type StatusStreamDiffer,
   log,
 } from "@/utils";
+
+/**
+ * When ODE_SLACK_STATUS_STREAMING=1 and the IM adapter supports the
+ * Slack-style streaming API (chat.startStream/appendStream/stopStream), we
+ * render live status as task_update/plan_update chunks instead of repeated
+ * chat.update edits. Currently Slack-only; other adapters lack the methods
+ * and the code path automatically falls back.
+ */
+function isStatusStreamingEnabled(): boolean {
+  return process.env.ODE_SLACK_STATUS_STREAMING === "1";
+}
 
 /**
  * Guard against publishing the user's own prompt as the bot's final reply.
@@ -92,6 +105,13 @@ export type RunTrackedRequestParams = {
   onComplete: () => void;
   onFail: (message: string) => void;
   publishFinalText: (text: string) => Promise<void>;
+  /**
+   * Optional. When the runner used the streaming API for live status, the
+   * failure path needs to stop the stream before chat.update would 409 with
+   * `streaming_state_conflict`. The kernel passes a closure that knows how
+   * to terminate the stream and emit a one-line error summary.
+   */
+  publishErrorStatus?: (errorStatusText: string) => Promise<void>;
   failureLogLabel: string;
   agentResultDetailId: string | null;
   threadKey: string;
@@ -536,13 +556,31 @@ export async function runOpenRequest(
 
   const providerLabel = deps.agent.getDisplayNameForSession(sessionId);
 
+  // Streaming-API path is opt-in via env var AND requires the adapter to
+  // implement startStatusStream (currently Slack-only). When unavailable
+  // we silently fall back to the chat.postMessage + chat.update path.
+  const useStreaming = isStatusStreamingEnabled()
+    && typeof deps.im.startStatusStream === "function"
+    && typeof deps.im.appendStatusStream === "function";
+
   let initialStatusTs: string | undefined;
   try {
-    initialStatusTs = await deps.im.sendMessage(
-      context.channelId,
-      context.replyThreadId,
-      `${providerLabel} is running...`
-    );
+    if (useStreaming && deps.im.startStatusStream) {
+      initialStatusTs = await deps.im.startStatusStream(
+        context.channelId,
+        context.replyThreadId,
+        {
+          recipientUserId: context.userId,
+          seedPlanTitle: `${providerLabel} is running...`,
+        }
+      );
+    } else {
+      initialStatusTs = await deps.im.sendMessage(
+        context.channelId,
+        context.replyThreadId,
+        `${providerLabel} is running...`
+      );
+    }
   } catch (err) {
     // Swallow initial-status send failure so the request lifecycle below never
     // gets skipped by an unhandled rejection. A transient Slack error on the
@@ -596,6 +634,10 @@ export async function runOpenRequest(
     ? `${options.model.providerID}/${options.model.modelID}`
     : null;
   const providerId = deps.agent.getProviderForSession(sessionId);
+
+  // One differ instance per run; keeps last-seen fingerprints so we only
+  // send chunks for tools whose shape actually changed.
+  const streamDiffer: StatusStreamDiffer | null = useStreaming ? createStatusStreamDiffer() : null;
   const result = await runTrackedRequest({
     deps,
     request,
@@ -625,12 +667,47 @@ export async function runOpenRequest(
       // progress updates pointed at the actual live message.
       statusTs = request.statusMessageTs;
       const currentStatusKey = getStatusMessageKey(request);
+      const currentState = liveParsedState.get(currentStatusKey);
+
+      // Streaming path: diff state -> chunks -> chat.appendStream.
+      // Falls back to plain-text chat.update when the differ produced no
+      // chunks (nothing changed) so we don't waste a Tier-4 round-trip.
+      if (streamDiffer && currentState && deps.im.appendStatusStream && !request.statusFrozen) {
+        const chunks = streamDiffer.diff({
+          state: currentState,
+          workingPath: cwd,
+          startedAt: request.startedAt,
+        });
+        if (chunks.length > 0) {
+          try {
+            await deps.im.appendStatusStream(context.channelId, statusTs, chunks);
+          } catch (err) {
+            // appendStream failed (rate limit, streaming_state_conflict,
+            // network blip…). Don't crash the tick — the next tick will
+            // re-diff against the same lastFingerprints and retry only the
+            // still-unchanged delta, so we don't replay the entire history.
+            log.warn("Slack appendStatusStream failed", {
+              channelId: context.channelId,
+              statusTs,
+              chunkCount: chunks.length,
+              error: String(err),
+            });
+          }
+        }
+        updateActiveRequest(context.channelId, context.threadId, {
+          statusMessageTs: request.statusMessageTs,
+          currentText: request.currentText,
+          todos: request.todos,
+          statusFrozen: request.statusFrozen,
+        });
+        return;
+      }
 
       const statusText = buildStatusMessageForAgent({
         agent: deps.agent,
         request,
         workingPath: cwd,
-        state: liveParsedState.get(currentStatusKey),
+        state: currentState,
         statusMessageFormat: getUserGeneralSettings().defaultStatusMessageFormat,
       });
       if (!request.statusFrozen) {
@@ -700,6 +777,43 @@ export async function runOpenRequest(
       failActiveRequest(context.channelId, context.threadId, failureMessage);
     },
     publishFinalText: async (text) => {
+      // If we were rendering status via the streaming API, terminate the
+      // stream first. This converts the live plan card to a static block
+      // (no more spinner), prevents `streaming_state_conflict` on the
+      // subsequent chat.update/delete in publishFinalText, and gives us a
+      // place to record a one-line "done in 12s" summary via a final
+      // plan_update chunk (chunks-mode streams can't accept markdown_text
+      // on stop, so we use an appendStream first if we need a summary).
+      if (useStreaming && streamDiffer && deps.im.stopStatusStream) {
+        try {
+          const currentState = liveParsedState.get(getStatusMessageKey(request));
+          if (currentState && deps.im.appendStatusStream) {
+            const summary = streamDiffer.finalize({
+              state: currentState,
+              workingPath: cwd,
+              startedAt: request.startedAt,
+            });
+            try {
+              await deps.im.appendStatusStream(
+                context.channelId,
+                request.statusMessageTs,
+                [{ type: "plan_update", title: summary }]
+              );
+            } catch (err) {
+              log.debug("Final summary plan_update failed; proceeding to stop", {
+                error: String(err),
+              });
+            }
+          }
+          await deps.im.stopStatusStream(context.channelId, request.statusMessageTs);
+        } catch (err) {
+          log.warn("Slack stopStatusStream failed before final text", {
+            channelId: context.channelId,
+            statusTs: request.statusMessageTs,
+            error: String(err),
+          });
+        }
+      }
       await publishFinalText({
         channelId: context.channelId,
         threadId: context.replyThreadId,
@@ -707,6 +821,49 @@ export async function runOpenRequest(
         text,
       });
     },
+    publishErrorStatus: useStreaming && deps.im.stopStatusStream
+      ? async (errorStatusText: string) => {
+          // Append the error as a final plan_update chunk so the streamed
+          // card surfaces the failure inline, then stop the stream. Chunks-
+          // mode streams can't carry markdown_text on stop, so we can't
+          // pass the error there directly.
+          try {
+            if (deps.im.appendStatusStream) {
+              try {
+                await deps.im.appendStatusStream(
+                  context.channelId,
+                  request.statusMessageTs,
+                  [{ type: "plan_update", title: `Error: ${errorStatusText.split("\n")[0]?.slice(0, 200) ?? ""}` }]
+                );
+              } catch (err) {
+                log.debug("Final error plan_update failed; proceeding to stop", {
+                  error: String(err),
+                });
+              }
+            }
+            await deps.im.stopStatusStream!(context.channelId, request.statusMessageTs);
+          } catch (err) {
+            log.warn("Slack stopStatusStream failed in error path", {
+              channelId: context.channelId,
+              statusTs: request.statusMessageTs,
+              error: String(err),
+            });
+            // Best-effort: still try a plain update so the user sees something.
+            try {
+              await deps.im.updateMessage(
+                context.channelId,
+                request.statusMessageTs,
+                errorStatusText
+              );
+            } catch (updateErr) {
+              log.warn("Fallback chat.update after stopStream failure also failed", {
+                channelId: context.channelId,
+                error: String(updateErr),
+              });
+            }
+          }
+        }
+      : undefined,
     failureLogLabel: "Request failed",
     agentResultDetailId,
     threadKey,
@@ -894,7 +1051,24 @@ export async function runTrackedRequest(
       workingDirectory: workingPath,
     });
     deps.im.cancelPendingUpdates?.(request.channelId, request.statusMessageTs);
-    await deps.im.updateMessage(request.channelId, request.statusMessageTs, errorStatus);
+    if (params.publishErrorStatus) {
+      // Streaming path: caller-supplied closure terminates the live stream
+      // (via chat.stopStream) and posts a new message with the error text,
+      // because chat.update against a streaming message returns
+      // `streaming_state_conflict`.
+      try {
+        await params.publishErrorStatus(errorStatus);
+      } catch (err) {
+        log.warn("publishErrorStatus failed; falling back to chat.update", {
+          channelId: request.channelId,
+          statusTs: request.statusMessageTs,
+          error: String(err),
+        });
+        await deps.im.updateMessage(request.channelId, request.statusMessageTs, errorStatus);
+      }
+    } else {
+      await deps.im.updateMessage(request.channelId, request.statusMessageTs, errorStatus);
+    }
     deps.im.markMessageFinalized?.(request.channelId, request.statusMessageTs);
     onFail(message);
     return { responses: null };

--- a/packages/core/kernel/request-run.ts
+++ b/packages/core/kernel/request-run.ts
@@ -379,6 +379,24 @@ async function startKernelEventStreamWatcher(params: {
 
             if (!statusRateLimited) {
               try {
+                if (request.statusStreamActive && request.statusStreamTs === oldStatusTs && deps.im.stopStatusStream) {
+                  try {
+                    await deps.im.stopStatusStream(request.channelId, oldStatusTs);
+                  } catch (err) {
+                    log.warn("Failed to stop stale stream after question reply", {
+                      channelId: request.channelId,
+                      threadId: request.threadId,
+                      statusTs: oldStatusTs,
+                      error: String(err),
+                    });
+                  }
+                  request.statusStreamActive = false;
+                  request.statusStreamTs = undefined;
+                  updateActiveRequest(request.channelId, request.threadId, {
+                    statusStreamActive: false,
+                    statusStreamTs: undefined,
+                  }, { immediate: true });
+                }
                 await deps.im.deleteMessage(request.channelId, oldStatusTs);
               } catch (err) {
                 log.warn("Failed to delete stale status message after question reply", {
@@ -419,6 +437,8 @@ async function startKernelEventStreamWatcher(params: {
               request.statusMessageTs = newStatusTs;
               updateActiveRequest(request.channelId, request.threadId, {
                 statusMessageTs: newStatusTs,
+                statusStreamActive: false,
+                statusStreamTs: undefined,
               });
               // Move the live-state buffers to the new ts key so the
               // subscription handler and the progress tick keep reading
@@ -556,10 +576,12 @@ export async function runOpenRequest(
 
   const providerLabel = deps.agent.getDisplayNameForSession(sessionId);
 
-  // Streaming-API path is opt-in via env var AND requires the adapter to
-  // implement startStatusStream (currently Slack-only). When unavailable
-  // we silently fall back to the chat.postMessage + chat.update path.
+  // Streaming-API path is opt-in via env var, requires live agent events,
+  // and requires the adapter to implement the stream lifecycle methods
+  // (currently Slack-only). When unavailable we silently fall back to the
+  // chat.postMessage + chat.update path.
   const streamingRequested = isStatusStreamingEnabled()
+    && deps.agent.supportsEventStream
     && typeof deps.im.startStatusStream === "function"
     && typeof deps.im.appendStatusStream === "function";
 
@@ -649,6 +671,10 @@ export async function runOpenRequest(
     statusTs,
     message
   );
+  if (useStreaming && streamingStatusTs) {
+    request.statusStreamActive = true;
+    request.statusStreamTs = streamingStatusTs;
+  }
   session.activeRequest = request;
   saveSession(session);
 
@@ -679,6 +705,54 @@ export async function runOpenRequest(
   // One differ instance per run; keeps last-seen fingerprints so we only
   // send chunks for tools whose shape actually changed.
   const streamDiffer: StatusStreamDiffer | null = useStreaming ? createStatusStreamDiffer() : null;
+
+  async function stopTrackedStatusStream(reason: string, appendChunks?: Array<{ type: "plan_update"; title: string }>): Promise<void> {
+    const streamTs = streamingStatusTs ?? request.statusStreamTs;
+    if (!streamTs || !deps.im.stopStatusStream) {
+      useStreaming = false;
+      streamingStatusTs = undefined;
+      request.statusStreamActive = false;
+      request.statusStreamTs = undefined;
+      updateActiveRequest(context.channelId, context.threadId, {
+        statusStreamActive: false,
+        statusStreamTs: undefined,
+      }, { immediate: true });
+      return;
+    }
+
+    useStreaming = false;
+    streamingStatusTs = undefined;
+    request.statusStreamActive = false;
+    request.statusStreamTs = undefined;
+    updateActiveRequest(context.channelId, context.threadId, {
+      statusStreamActive: false,
+      statusStreamTs: undefined,
+    }, { immediate: true });
+
+    try {
+      if (appendChunks && appendChunks.length > 0 && deps.im.appendStatusStream) {
+        try {
+          await deps.im.appendStatusStream(context.channelId, streamTs, appendChunks);
+        } catch (err) {
+          log.debug("Final stream append failed before stop", {
+            reason,
+            channelId: context.channelId,
+            statusTs: streamTs,
+            error: String(err),
+          });
+        }
+      }
+      await deps.im.stopStatusStream(context.channelId, streamTs);
+    } catch (err) {
+      log.warn("Slack stopStatusStream failed", {
+        reason,
+        channelId: context.channelId,
+        statusTs: streamTs,
+        error: String(err),
+      });
+    }
+  }
+
   const result = await runTrackedRequest({
     deps,
     request,
@@ -724,8 +798,12 @@ export async function runOpenRequest(
           previousStreamingTs: streamingStatusTs,
           newStatusTs: statusTs,
         });
-        useStreaming = false;
-        streamingStatusTs = undefined;
+        if (request.statusStreamActive && request.statusStreamTs === streamingStatusTs) {
+          await stopTrackedStatusStream("status message rotated");
+        } else {
+          useStreaming = false;
+          streamingStatusTs = undefined;
+        }
       }
 
       // Streaming path: diff state -> chunks -> chat.appendStream.
@@ -810,7 +888,11 @@ export async function runOpenRequest(
               updateActiveRequest(
                 context.channelId,
                 context.threadId,
-                { statusMessageTs: replacementStatusTs },
+                {
+                  statusMessageTs: replacementStatusTs,
+                  statusStreamActive: false,
+                  statusStreamTs: undefined,
+                },
                 { immediate: true }
               );
             }
@@ -847,34 +929,17 @@ export async function runOpenRequest(
       // place to record a one-line "done in 12s" summary via a final
       // plan_update chunk (chunks-mode streams can't accept markdown_text
       // on stop, so we use an appendStream first if we need a summary).
-      if (useStreaming && streamDiffer && deps.im.stopStatusStream) {
-        try {
-          const currentState = liveParsedState.get(getStatusMessageKey(request));
-          if (currentState && deps.im.appendStatusStream) {
-            const summary = streamDiffer.finalize({
-              state: currentState,
-              workingPath: cwd,
-              startedAt: request.startedAt,
-            });
-            try {
-              await deps.im.appendStatusStream(
-                context.channelId,
-                request.statusMessageTs,
-                [{ type: "plan_update", title: summary }]
-              );
-            } catch (err) {
-              log.debug("Final summary plan_update failed; proceeding to stop", {
-                error: String(err),
-              });
-            }
-          }
-          await deps.im.stopStatusStream(context.channelId, request.statusMessageTs);
-        } catch (err) {
-          log.warn("Slack stopStatusStream failed before final text", {
-            channelId: context.channelId,
-            statusTs: request.statusMessageTs,
-            error: String(err),
+      if ((useStreaming || request.statusStreamActive) && streamDiffer && deps.im.stopStatusStream) {
+        const currentState = liveParsedState.get(getStatusMessageKey(request));
+        if (currentState) {
+          const summary = streamDiffer.finalize({
+            state: currentState,
+            workingPath: cwd,
+            startedAt: request.startedAt,
           });
+          await stopTrackedStatusStream("final text", [{ type: "plan_update", title: summary }]);
+        } else {
+          await stopTrackedStatusStream("final text");
         }
       }
       await publishFinalText({
@@ -886,25 +951,18 @@ export async function runOpenRequest(
     },
     publishErrorStatus: useStreaming && deps.im.stopStatusStream
       ? async (errorStatusText: string) => {
+          if (!useStreaming && !request.statusStreamActive && !request.statusStreamTs) {
+            await deps.im.updateMessage(context.channelId, request.statusMessageTs, errorStatusText);
+            return;
+          }
           // Append the error as a final plan_update chunk so the streamed
           // card surfaces the failure inline, then stop the stream. Chunks-
           // mode streams can't carry markdown_text on stop, so we can't
           // pass the error there directly.
           try {
-            if (deps.im.appendStatusStream) {
-              try {
-                await deps.im.appendStatusStream(
-                  context.channelId,
-                  request.statusMessageTs,
-                  [{ type: "plan_update", title: `Error: ${errorStatusText.split("\n")[0]?.slice(0, 200) ?? ""}` }]
-                );
-              } catch (err) {
-                log.debug("Final error plan_update failed; proceeding to stop", {
-                  error: String(err),
-                });
-              }
-            }
-            await deps.im.stopStatusStream!(context.channelId, request.statusMessageTs);
+            await stopTrackedStatusStream("error status", [
+              { type: "plan_update", title: `Error: ${errorStatusText.split("\n")[0]?.slice(0, 200) ?? ""}` },
+            ]);
           } catch (err) {
             log.warn("Slack stopStatusStream failed in error path", {
               channelId: context.channelId,
@@ -1039,14 +1097,13 @@ export async function runTrackedRequest(
     request.state = "completed";
     request.statusFrozen = true;
 
-    liveEventHistory.delete(getStatusMessageKey(request));
-    liveParsedState.delete(getStatusMessageKey(request));
-
     if (result.type === "stop") {
       const fallbackText = request.currentText?.trim();
       const safeFallback = isPromptEcho(fallbackText, request.prompt) ? undefined : fallbackText;
       const finalText = safeFallback || "_Done_";
       await publishFinalText(finalText);
+      liveEventHistory.delete(getStatusMessageKey(request));
+      liveParsedState.delete(getStatusMessageKey(request));
       tryCompleteAgentResult({
         detailId: agentResultDetailId,
         resultText: finalText,
@@ -1078,6 +1135,8 @@ export async function runTrackedRequest(
     const safeFallback = isPromptEcho(rawFallback, request.prompt) ? undefined : rawFallback;
     const finalText = builtText ?? (safeFallback || "_Done_");
     await publishFinalText(finalText);
+    liveEventHistory.delete(getStatusMessageKey(request));
+    liveParsedState.delete(getStatusMessageKey(request));
     tryCompleteAgentResult({
       detailId: agentResultDetailId,
       resultText: finalText,
@@ -1100,9 +1159,6 @@ export async function runTrackedRequest(
 
     request.state = "failed";
     request.error = message;
-
-    liveEventHistory.delete(getStatusMessageKey(request));
-    liveParsedState.delete(getStatusMessageKey(request));
 
     const errorStatus = `Error: ${message}\n_${suggestion}_`;
     tryFailAgentResult({
@@ -1133,6 +1189,8 @@ export async function runTrackedRequest(
       await deps.im.updateMessage(request.channelId, request.statusMessageTs, errorStatus);
     }
     deps.im.markMessageFinalized?.(request.channelId, request.statusMessageTs);
+    liveEventHistory.delete(getStatusMessageKey(request));
+    liveParsedState.delete(getStatusMessageKey(request));
     onFail(message);
     return { responses: null };
   } finally {

--- a/packages/core/kernel/request-run.ts
+++ b/packages/core/kernel/request-run.ts
@@ -568,6 +568,11 @@ export async function runOpenRequest(
   // sendMessage at startup or if a status rotation later replaces the TS
   // with a chat.postMessage-issued one.
   let useStreaming = false;
+  // The TS that we actually started a stream against. Used to detect
+  // status-message rotation (post-question / 429-fallback), which posts a
+  // brand-new chat.postMessage message — appendStream against that TS
+  // would fail with `message_not_in_streaming_state`.
+  let streamingStatusTs: string | undefined;
 
   let initialStatusTs: string | undefined;
   try {
@@ -595,6 +600,7 @@ export async function runOpenRequest(
       }
       if (initialStatusTs) {
         useStreaming = true;
+        streamingStatusTs = initialStatusTs;
       } else {
         // Adapter returned undefined (e.g. resolveWorkspaceAuth couldn't
         // produce a team id). Fall back to plain chat.postMessage instead
@@ -703,6 +709,24 @@ export async function runOpenRequest(
       statusTs = request.statusMessageTs;
       const currentStatusKey = getStatusMessageKey(request);
       const currentState = liveParsedState.get(currentStatusKey);
+
+      // If a status-message rotation replaced our stream TS with a fresh
+      // chat.postMessage TS (happens after a question.replied flow, or
+      // after a 429-fallback elsewhere in this tick), the streaming-API
+      // path no longer applies: appendStream against the new TS would
+      // fail with `message_not_in_streaming_state`. Downgrade to plain
+      // chat.update for the rest of the run. We do NOT try to re-start a
+      // fresh stream — that would post a second message in the thread for
+      // the same turn, which is more confusing than a continuation card.
+      if (useStreaming && streamingStatusTs && statusTs !== streamingStatusTs) {
+        log.info("Status TS rotated; disabling Slack streaming for the rest of the run", {
+          channelId: context.channelId,
+          previousStreamingTs: streamingStatusTs,
+          newStatusTs: statusTs,
+        });
+        useStreaming = false;
+        streamingStatusTs = undefined;
+      }
 
       // Streaming path: diff state -> chunks -> chat.appendStream.
       // Falls back to plain-text chat.update when the differ produced no

--- a/packages/core/kernel/runtime-facade.ts
+++ b/packages/core/kernel/runtime-facade.ts
@@ -241,8 +241,8 @@ export class KernelRuntimeFacade {
     });
   }
 
-  async recoverPendingRequests(): Promise<void> {
-    await recoverPendingRequestsInternal(this.runtimeDeps.im, this.deps.platform);
+  async recoverPendingRequests(options?: { startedBeforeMs?: number }): Promise<void> {
+    await recoverPendingRequestsInternal(this.runtimeDeps.im, this.deps.platform, options);
   }
 
   private async handleUserMessageInternal(context: RuntimeRequestContext, text: string): Promise<void> {

--- a/packages/core/kernel/stop-command.ts
+++ b/packages/core/kernel/stop-command.ts
@@ -49,7 +49,31 @@ export async function handleStopCommand(params: {
   request.state = "failed";
   request.error = "Stopped by user";
 
-  await deps.im.deleteMessage(request.channelId, request.statusMessageTs);
+  if (request.statusStreamActive && request.statusStreamTs && deps.im.stopStatusStream) {
+    try {
+      await deps.im.stopStatusStream(request.channelId, request.statusStreamTs);
+    } catch (err) {
+      log.warn("Failed to stop active status stream on stop command", {
+        channelId: request.channelId,
+        threadId: request.threadId,
+        statusTs: request.statusStreamTs,
+        error: String(err),
+      });
+    }
+    request.statusStreamActive = false;
+    request.statusStreamTs = undefined;
+  }
+
+  try {
+    await deps.im.deleteMessage(request.channelId, request.statusMessageTs);
+  } catch (err) {
+    log.warn("Failed to delete status message on stop command", {
+      channelId: request.channelId,
+      threadId: request.threadId,
+      statusTs: request.statusMessageTs,
+      error: String(err),
+    });
+  }
 
   failActiveRequest(channelId, threadId, "Stopped by user");
   return true;

--- a/packages/core/pr-tracker/scheduler.ts
+++ b/packages/core/pr-tracker/scheduler.ts
@@ -24,10 +24,10 @@ import {
   buildFinalResponseText,
   categorizeRuntimeError,
 } from "@/core/runtime/helpers";
+import { sendSlackChannelMessage } from "@/core/runtime/slack-senders";
 import { buildSessionEnvironment, prepareSessionWorkspace } from "@/core/session";
 import { sendChannelMessage as sendDiscordChannelMessage } from "@/ims/discord/client";
 import { sendChannelMessage as sendLarkChannelMessage } from "@/ims/lark/client";
-import { sendChannelMessage as sendSlackChannelMessage } from "@/ims/slack/client";
 import {
   type AgentProviderId,
 } from "@/shared/agent-provider";

--- a/packages/core/runtime.ts
+++ b/packages/core/runtime.ts
@@ -7,6 +7,7 @@ export function createCoreRuntime(deps: RuntimeDeps) {
       facade.handleInboundEvent(event),
     handleButtonSelection: (params: Parameters<KernelRuntimeFacade["handleButtonSelection"]>[0]) =>
       facade.handleButtonSelection(params),
-    recoverPendingRequests: () => facade.recoverPendingRequests(),
+    recoverPendingRequests: (options?: Parameters<KernelRuntimeFacade["recoverPendingRequests"]>[0]) =>
+      facade.recoverPendingRequests(options),
   };
 }

--- a/packages/core/runtime/slack-senders.ts
+++ b/packages/core/runtime/slack-senders.ts
@@ -1,0 +1,18 @@
+export async function sendSlackChannelMessage(
+  channelId: string,
+  text: string,
+  processorId?: string
+): Promise<string | undefined> {
+  const { sendChannelMessage } = await import("@/ims/slack/client");
+  return sendChannelMessage(channelId, text, processorId);
+}
+
+export async function sendSlackThreadMessage(
+  channelId: string,
+  threadId: string,
+  text: string,
+  processorId?: string
+): Promise<string | undefined> {
+  const { sendMessage } = await import("@/ims/slack/client");
+  return sendMessage(channelId, threadId, text, processorId);
+}

--- a/packages/core/tasks/scheduler.ts
+++ b/packages/core/tasks/scheduler.ts
@@ -32,13 +32,13 @@ import {
 } from "@/config/local/sessions";
 import { buildMessageOptions } from "@/core/runtime/message-options";
 import { buildFinalResponseText, categorizeRuntimeError } from "@/core/runtime/helpers";
+import {
+  sendSlackChannelMessage,
+  sendSlackThreadMessage,
+} from "@/core/runtime/slack-senders";
 import { buildSessionEnvironment, prepareSessionWorkspace } from "@/core/session";
 import { sendChannelMessage as sendDiscordChannelMessage } from "@/ims/discord/client";
 import { sendChannelMessage as sendLarkChannelMessage } from "@/ims/lark/client";
-import {
-  sendChannelMessage as sendSlackChannelMessage,
-  sendMessage as sendSlackThreadMessage,
-} from "@/ims/slack/client";
 import { type AgentProviderId, isAgentProviderId } from "@/shared/agent-provider";
 import { log } from "@/utils";
 

--- a/packages/core/test/recovery.test.ts
+++ b/packages/core/test/recovery.test.ts
@@ -65,4 +65,36 @@ describe("recoverPendingRequests", () => {
     clearActiveRequest(channelId, threadId);
     deleteSession(channelId, threadId);
   });
+
+  it("does not recover requests created after the startup cutoff", async () => {
+    const channelId = "CR-3";
+    const threadId = "TR-3";
+    const statusTs = "323.45";
+
+    const active = createActiveRequest("ses-r3", channelId, threadId, threadId, statusTs, "hello");
+    active.startedAt = Date.now();
+
+    saveSession({
+      sessionId: "ses-r3",
+      channelId,
+      threadId,
+      workingDirectory: "/tmp",
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+      activeRequest: active,
+    });
+
+    const updates: string[] = [];
+    await recoverPendingRequests({
+      updateMessage: async (_channelId: string, _ts: string, text: string) => {
+        updates.push(text);
+      },
+    } as any, undefined, { startedBeforeMs: active.startedAt - 1 });
+
+    expect(updates).toEqual([]);
+    expect(loadSession(channelId, threadId)?.activeRequest?.state).toBe("processing");
+
+    clearActiveRequest(channelId, threadId);
+    deleteSession(channelId, threadId);
+  });
 });

--- a/packages/core/test/recovery.test.ts
+++ b/packages/core/test/recovery.test.ts
@@ -34,6 +34,48 @@ describe("recoverPendingRequests", () => {
     deleteSession(channelId, threadId);
   });
 
+  it("stops persisted status stream before updating recovered request", async () => {
+    const channelId = "CR-STREAM";
+    const threadId = "TR-STREAM";
+    const streamTs = "stream-123.45";
+
+    const active = createActiveRequest("ses-stream", channelId, threadId, threadId, streamTs, "hello");
+    active.startedAt = Date.now() - 60_000;
+    active.statusStreamActive = true;
+    active.statusStreamTs = streamTs;
+
+    saveSession({
+      sessionId: "ses-stream",
+      channelId,
+      threadId,
+      workingDirectory: "/tmp",
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+      activeRequest: active,
+    });
+
+    const events: string[] = [];
+    const stopped = new Set<string>();
+    await recoverPendingRequests({
+      stopStatusStream: async (_channelId: string, ts: string) => {
+        events.push(`stop:${ts}`);
+        stopped.add(ts);
+      },
+      updateMessage: async (_channelId: string, ts: string, text: string) => {
+        events.push(`update:${ts}:${text}`);
+        if (!stopped.has(ts)) {
+          throw new Error("streaming_state_conflict");
+        }
+      },
+    } as any);
+
+    expect(events[0]).toBe(`stop:${streamTs}`);
+    expect(events[1]).toBe(`update:${streamTs}:_Bot restarted - please resend your message_`);
+    expect(loadSession(channelId, threadId)?.activeRequest).toBeUndefined();
+
+    deleteSession(channelId, threadId);
+  });
+
   it("clears stale request without update", async () => {
     const channelId = "CR-2";
     const threadId = "TR-2";

--- a/packages/core/test/runtime-resilience-e2e.test.ts
+++ b/packages/core/test/runtime-resilience-e2e.test.ts
@@ -420,6 +420,71 @@ describe("core runtime resilience e2e", () => {
     deleteSession(channelId, threadId);
   });
 
+  it("keeps persisted stream state active when stopStream fails during finalization", async () => {
+    process.env.ODE_SLACK_STATUS_STREAMING = "1";
+    const streamTs = "stream-stop-fail";
+    const logs = {
+      sends: [] as Array<{ channelId: string; threadId: string; text: string; messageTs: string }>,
+      appends: [] as Array<{ channelId: string; messageTs: string; chunks: unknown[] }>,
+      stops: [] as Array<{ channelId: string; messageTs: string }>,
+      deletes: [] as Array<{ channelId: string; messageTs: string }>,
+    };
+    let nextTs = 0;
+    const im: IMAdapter = {
+      sendMessage: async (channelId, threadId, text) => {
+        nextTs += 1;
+        const messageTs = `ts-${nextTs}`;
+        logs.sends.push({ channelId, threadId, text, messageTs });
+        return messageTs;
+      },
+      updateMessage: async () => {},
+      deleteMessage: async (channelId, messageTs) => {
+        logs.deletes.push({ channelId, messageTs });
+        if (messageTs === streamTs) {
+          throw new Error("streaming_state_conflict");
+        }
+      },
+      fetchThreadHistory: async () => null,
+      buildAgentContext: async () => ({ slack: { channelId: "C", threadId: "T", userId: "U" } }),
+      startStatusStream: async () => streamTs,
+      appendStatusStream: async (channelId, messageTs, chunks) => {
+        logs.appends.push({ channelId, messageTs, chunks });
+      },
+      stopStatusStream: async (channelId, messageTs) => {
+        logs.stops.push({ channelId, messageTs });
+        throw new Error("temporarily_unavailable");
+      },
+    };
+    const { agent } = createFakeAgent({
+      supportsEventStream: true,
+      responseText: "finished despite stop failure",
+    });
+    const runtime = createCoreRuntime({ platform: "slack", im, agent });
+    const channelId = uniqueId("CE2E-STREAM-STOP-FAIL");
+    const threadId = uniqueId("TE2E-STREAM-STOP-FAIL");
+
+    await runtime.handleInboundEvent(toInboundEvent({
+      channelId,
+      threadId,
+      userId: "UE2E-stream-stop-fail",
+      messageId: uniqueId("ME2E-stream-stop-fail"),
+      text: "trigger streaming stop failure",
+    }));
+
+    await waitFor(
+      () => logs.sends.some((entry) => entry.text === "finished despite stop failure"),
+      5000
+    );
+
+    const savedRequest = loadSession(channelId, threadId)?.activeRequest;
+    expect(logs.stops).toEqual([{ channelId, messageTs: streamTs }]);
+    expect(logs.deletes).toContainEqual({ channelId, messageTs: streamTs });
+    expect(savedRequest?.statusStreamActive).toBe(true);
+    expect(savedRequest?.statusStreamTs).toBe(streamTs);
+
+    deleteSession(channelId, threadId);
+  });
+
   it("does not crash when the initial status send throws", async () => {
     const logs = { sends: [], updates: [] } as {
       sends: Array<{ channelId: string; threadId: string; text: string; messageTs: string }>;

--- a/packages/core/test/runtime-resilience-e2e.test.ts
+++ b/packages/core/test/runtime-resilience-e2e.test.ts
@@ -118,6 +118,7 @@ function createFakeAgent(params?: {
   streamStopAfterMs?: number;
   delayMs?: number;
   responseText?: string;
+  errorMessage?: string;
 }) {
   const sentPrompts: string[] = [];
   const supportsEventStream = Boolean(params?.supportsEventStream);
@@ -129,6 +130,9 @@ function createFakeAgent(params?: {
     getOrCreateSession: async () => ({ sessionId: "session-resilience", created: true }),
     sendMessage: async (_channelId, _sessionId, message) => {
       sentPrompts.push(message);
+      if (params?.errorMessage) {
+        throw new Error(params.errorMessage);
+      }
       if (params?.delayMs) {
         await sleep(params.delayMs);
       }
@@ -191,6 +195,7 @@ function toInboundEvent(params: {
 describe("core runtime resilience e2e", () => {
   const previousCi = process.env.CI;
   const previousInboxDbFile = process.env.ODE_INBOX_DB_FILE;
+  const previousSlackStatusStreaming = process.env.ODE_SLACK_STATUS_STREAMING;
 
   beforeAll(() => {
     process.env.CI = "1";
@@ -211,9 +216,14 @@ describe("core runtime resilience e2e", () => {
     fs.rmSync(tempInboxDir, { recursive: true, force: true });
     if (previousCi === undefined) {
       delete process.env.CI;
-      return;
+    } else {
+      process.env.CI = previousCi;
     }
-    process.env.CI = previousCi;
+    if (previousSlackStatusStreaming === undefined) {
+      delete process.env.ODE_SLACK_STATUS_STREAMING;
+    } else {
+      process.env.ODE_SLACK_STATUS_STREAMING = previousSlackStatusStreaming;
+    }
   });
 
   it("falls back to sending final message when status updates are rate-limited", async () => {
@@ -339,6 +349,75 @@ describe("core runtime resilience e2e", () => {
     expect(logs.sends.some((entry) => entry.text === "_Done_")).toBe(true);
 
     deleteSession(context.channelId, context.threadId);
+  });
+
+  it("preserves full error status after stopping an active status stream", async () => {
+    process.env.ODE_SLACK_STATUS_STREAMING = "1";
+    const logs = {
+      sends: [] as Array<{ channelId: string; threadId: string; text: string; messageTs: string }>,
+      updates: [] as Array<{ channelId: string; messageTs: string; text: string }>,
+      appends: [] as Array<{ channelId: string; messageTs: string; chunks: unknown[] }>,
+      stops: [] as Array<{ channelId: string; messageTs: string }>,
+      events: [] as string[],
+    };
+    let nextTs = 0;
+    const streamTs = "stream-1";
+    const im: IMAdapter = {
+      sendMessage: async (channelId, threadId, text) => {
+        nextTs += 1;
+        const messageTs = `ts-${nextTs}`;
+        logs.events.push(`send:${text}`);
+        logs.sends.push({ channelId, threadId, text, messageTs });
+        return messageTs;
+      },
+      updateMessage: async (channelId, messageTs, text) => {
+        logs.updates.push({ channelId, messageTs, text });
+        if (messageTs === streamTs) {
+          throw new Error("streaming_state_conflict");
+        }
+      },
+      deleteMessage: async () => {},
+      fetchThreadHistory: async () => null,
+      buildAgentContext: async () => ({ slack: { channelId: "C", threadId: "T", userId: "U" } }),
+      startStatusStream: async () => streamTs,
+      appendStatusStream: async (channelId, messageTs, chunks) => {
+        logs.appends.push({ channelId, messageTs, chunks });
+      },
+      stopStatusStream: async (channelId, messageTs) => {
+        logs.events.push(`stop:${messageTs}`);
+        logs.stops.push({ channelId, messageTs });
+      },
+    };
+    const { agent } = createFakeAgent({
+      supportsEventStream: true,
+      errorMessage: "tool exploded with full details",
+    });
+    const runtime = createCoreRuntime({ platform: "slack", im, agent });
+    const channelId = uniqueId("CE2E-STREAM-ERR");
+    const threadId = uniqueId("TE2E-STREAM-ERR");
+
+    await runtime.handleInboundEvent(toInboundEvent({
+      channelId,
+      threadId,
+      userId: "UE2E-stream-err",
+      messageId: uniqueId("ME2E-stream-err"),
+      text: "trigger streaming error",
+    }));
+
+    await waitFor(
+      () => logs.sends.some((entry) => entry.text.includes("Error: tool exploded with full details")),
+      5000
+    );
+
+    const errorMessage = logs.sends.find((entry) => entry.text.includes("Error: tool exploded with full details"));
+    expect(errorMessage?.text).toContain("_If this persists, try starting a new thread or contact support._");
+    expect(logs.stops).toEqual([{ channelId, messageTs: streamTs }]);
+    expect(logs.updates.some((entry) => entry.messageTs === streamTs)).toBe(false);
+    expect(logs.events.indexOf(`stop:${streamTs}`)).toBeLessThan(
+      logs.events.findIndex((entry) => entry.startsWith("send:Error: tool exploded"))
+    );
+
+    deleteSession(channelId, threadId);
   });
 
   it("does not crash when the initial status send throws", async () => {

--- a/packages/core/test/stop-command.test.ts
+++ b/packages/core/test/stop-command.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "bun:test";
+import { createActiveRequest, deleteSession, loadSession, saveSession } from "@/config/local/sessions";
+import { handleStopCommand } from "../kernel/stop-command";
+import type { AgentAdapter, IMAdapter } from "@/core/types";
+
+function createAgent(): AgentAdapter {
+  return {
+    supportsEventStream: false,
+    getProviderForSession: () => "opencode",
+    getDisplayNameForSession: () => "FakeAgent",
+    getOrCreateSession: async () => ({ sessionId: "session-stop", created: false }),
+    sendMessage: async () => [],
+    abortSession: async () => {},
+    ensureSession: async () => {},
+    subscribeToSession: () => () => {},
+    replyToQuestion: async () => {},
+    normalizeQuestions: () => [],
+  };
+}
+
+describe("handleStopCommand", () => {
+  it("stops an active status stream before deleting the status message", async () => {
+    const channelId = `C-stop-${process.pid}-${Date.now()}`;
+    const threadId = `T-stop-${process.pid}-${Date.now()}`;
+    const statusTs = "123.456";
+    const activeRequest = createActiveRequest("session-stop", channelId, threadId, threadId, statusTs, "hello");
+    activeRequest.statusStreamActive = true;
+    activeRequest.statusStreamTs = statusTs;
+
+    saveSession({
+      sessionId: "session-stop",
+      channelId,
+      threadId,
+      workingDirectory: "/tmp",
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+      activeRequest,
+    }, { immediate: true });
+
+    const calls: string[] = [];
+    const im: IMAdapter = {
+      sendMessage: async () => "unused",
+      updateMessage: async () => undefined,
+      stopStatusStream: async (_channelId, messageTs) => {
+        calls.push(`stop:${messageTs}`);
+      },
+      deleteMessage: async (_channelId, messageTs) => {
+        calls.push(`delete:${messageTs}`);
+      },
+      fetchThreadHistory: async () => null,
+      buildAgentContext: async () => ({}),
+    };
+
+    await handleStopCommand({
+      deps: { agent: createAgent(), im },
+      channelId,
+      threadId,
+    });
+
+    expect(calls).toEqual([`stop:${statusTs}`, `delete:${statusTs}`]);
+    const saved = loadSession(channelId, threadId)?.activeRequest;
+    expect(saved?.state).toBe("failed");
+    expect(saved?.statusStreamActive).toBe(false);
+
+    deleteSession(channelId, threadId);
+  });
+});

--- a/packages/core/types.ts
+++ b/packages/core/types.ts
@@ -41,9 +41,60 @@ export type AgentStatusMessageParams = {
   statusMessageFormat: StatusMessageFormat;
 };
 
+/**
+ * Chunk emitted by the status-stream renderer. Mirrors the shape of Slack's
+ * `chat.appendStream` `chunks` payload, but kept platform-agnostic so other
+ * IM adapters can choose their own rendering (or ignore it).
+ *
+ * - `task_update`: one tool / step card. `id` is a stable per-tool key, status
+ *   transitions from `pending` → `in_progress` → `complete`/`error`.
+ * - `plan_update`: rename the surrounding plan container (e.g. session title
+ *   or phase label).
+ * - `markdown_text`: free-form markdown chunk appended to the stream body.
+ */
+export type StatusStreamChunk =
+  | {
+      type: "task_update";
+      id: string;
+      title: string;
+      status: "pending" | "in_progress" | "complete" | "error";
+      details?: string;
+      output?: string;
+      sources?: Array<{ type: "url"; text: string; url: string }>;
+    }
+  | { type: "plan_update"; title: string }
+  | { type: "markdown_text"; text: string };
+
 export interface IMAdapter {
   maxEditableMessageChars?: number;
   sendMessage(channelId: string, threadId: string, text: string): Promise<string | undefined>;
+  /**
+   * Optional. When implemented, the runtime uses Slack's (or equivalent)
+   * Streaming API to render live status updates — `task_update` /
+   * `plan_update` chunks render as animated task cards instead of repeated
+   * `chat.update` calls against a plain-text message.
+   *
+   * Channel (non-DM) streams on Slack require the requesting user's id and
+   * team id; pass them on `startStatusStream` and the adapter forwards.
+   *
+   * Lifecycle: `startStatusStream` once → many `appendStatusStream` calls →
+   * one `stopStatusStream` (or fall back to `updateMessage` if the stream
+   * was never started for this message TS).
+   *
+   * Slack-specific quirk: the stream is mode-locked to "chunks" at start;
+   * `appendStatusStream` / `stopStatusStream` cannot mix in plain markdown.
+   */
+  startStatusStream?(
+    channelId: string,
+    threadId: string,
+    opts: { recipientUserId: string; seedPlanTitle?: string }
+  ): Promise<string | undefined>;
+  appendStatusStream?(
+    channelId: string,
+    messageTs: string,
+    chunks: StatusStreamChunk[]
+  ): Promise<void>;
+  stopStatusStream?(channelId: string, messageTs: string): Promise<void>;
   /**
    * Optional. When present, the runtime calls this for ask_user-style prompts
    * so the IM can render interactive UI (e.g. Slack buttons) when the options

--- a/packages/core/web/http.ts
+++ b/packages/core/web/http.ts
@@ -3,6 +3,7 @@ export type JsonResponse = {
   error?: string;
   version?: string;
   config?: unknown;
+  dev?: unknown;
   workspace?: unknown;
   result?: unknown;
 };

--- a/packages/core/web/routes/config.ts
+++ b/packages/core/web/routes/config.ts
@@ -5,6 +5,11 @@ import { jsonResponse, runRoute } from "../http";
 import { validateWorkspaceConfig } from "../config-validation";
 import { APP_VERSION } from "../version";
 
+function isDevEnabled(): boolean {
+  const value = process.env.ODE_DEV?.trim().toLowerCase();
+  return value === "1" || value === "true" || value === "yes" || value === "on";
+}
+
 export function registerConfigRoutes(app: Elysia): void {
   app.get("/api/config", async () => {
     const config = await readLocalSettings();
@@ -12,6 +17,7 @@ export function registerConfigRoutes(app: Elysia): void {
       ok: true,
       config: config as typeof defaultDashboardConfig,
       version: APP_VERSION,
+      dev: { enabled: isDevEnabled() },
     });
   });
 
@@ -31,6 +37,7 @@ export function registerConfigRoutes(app: Elysia): void {
         ok: true,
         config: sanitized as typeof defaultDashboardConfig,
         version: APP_VERSION,
+        dev: { enabled: isDevEnabled() },
       }),
       { fallbackMessage: "Invalid payload", status: 400 }
     );

--- a/packages/ims/discord/client.ts
+++ b/packages/ims/discord/client.ts
@@ -673,6 +673,6 @@ const discordRuntimeController = createRuntimeController({
   },
 });
 
-export async function recoverPendingRequests(): Promise<void> {
-  await discordRecoveryRuntime.recoverPendingRequests();
+export async function recoverPendingRequests(options?: { startedBeforeMs?: number }): Promise<void> {
+  await discordRecoveryRuntime.recoverPendingRequests(options);
 }

--- a/packages/ims/discord/client.ts
+++ b/packages/ims/discord/client.ts
@@ -39,6 +39,7 @@ import {
   formatThreadNameFromBranch,
   formatThreadNameFromStatusTitle,
   isTopLevelMessage,
+  markdownToDiscord,
   splitForDiscord,
 } from "@/ims/discord/utils/message-utils";
 import {
@@ -186,7 +187,8 @@ async function sendMessage(
   try {
     const resolvedProcessorId = processorId || getRememberedThreadProcessor(channelId, threadId);
     const channel = await resolveTextChannel(threadId, resolvedProcessorId);
-    const chunks = splitForDiscord(text, DISCORD_MESSAGE_LIMIT);
+    const formattedText = markdownToDiscord(text);
+    const chunks = splitForDiscord(formattedText, DISCORD_MESSAGE_LIMIT);
     let firstId: string | undefined;
     for (let index = 0; index < chunks.length; index += 1) {
       const chunk = chunks[index] ?? "";
@@ -223,7 +225,8 @@ export async function sendChannelMessage(
 ): Promise<string | undefined> {
   try {
     const channel = await resolveTextChannel(channelId, processorId);
-    const chunks = splitForDiscord(text, DISCORD_MESSAGE_LIMIT);
+    const formattedText = markdownToDiscord(text);
+    const chunks = splitForDiscord(formattedText, DISCORD_MESSAGE_LIMIT);
     let firstId: string | undefined;
     for (let index = 0; index < chunks.length; index += 1) {
       const chunk = chunks[index] ?? "";
@@ -262,7 +265,8 @@ async function updateMessage(
     }
     const resolvedProcessorId = processorId || getRememberedThreadProcessor(channelId, threadId);
     const channel = await resolveTextChannel(threadId, resolvedProcessorId);
-    const content = splitForDiscord(text, DISCORD_MESSAGE_LIMIT)[0] ?? text;
+    const formattedText = markdownToDiscord(text);
+    const content = splitForDiscord(formattedText, DISCORD_MESSAGE_LIMIT)[0] ?? formattedText;
     let lastRateLimitError: unknown;
 
     for (let attempt = 1; attempt <= DISCORD_UPDATE_MAX_ATTEMPTS; attempt += 1) {

--- a/packages/ims/discord/message-utils.test.ts
+++ b/packages/ims/discord/message-utils.test.ts
@@ -4,6 +4,7 @@ import {
   cleanBotMention,
   formatThreadNameFromBranch,
   formatThreadNameFromStatusTitle,
+  markdownToDiscord,
   splitForDiscord,
 } from "@/ims/discord/utils/message-utils";
 import { isDiscordRateLimitErrorMessage, parseDiscordRetryAfterMs } from "@/ims/discord/utils/rate-limit";
@@ -12,6 +13,10 @@ describe("discord message utilities", () => {
   it("splits oversized content by limit", () => {
     const chunks = splitForDiscord("abcdef", 2);
     expect(chunks).toEqual(["ab", "cd", "ef"]);
+  });
+
+  it("keeps standard markdown unchanged for Discord", () => {
+    expect(markdownToDiscord("**bold** _italic_ `code`")).toBe("**bold** _italic_ `code`");
   });
 
   it("normalizes mention and thread names", () => {

--- a/packages/ims/discord/utils/index.ts
+++ b/packages/ims/discord/utils/index.ts
@@ -1,4 +1,5 @@
 export {
+  markdownToDiscord,
   splitForDiscord,
   cleanBotMention,
   isTopLevelMessage,

--- a/packages/ims/discord/utils/message-utils.ts
+++ b/packages/ims/discord/utils/message-utils.ts
@@ -1,3 +1,7 @@
+export function markdownToDiscord(text: string): string {
+  return text;
+}
+
 export function splitForDiscord(text: string, limit: number): string[] {
   if (text.length <= limit) return [text];
   const chunks: string[] = [];

--- a/packages/ims/index.ts
+++ b/packages/ims/index.ts
@@ -12,8 +12,8 @@ import { recoverPendingRequests as recoverSlackPendingRequests } from "./slack/c
 import { recoverPendingRequests as recoverDiscordPendingRequests } from "./discord/client";
 import { recoverPendingRequests as recoverLarkPendingRequests } from "./lark/client";
 
-export async function recoverPendingRequestsAcrossPlatforms(): Promise<void> {
-  await recoverSlackPendingRequests();
-  await recoverDiscordPendingRequests();
-  await recoverLarkPendingRequests();
+export async function recoverPendingRequestsAcrossPlatforms(options?: { startedBeforeMs?: number }): Promise<void> {
+  await recoverSlackPendingRequests(options);
+  await recoverDiscordPendingRequests(options);
+  await recoverLarkPendingRequests(options);
 }

--- a/packages/ims/index.ts
+++ b/packages/ims/index.ts
@@ -1,4 +1,4 @@
-export * from "./slack";
+export { uploadSlackFile, getSlackThreadMessages, addSlackReaction, postSlackQuestion } from "./slack/api";
 export * from "./discord";
 export * from "./lark";
 export {
@@ -8,11 +8,10 @@ export {
   defaultDumpPath as defaultDeliveryStatsDumpPath,
 } from "./shared/delivery-stats";
 
-import { recoverPendingRequests as recoverSlackPendingRequests } from "./slack/client";
-import { recoverPendingRequests as recoverDiscordPendingRequests } from "./discord/client";
-import { recoverPendingRequests as recoverLarkPendingRequests } from "./lark/client";
-
 export async function recoverPendingRequestsAcrossPlatforms(options?: { startedBeforeMs?: number }): Promise<void> {
+  const { recoverPendingRequests: recoverSlackPendingRequests } = await import("./slack/client");
+  const { recoverPendingRequests: recoverDiscordPendingRequests } = await import("./discord/client");
+  const { recoverPendingRequests: recoverLarkPendingRequests } = await import("./lark/client");
   await recoverSlackPendingRequests(options);
   await recoverDiscordPendingRequests(options);
   await recoverLarkPendingRequests(options);

--- a/packages/ims/lark/client.ts
+++ b/packages/ims/lark/client.ts
@@ -1368,6 +1368,6 @@ const larkRuntimeController = createRuntimeController({
   },
 });
 
-export async function recoverPendingRequests(): Promise<void> {
-  await larkRecoveryRuntime.recoverPendingRequests();
+export async function recoverPendingRequests(options?: { startedBeforeMs?: number }): Promise<void> {
+  await larkRecoveryRuntime.recoverPendingRequests(options);
 }

--- a/packages/ims/slack/api.test.ts
+++ b/packages/ims/slack/api.test.ts
@@ -1,0 +1,68 @@
+import { beforeEach, describe, expect, it, mock } from "bun:test";
+
+const apiCalls: Array<{ method: string; args: Record<string, unknown> }> = [];
+
+mock.module("./client", () => ({
+  getApp: () => ({
+    client: {
+      apiCall: async (method: string, args: Record<string, unknown>) => {
+        apiCalls.push({ method, args });
+        return method === "chat.startStream" ? { ts: "111.222" } : {};
+      },
+    },
+  }),
+  getSlackBotToken: () => "xoxb-test",
+}));
+
+describe("Slack streaming API helpers", () => {
+  beforeEach(() => {
+    apiCalls.length = 0;
+  });
+
+  it("uses raw apiCall methods for stream lifecycle operations", async () => {
+    const { appendSlackStream, startSlackStream, stopSlackStream } = await import("./api");
+
+    const ts = await startSlackStream({
+      channelId: "C1",
+      threadId: "1700000000.000001",
+      recipientUserId: "U1",
+      recipientTeamId: "T1",
+      seedPlanTitle: "Working",
+      token: "xoxb-test",
+    });
+    await appendSlackStream({
+      channelId: "C1",
+      messageTs: ts!,
+      chunks: [{ type: "plan_update", title: "Still working" }],
+      token: "xoxb-test",
+    });
+    await stopSlackStream({
+      channelId: "C1",
+      messageTs: ts!,
+      token: "xoxb-test",
+    });
+
+    expect(apiCalls.map((call) => call.method)).toEqual([
+      "chat.startStream",
+      "chat.appendStream",
+      "chat.stopStream",
+    ]);
+    expect(apiCalls[0]?.args).toMatchObject({
+      channel: "C1",
+      thread_ts: "1700000000.000001",
+      recipient_user_id: "U1",
+      recipient_team_id: "T1",
+      token: "xoxb-test",
+    });
+    expect(apiCalls[1]?.args).toMatchObject({
+      channel: "C1",
+      ts: "111.222",
+      token: "xoxb-test",
+    });
+    expect(apiCalls[2]?.args).toMatchObject({
+      channel: "C1",
+      ts: "111.222",
+      token: "xoxb-test",
+    });
+  });
+});

--- a/packages/ims/slack/api.ts
+++ b/packages/ims/slack/api.ts
@@ -362,6 +362,11 @@ function serializeStreamChunk(chunk: StatusStreamChunk): Record<string, unknown>
  *
  * Seeds the stream with a single `plan_update` chunk (using `seedPlanTitle`)
  * so subsequent `appendSlackStream` calls don't trip `streaming_mode_mismatch`.
+ *
+ * `token` is required: the adapter resolves the right bot token (processor-
+ * scoped or channel-scoped) at the call site so append/stop can use the
+ * same identity by passing it explicitly. Mixing tokens within a single
+ * stream lifecycle causes Slack to reject later calls.
  */
 export async function startSlackStream(args: {
   channelId: string;
@@ -369,15 +374,13 @@ export async function startSlackStream(args: {
   recipientUserId: string;
   recipientTeamId: string;
   seedPlanTitle?: string;
+  token: string;
 }): Promise<string | undefined> {
   const channelId = requireString(args.channelId, "channelId");
   const threadId = requireString(args.threadId, "threadId");
   const recipientUserId = requireString(args.recipientUserId, "recipientUserId");
   const recipientTeamId = requireString(args.recipientTeamId, "recipientTeamId");
-  const token = getSlackBotToken(channelId, threadId);
-  if (!token) {
-    throw new Error("No Slack bot token available for channel");
-  }
+  const token = requireString(args.token, "token");
   const client = getApp().client;
   const result = await (client.chat as unknown as {
     startStream: (args: Record<string, unknown>) => Promise<{ ts?: string }>;
@@ -397,19 +400,21 @@ export async function startSlackStream(args: {
  * Append chunks to a running chunks-mode Slack stream message. Does NOT
  * accept a markdown_text body — the API rejects messages that mix the two
  * with `cannot_provide_both_markdown_text_and_chunks`.
+ *
+ * `token` must be the same bot token that started the stream — using a
+ * different workspace's token (e.g. when multiple Slack workspaces are
+ * installed) causes Slack to silently reject the append.
  */
 export async function appendSlackStream(args: {
   channelId: string;
   messageTs: string;
   chunks: StatusStreamChunk[];
+  token: string;
 }): Promise<void> {
   const channelId = requireString(args.channelId, "channelId");
   const messageTs = requireString(args.messageTs, "messageTs");
+  const token = requireString(args.token, "token");
   if (!Array.isArray(args.chunks) || args.chunks.length === 0) return;
-  const token = getSlackBotToken(channelId);
-  if (!token) {
-    throw new Error("No Slack bot token available for channel");
-  }
   const client = getApp().client;
   await (client.chat as unknown as {
     appendStream: (args: Record<string, unknown>) => Promise<unknown>;
@@ -424,18 +429,17 @@ export async function appendSlackStream(args: {
 /**
  * Stop a chunks-mode stream. Cannot pass markdown_text here either — the
  * stream is mode-locked. If you need a final summary line, append a final
- * `plan_update` chunk before calling stop.
+ * `plan_update` chunk before calling stop. `token` must match the start
+ * call's token (see `appendSlackStream`).
  */
 export async function stopSlackStream(args: {
   channelId: string;
   messageTs: string;
+  token: string;
 }): Promise<void> {
   const channelId = requireString(args.channelId, "channelId");
   const messageTs = requireString(args.messageTs, "messageTs");
-  const token = getSlackBotToken(channelId);
-  if (!token) {
-    throw new Error("No Slack bot token available for channel");
-  }
+  const token = requireString(args.token, "token");
   const client = getApp().client;
   await (client.chat as unknown as {
     stopStream: (args: Record<string, unknown>) => Promise<unknown>;

--- a/packages/ims/slack/api.ts
+++ b/packages/ims/slack/api.ts
@@ -1,6 +1,7 @@
 import { basename } from "path";
 import { getApp, getSlackBotToken } from "./client";
 import { hasSimpleOptions } from "@/core/runtime/helpers";
+import type { StatusStreamChunk } from "@/core/types";
 
 // ---------------------------------------------------------------------------
 // Slack IM helper module.
@@ -297,4 +298,150 @@ export async function addSlackReaction(args: {
     name,
   }, token);
   return { status: "reaction_added" };
+}
+
+// ---------------------------------------------------------------------------
+// Streaming status (chat.startStream / chat.appendStream / chat.stopStream)
+//
+// Slack's text-streaming API (Feb 2026, expanded Apr 2026) is purpose-built
+// for AI agents rendering live progress as `task_card` / `plan` blocks.
+// We expose three thin helpers used by the Slack IMAdapter when the
+// `ODE_SLACK_STATUS_STREAMING=1` flag is on.
+//
+// Empirical quirks (the docs lie a bit):
+//   - Channel (non-DM) streams REQUIRE `recipient_user_id` +
+//     `recipient_team_id`. Omitting them yields `missing_recipient_team_id`.
+//   - A stream is locked to either "text" mode or "chunks" mode at
+//     `startStream` time. After that, you cannot mix `markdown_text` and
+//     `chunks` on `appendStream` (returns
+//     `cannot_provide_both_markdown_text_and_chunks`) nor switch modes
+//     (returns `streaming_mode_mismatch`). We always use chunks mode.
+//   - To start in chunks mode you MUST pass `chunks` on `startStream` (a
+//     `plan_update` is a natural opener); a bare/empty `markdown_text` locks
+//     you into text mode forever.
+//   - Per-chunk title/details/output cap = 256 chars (Slack-side).
+//   - `task_display_mode: "plan"` groups task_updates inside a single plan
+//     block; `"individual"` (default) renders each as a standalone card.
+// ---------------------------------------------------------------------------
+
+const STREAM_CHUNK_MAX_CHARS = 256;
+
+function truncateStreamField(value: string | undefined): string | undefined {
+  if (typeof value !== "string") return undefined;
+  if (value.length <= STREAM_CHUNK_MAX_CHARS) return value;
+  return value.slice(0, STREAM_CHUNK_MAX_CHARS - 1) + "…";
+}
+
+function serializeStreamChunk(chunk: StatusStreamChunk): Record<string, unknown> {
+  if (chunk.type === "task_update") {
+    return {
+      type: "task_update",
+      id: chunk.id,
+      title: truncateStreamField(chunk.title) ?? "",
+      status: chunk.status,
+      ...(chunk.details ? { details: truncateStreamField(chunk.details) } : {}),
+      ...(chunk.output ? { output: truncateStreamField(chunk.output) } : {}),
+      ...(chunk.sources && chunk.sources.length > 0 ? { sources: chunk.sources } : {}),
+    };
+  }
+  if (chunk.type === "plan_update") {
+    return { type: "plan_update", title: truncateStreamField(chunk.title) ?? "" };
+  }
+  // markdown_text — only valid in text-mode streams; the kernel currently
+  // never emits these, but we serialize defensively.
+  return { type: "markdown_text", text: chunk.text };
+}
+
+/**
+ * Start a Slack streaming status message in chunks mode.
+ *
+ * Channel (non-DM) streams require recipient identification; we resolve the
+ * team id via `auth.test` on the bot token and accept the requesting user id
+ * from the caller. `task_display_mode: "plan"` is what gives us the unified
+ * "thinking steps" card with a checklist of task_card rows.
+ *
+ * Seeds the stream with a single `plan_update` chunk (using `seedPlanTitle`)
+ * so subsequent `appendSlackStream` calls don't trip `streaming_mode_mismatch`.
+ */
+export async function startSlackStream(args: {
+  channelId: string;
+  threadId: string;
+  recipientUserId: string;
+  recipientTeamId: string;
+  seedPlanTitle?: string;
+}): Promise<string | undefined> {
+  const channelId = requireString(args.channelId, "channelId");
+  const threadId = requireString(args.threadId, "threadId");
+  const recipientUserId = requireString(args.recipientUserId, "recipientUserId");
+  const recipientTeamId = requireString(args.recipientTeamId, "recipientTeamId");
+  const token = getSlackBotToken(channelId, threadId);
+  if (!token) {
+    throw new Error("No Slack bot token available for channel");
+  }
+  const client = getApp().client;
+  const result = await (client.chat as unknown as {
+    startStream: (args: Record<string, unknown>) => Promise<{ ts?: string }>;
+  }).startStream({
+    channel: channelId,
+    thread_ts: threadId,
+    task_display_mode: "plan",
+    recipient_user_id: recipientUserId,
+    recipient_team_id: recipientTeamId,
+    chunks: [{ type: "plan_update", title: truncateStreamField(args.seedPlanTitle ?? "Working") }],
+    token,
+  });
+  return result.ts ?? undefined;
+}
+
+/**
+ * Append chunks to a running chunks-mode Slack stream message. Does NOT
+ * accept a markdown_text body — the API rejects messages that mix the two
+ * with `cannot_provide_both_markdown_text_and_chunks`.
+ */
+export async function appendSlackStream(args: {
+  channelId: string;
+  messageTs: string;
+  chunks: StatusStreamChunk[];
+}): Promise<void> {
+  const channelId = requireString(args.channelId, "channelId");
+  const messageTs = requireString(args.messageTs, "messageTs");
+  if (!Array.isArray(args.chunks) || args.chunks.length === 0) return;
+  const token = getSlackBotToken(channelId);
+  if (!token) {
+    throw new Error("No Slack bot token available for channel");
+  }
+  const client = getApp().client;
+  await (client.chat as unknown as {
+    appendStream: (args: Record<string, unknown>) => Promise<unknown>;
+  }).appendStream({
+    channel: channelId,
+    ts: messageTs,
+    chunks: args.chunks.map(serializeStreamChunk),
+    token,
+  });
+}
+
+/**
+ * Stop a chunks-mode stream. Cannot pass markdown_text here either — the
+ * stream is mode-locked. If you need a final summary line, append a final
+ * `plan_update` chunk before calling stop.
+ */
+export async function stopSlackStream(args: {
+  channelId: string;
+  messageTs: string;
+}): Promise<void> {
+  const channelId = requireString(args.channelId, "channelId");
+  const messageTs = requireString(args.messageTs, "messageTs");
+  const token = getSlackBotToken(channelId);
+  if (!token) {
+    throw new Error("No Slack bot token available for channel");
+  }
+  const client = getApp().client;
+  await (client.chat as unknown as {
+    stopStream: (args: Record<string, unknown>) => Promise<unknown>;
+  }).stopStream({
+    channel: channelId,
+    ts: messageTs,
+    token,
+  });
 }

--- a/packages/ims/slack/api.ts
+++ b/packages/ims/slack/api.ts
@@ -382,9 +382,7 @@ export async function startSlackStream(args: {
   const recipientTeamId = requireString(args.recipientTeamId, "recipientTeamId");
   const token = requireString(args.token, "token");
   const client = getApp().client;
-  const result = await (client.chat as unknown as {
-    startStream: (args: Record<string, unknown>) => Promise<{ ts?: string }>;
-  }).startStream({
+  const result = await client.apiCall("chat.startStream", {
     channel: channelId,
     thread_ts: threadId,
     task_display_mode: "plan",
@@ -392,7 +390,7 @@ export async function startSlackStream(args: {
     recipient_team_id: recipientTeamId,
     chunks: [{ type: "plan_update", title: truncateStreamField(args.seedPlanTitle ?? "Working") }],
     token,
-  });
+  }) as { ts?: string };
   return result.ts ?? undefined;
 }
 
@@ -416,9 +414,7 @@ export async function appendSlackStream(args: {
   const token = requireString(args.token, "token");
   if (!Array.isArray(args.chunks) || args.chunks.length === 0) return;
   const client = getApp().client;
-  await (client.chat as unknown as {
-    appendStream: (args: Record<string, unknown>) => Promise<unknown>;
-  }).appendStream({
+  await client.apiCall("chat.appendStream", {
     channel: channelId,
     ts: messageTs,
     chunks: args.chunks.map(serializeStreamChunk),
@@ -441,9 +437,7 @@ export async function stopSlackStream(args: {
   const messageTs = requireString(args.messageTs, "messageTs");
   const token = requireString(args.token, "token");
   const client = getApp().client;
-  await (client.chat as unknown as {
-    stopStream: (args: Record<string, unknown>) => Promise<unknown>;
-  }).stopStream({
+  await client.apiCall("chat.stopStream", {
     channel: channelId,
     ts: messageTs,
     token,

--- a/packages/ims/slack/client.ts
+++ b/packages/ims/slack/client.ts
@@ -637,32 +637,61 @@ function createSlackAdapter(processorId?: string): IMAdapter {
     updateMessage: (channelId: string, messageTs: string, text: string) =>
       updateMessage(channelId, messageTs, text, processorId),
     startStatusStream: async (channelId, threadId, opts) => {
-      // Resolve recipient_team_id from the channel's registered workspace
-      // auth — Slack's chat.startStream requires it for non-DM streams.
-      const auth = slackAuthRegistry.resolveWorkspaceAuth(
-        getSlackBotTokenForProcessor(processorId) ?? getSlackBotToken(channelId, threadId)
-      );
+      // Resolve recipient_team_id + bot token together so append/stop can
+      // use the same identity by reading the token back from the
+      // message-bot-token registry (see setMessageBotToken below).
+      const botToken = getSlackBotTokenForProcessor(processorId)
+        ?? getSlackBotToken(channelId, threadId);
+      if (!botToken) {
+        log.warn("No Slack bot token available for channel; cannot start stream", { channelId });
+        return undefined;
+      }
+      const auth = slackAuthRegistry.resolveWorkspaceAuth(botToken);
       const recipientTeamId = auth?.teamId ?? undefined;
       if (!recipientTeamId) {
         log.warn("No team id resolved for channel; cannot start Slack stream", { channelId });
         return undefined;
       }
       const { startSlackStream } = await import("./api");
-      return startSlackStream({
+      const ts = await startSlackStream({
         channelId,
         threadId,
         recipientUserId: opts.recipientUserId,
         recipientTeamId,
         seedPlanTitle: opts.seedPlanTitle,
+        token: botToken,
       });
+      if (ts) {
+        // Bind the bot token to the streamed TS so future
+        // appendStatusStream / stopStatusStream calls resolve the SAME
+        // workspace token via getMessageBotToken — multi-workspace installs
+        // would otherwise risk mixing identities and getting silent
+        // rejections from Slack mid-stream.
+        slackAuthRegistry.setMessageBotToken(channelId, ts, botToken);
+      }
+      return ts;
     },
     appendStatusStream: async (channelId, messageTs, chunks) => {
+      const token = slackAuthRegistry.getMessageBotToken(channelId, messageTs)
+        ?? getSlackBotTokenForProcessor(processorId)
+        ?? getSlackBotToken(channelId);
+      if (!token) {
+        log.warn("No Slack bot token available for stream append", { channelId, messageTs });
+        return;
+      }
       const { appendSlackStream } = await import("./api");
-      await appendSlackStream({ channelId, messageTs, chunks });
+      await appendSlackStream({ channelId, messageTs, chunks, token });
     },
     stopStatusStream: async (channelId, messageTs) => {
+      const token = slackAuthRegistry.getMessageBotToken(channelId, messageTs)
+        ?? getSlackBotTokenForProcessor(processorId)
+        ?? getSlackBotToken(channelId);
+      if (!token) {
+        log.warn("No Slack bot token available for stream stop", { channelId, messageTs });
+        return;
+      }
       const { stopSlackStream } = await import("./api");
-      await stopSlackStream({ channelId, messageTs });
+      await stopSlackStream({ channelId, messageTs, token });
     },
     cancelPendingUpdates: (channelId: string, messageTs: string) =>
       slackMessageUpdateManager.cancelPendingUpdates(channelId, messageTs),

--- a/packages/ims/slack/client.ts
+++ b/packages/ims/slack/client.ts
@@ -724,8 +724,8 @@ const slackRecoveryRuntime = createCoreRuntime({
   agent: createAgentAdapter(),
 });
 
-export async function recoverPendingRequests(): Promise<void> {
-  await slackRecoveryRuntime.recoverPendingRequests();
+export async function recoverPendingRequests(options?: { startedBeforeMs?: number }): Promise<void> {
+  await slackRecoveryRuntime.recoverPendingRequests(options);
 }
 
 export async function handleButtonSelection(

--- a/packages/ims/slack/client.ts
+++ b/packages/ims/slack/client.ts
@@ -1,5 +1,4 @@
 import { App } from "@slack/bolt";
-import { WebClient } from "@slack/web-api";
 import {
   getSlackTargetChannels,
   getSlackBotTokens,
@@ -222,38 +221,46 @@ async function syncWorkspaceAfterMention(
   }
 }
 
-async function fetchWorkspaceAuth(
+function buildWorkspaceAuthFromConfig(
   appToken: string,
   botToken: string,
   workspaceId: string,
   workspaceName: string
-): Promise<WorkspaceAuth | null> {
-  try {
-    const client = new WebClient(botToken);
-    const auth = await client.auth.test();
-    return {
-      appToken,
-      botToken,
-      workspaceId,
-      workspaceName,
-      teamId: (auth as any).team_id ?? null,
-      enterpriseId: (auth as any).enterprise_id ?? null,
-      botUserId: (auth as any).bot_user_id ?? (auth as any).user_id ?? null,
-      botId: (auth as any).bot_id ?? null,
-      userId: (auth as any).user_id ?? null,
-    };
-  } catch (err) {
-    log.error("Slack auth.test failed", {
-      botToken: truncateToken(botToken),
-      workspaceName,
-      error: String(err),
-    });
-    return null;
-  }
+): WorkspaceAuth {
+  return {
+    appToken,
+    botToken,
+    workspaceId,
+    workspaceName,
+    teamId: null,
+    enterpriseId: null,
+    botUserId: null,
+    botId: null,
+    userId: null,
+  };
 }
 
 function registerWorkspaceAuth(auth: WorkspaceAuth): void {
   slackAuthRegistry.registerWorkspaceAuth(auth);
+}
+
+function asWorkspaceAuth(auth: { [key: string]: unknown } | undefined): WorkspaceAuth | null {
+  const appToken = typeof auth?.appToken === "string" ? auth.appToken : "";
+  const botToken = typeof auth?.botToken === "string" ? auth.botToken : "";
+  const workspaceId = typeof auth?.workspaceId === "string" ? auth.workspaceId : "";
+  const workspaceName = typeof auth?.workspaceName === "string" ? auth.workspaceName : "config";
+  if (!appToken || !botToken || !workspaceId) return null;
+  return {
+    appToken,
+    botToken,
+    workspaceId,
+    workspaceName,
+    teamId: typeof auth?.teamId === "string" ? auth.teamId : null,
+    enterpriseId: typeof auth?.enterpriseId === "string" ? auth.enterpriseId : null,
+    botUserId: typeof auth?.botUserId === "string" ? auth.botUserId : null,
+    botId: typeof auth?.botId === "string" ? auth.botId : null,
+    userId: typeof auth?.userId === "string" ? auth.userId : null,
+  };
 }
 
 export async function initializeWorkspaceAuth(): Promise<void> {
@@ -271,19 +278,22 @@ export async function initializeWorkspaceAuth(): Promise<void> {
     log.warn("No Slack bot tokens configured", { mode: "local" });
   }
 
-  for (const [botToken, workspace] of combined.entries()) {
-    if (!botToken) continue;
+  const auths = Array.from(combined.entries()).map(([botToken, workspace]) => {
+    if (!botToken) return null;
     const name = workspace.workspaceName ?? "unknown";
-    const auth = await fetchWorkspaceAuth(workspace.appToken, botToken, workspace.workspaceId, name);
+    return buildWorkspaceAuthFromConfig(workspace.appToken, botToken, workspace.workspaceId, name);
+  });
+
+  for (const auth of auths) {
     if (!auth) continue;
     registerWorkspaceAuth(auth);
     log.debug("Registered Slack workspace auth", {
-      workspace: name,
+      workspace: auth.workspaceName,
       workspaceId: auth.workspaceId,
       teamId: auth.teamId,
       enterpriseId: auth.enterpriseId,
       botUserId: auth.botUserId,
-      botToken: truncateToken(botToken),
+      botToken: truncateToken(auth.botToken),
     });
   }
 }
@@ -752,8 +762,10 @@ export function setupMessageHandlers(): void {
         slackAuthRegistry.setChannelWorkspaceName(channelId, workspaceName);
       },
       setChannelWorkspaceAuth: (channelId, auth) => {
-        if (!auth?.botToken) return;
-        slackAuthRegistry.setChannelWorkspaceAuthByBotToken(channelId, auth.botToken);
+        const workspaceAuth = asWorkspaceAuth(auth);
+        if (!workspaceAuth) return;
+        registerWorkspaceAuth(workspaceAuth);
+        slackAuthRegistry.setChannelWorkspaceAuthByBotToken(channelId, workspaceAuth.botToken);
       },
       isThreadOwner: (channelId, threadId, userId) => {
         const session = loadSession(channelId, threadId);

--- a/packages/ims/slack/client.ts
+++ b/packages/ims/slack/client.ts
@@ -636,6 +636,34 @@ function createSlackAdapter(processorId?: string): IMAdapter {
     },
     updateMessage: (channelId: string, messageTs: string, text: string) =>
       updateMessage(channelId, messageTs, text, processorId),
+    startStatusStream: async (channelId, threadId, opts) => {
+      // Resolve recipient_team_id from the channel's registered workspace
+      // auth — Slack's chat.startStream requires it for non-DM streams.
+      const auth = slackAuthRegistry.resolveWorkspaceAuth(
+        getSlackBotTokenForProcessor(processorId) ?? getSlackBotToken(channelId, threadId)
+      );
+      const recipientTeamId = auth?.teamId ?? undefined;
+      if (!recipientTeamId) {
+        log.warn("No team id resolved for channel; cannot start Slack stream", { channelId });
+        return undefined;
+      }
+      const { startSlackStream } = await import("./api");
+      return startSlackStream({
+        channelId,
+        threadId,
+        recipientUserId: opts.recipientUserId,
+        recipientTeamId,
+        seedPlanTitle: opts.seedPlanTitle,
+      });
+    },
+    appendStatusStream: async (channelId, messageTs, chunks) => {
+      const { appendSlackStream } = await import("./api");
+      await appendSlackStream({ channelId, messageTs, chunks });
+    },
+    stopStatusStream: async (channelId, messageTs) => {
+      const { stopSlackStream } = await import("./api");
+      await stopSlackStream({ channelId, messageTs });
+    },
     cancelPendingUpdates: (channelId: string, messageTs: string) =>
       slackMessageUpdateManager.cancelPendingUpdates(channelId, messageTs),
     markMessageFinalized: (channelId: string, messageTs: string) =>

--- a/packages/ims/slack/commands.ts
+++ b/packages/ims/slack/commands.ts
@@ -1,4 +1,4 @@
-import { getApps } from "./client";
+import * as slackClient from "./client";
 import {
   findMatchingModel,
   getProviderModelList,
@@ -513,7 +513,7 @@ function buildGeneralSettingsModal(params: {
 }
 
 export function setupInteractiveHandlers(): void {
-  for (const slackApp of getApps()) {
+  for (const slackApp of slackClient.getApps()) {
     slackApp.action(SETTINGS_LAUNCH_ACTION, async ({ ack, body, client }) => {
     await ack();
 

--- a/packages/ims/slack/message-router.ts
+++ b/packages/ims/slack/message-router.ts
@@ -318,6 +318,17 @@ export function registerSlackMessageRouter(deps: RouterDeps): void {
       });
 
       const currentBotUserId = identity.botUserId;
+      if (workspaceAuth) {
+        workspaceAuth = {
+          ...workspaceAuth,
+          teamId: identity.teamId ?? workspaceAuth.teamId,
+          enterpriseId: identity.enterpriseId ?? workspaceAuth.enterpriseId,
+          botUserId: identity.botUserId || workspaceAuth.botUserId,
+          botId: identity.botId ?? workspaceAuth.botId,
+          userId: identity.botUserId || workspaceAuth.userId,
+        };
+        deps.setChannelWorkspaceAuth(channelId, workspaceAuth);
+      }
       if (!workspaceAuth && contextBotToken) {
         workspaceAuth = syncWorkspaceAuth(deps, channelId, contextBotToken);
       }

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -20,6 +20,7 @@ export {
   createStatusStreamDiffer,
   type StatusStreamDiffer,
   type StatusStreamDiffInput,
+  type StatusStreamDiffResult,
 } from "./status-stream";
 export { extractEventSessionId } from "./session-id";
 export { ensureSessionWorktree, resolveRepoRoot } from "./worktree";

--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -16,6 +16,11 @@ export {
   getToolIcon,
   trimToolPath,
 } from "./status";
+export {
+  createStatusStreamDiffer,
+  type StatusStreamDiffer,
+  type StatusStreamDiffInput,
+} from "./status-stream";
 export { extractEventSessionId } from "./session-id";
 export { ensureSessionWorktree, resolveRepoRoot } from "./worktree";
 export {

--- a/packages/utils/status-stream.ts
+++ b/packages/utils/status-stream.ts
@@ -1,0 +1,208 @@
+// ---------------------------------------------------------------------------
+// SessionMessageState → Slack streaming-API chunk diff.
+//
+// Companion to packages/utils/status.ts (which renders the whole status as
+// markdown text for chat.update). This module instead produces incremental
+// `task_update` / `plan_update` chunks that Slack's chat.appendStream API
+// renders as animated task cards in a plan block.
+//
+// Usage from the kernel:
+//   const differ = createStatusStreamDiffer();
+//   // on each progress tick:
+//   const chunks = differ.diff(state, request);
+//   if (chunks.length > 0) await im.appendStatusStream(...chunks);
+//
+// Design notes:
+//   - We use SessionTool.id as the task_update.id; ids must be stable across
+//     ticks for Slack to update the same card instead of appending a new one.
+//   - We only emit a chunk when a tool's effective shape (title/status/output)
+//     actually changes — Slack drops near-duplicate appends but emitting them
+//     anyway wastes the Tier-4 budget (100/min).
+//   - The plan title is driven by phaseStatus, with sessionTitle as fallback.
+//   - All free-text fields are pre-truncated to Slack's 256-char chunk limit
+//     inside serializeStreamChunk (api.ts) — here we focus on shape & diffing.
+// ---------------------------------------------------------------------------
+
+import type { SessionMessageState, SessionTool } from "./session-inspector";
+import type { StatusStreamChunk } from "@/core/types";
+import { formatElapsedTime, trimToolPath } from "./status";
+
+type TaskStatus = "pending" | "in_progress" | "complete" | "error";
+
+type ToolFingerprint = {
+  title: string;
+  status: TaskStatus;
+  details?: string;
+  output?: string;
+};
+
+function mapToolStatus(status: string): TaskStatus {
+  switch (status) {
+    case "running":
+      return "in_progress";
+    case "pending":
+      return "pending";
+    case "error":
+      return "error";
+    case "completed":
+    default:
+      return "complete";
+  }
+}
+
+function getToolDisplayName(name: string): string {
+  switch ((name || "").toLowerCase()) {
+    case "read_file":
+    case "read_many_files":
+      return "read";
+    case "write_file":
+      return "write";
+    case "run_shell_command":
+      return "bash";
+    case "grep_search":
+      return "grep";
+    default:
+      return name || "tool";
+  }
+}
+
+/**
+ * Build a short, human-readable task title from a SessionTool. Mirrors the
+ * one-liners that buildToolLines() shows in the plain-text status, e.g.
+ *   bash `git status`
+ *   read packages/core/kernel/request-run.ts
+ *   grep "TODO" in packages/
+ *
+ * Stays well under Slack's 256-char chunk cap; the streaming layer truncates
+ * again as a safety net.
+ */
+function buildTaskTitle(tool: SessionTool, workingPath: string): string {
+  const display = getToolDisplayName(tool.name);
+  const input = (tool.input || {}) as Record<string, unknown>;
+  const lowered = (tool.name || "").toLowerCase();
+
+  if (lowered === "bash" || lowered === "run_shell_command") {
+    const cmd = String(input.command || input.cmd || "").trim();
+    if (cmd) return `bash \`${cmd.slice(0, 180)}\``;
+  }
+  if (lowered === "read" || lowered === "read_file" || lowered === "read_many_files") {
+    const file = String(input.filePath || input.file_path || input.absolute_path || "");
+    if (file) return `read ${trimToolPath(file, workingPath)}`;
+  }
+  if (lowered === "edit" || lowered === "write" || lowered === "write_file") {
+    const file = String(input.filePath || input.file_path || input.absolute_path || "");
+    if (file) return `${display} ${trimToolPath(file, workingPath)}`;
+  }
+  if (lowered === "grep" || lowered === "rg" || lowered === "ripgrep" || lowered === "grep_search") {
+    const pattern = String(input.pattern || "");
+    const path = trimToolPath(String(input.path || "."), workingPath);
+    if (pattern) return `grep ${pattern} in ${path}`.trim();
+  }
+  if (lowered === "glob") {
+    const pattern = String(input.pattern || "");
+    const path = trimToolPath(String(input.path || "."), workingPath);
+    if (pattern) return `glob ${pattern} in ${path}`.trim();
+  }
+
+  // Fall back to the SDK-provided title or the bare tool name.
+  const title = tool.title?.trim();
+  return title ? `${display} ${trimToolPath(title, workingPath)}` : display;
+}
+
+function fingerprintTool(tool: SessionTool, workingPath: string): ToolFingerprint {
+  const status = mapToolStatus(tool.status);
+  const title = buildTaskTitle(tool, workingPath);
+  const output = status === "complete" || status === "error"
+    ? (tool.output || tool.error || "").trim() || undefined
+    : undefined;
+  const details = status === "in_progress" || status === "pending"
+    ? (tool.title?.trim() || undefined)
+    : undefined;
+  return { title, status, details, output };
+}
+
+function fingerprintsEqual(a: ToolFingerprint, b: ToolFingerprint): boolean {
+  return (
+    a.title === b.title &&
+    a.status === b.status &&
+    (a.details ?? "") === (b.details ?? "") &&
+    (a.output ?? "") === (b.output ?? "")
+  );
+}
+
+export type StatusStreamDiffInput = {
+  state: SessionMessageState;
+  workingPath: string;
+  startedAt: number;
+};
+
+export type StatusStreamDiffer = {
+  /**
+   * Produce the chunks needed to bring the Slack-side stream in sync with
+   * the latest SessionMessageState. Returns an empty array when nothing
+   * changed since the last call — callers should skip the appendStream
+   * round-trip in that case.
+   */
+  diff(input: StatusStreamDiffInput): StatusStreamChunk[];
+  /**
+   * Compose a short final summary line for chat.stopStream's
+   * `markdown_text`. Kept separate from `diff()` because stopping is a
+   * one-shot terminal transition.
+   */
+  finalize(input: StatusStreamDiffInput): string;
+};
+
+export function createStatusStreamDiffer(): StatusStreamDiffer {
+  const lastFingerprints = new Map<string, ToolFingerprint>();
+  let lastPlanTitle: string | undefined;
+
+  return {
+    diff({ state, workingPath, startedAt }) {
+      const chunks: StatusStreamChunk[] = [];
+
+      // Plan title: prefer the live phase (e.g. "Running tool: bash"), fall
+      // back to the session title, then a generic "Working".
+      const planTitle = (state.phaseStatus?.trim()
+        || state.sessionTitle?.trim()
+        || `Working (${formatElapsedTime(startedAt)})`);
+      if (planTitle !== lastPlanTitle) {
+        chunks.push({ type: "plan_update", title: planTitle });
+        lastPlanTitle = planTitle;
+      }
+
+      // Tools: emit a task_update for each tool whose fingerprint changed.
+      // Tools array is append-ordered by the inspector, so this naturally
+      // surfaces new tools in the order they fired.
+      for (const tool of state.tools) {
+        if (!tool.id) continue;
+        const fp = fingerprintTool(tool, workingPath);
+        const prev = lastFingerprints.get(tool.id);
+        if (prev && fingerprintsEqual(prev, fp)) continue;
+        lastFingerprints.set(tool.id, fp);
+        chunks.push({
+          type: "task_update",
+          id: tool.id,
+          title: fp.title,
+          status: fp.status,
+          ...(fp.details ? { details: fp.details } : {}),
+          ...(fp.output ? { output: fp.output } : {}),
+        });
+      }
+
+      return chunks;
+    },
+
+    finalize({ state, startedAt }) {
+      const elapsed = formatElapsedTime(startedAt);
+      const usage = state.tokenUsage;
+      const tokenSuffix = usage && usage.total > 0
+        ? ` · ${Math.round(usage.total / 1000)}K tokens`
+        : "";
+      const costSuffix = usage && typeof usage.cost === "number" && usage.cost > 0
+        ? ` · $${usage.cost.toFixed(3)}`
+        : "";
+      const titlePart = state.sessionTitle ? `*${state.sessionTitle}* — ` : "";
+      return `${titlePart}done in ${elapsed}${tokenSuffix}${costSuffix}`;
+    },
+  };
+}

--- a/packages/utils/status-stream.ts
+++ b/packages/utils/status-stream.ts
@@ -136,18 +136,32 @@ export type StatusStreamDiffInput = {
   startedAt: number;
 };
 
+export type StatusStreamDiffResult = {
+  /** Chunks to send to chat.appendStream. May be empty (no-op). */
+  chunks: StatusStreamChunk[];
+  /**
+   * Call AFTER chat.appendStream confirms success — this advances the
+   * differ's internal fingerprint cache so the same chunks aren't sent
+   * again. If the append fails, do NOT call commit: next diff() will
+   * re-emit the unconfirmed chunks (Slack will dedupe idempotent
+   * task_update payloads, and rate/network failures recover instead of
+   * leaving task cards permanently stale).
+   */
+  commit(): void;
+};
+
 export type StatusStreamDiffer = {
   /**
-   * Produce the chunks needed to bring the Slack-side stream in sync with
-   * the latest SessionMessageState. Returns an empty array when nothing
-   * changed since the last call — callers should skip the appendStream
-   * round-trip in that case.
+   * Compute the chunks needed to bring the Slack-side stream in sync with
+   * the latest SessionMessageState, plus a `commit()` callback the caller
+   * runs after the network append succeeds. When the chunks list is empty
+   * the caller should skip both the appendStream round-trip and commit().
    */
-  diff(input: StatusStreamDiffInput): StatusStreamChunk[];
+  diff(input: StatusStreamDiffInput): StatusStreamDiffResult;
   /**
-   * Compose a short final summary line for chat.stopStream's
-   * `markdown_text`. Kept separate from `diff()` because stopping is a
-   * one-shot terminal transition.
+   * Compose a short final summary line for the terminal plan_update chunk
+   * we emit just before chat.stopStream. Kept separate from `diff()`
+   * because stopping is a one-shot terminal transition.
    */
   finalize(input: StatusStreamDiffInput): string;
 };
@@ -159,6 +173,13 @@ export function createStatusStreamDiffer(): StatusStreamDiffer {
   return {
     diff({ state, workingPath, startedAt }) {
       const chunks: StatusStreamChunk[] = [];
+      // Pending updates accumulated this tick. Only applied to
+      // lastFingerprints / lastPlanTitle when commit() runs, so a network
+      // failure leaves the old state in place and the next tick re-emits
+      // the same delta.
+      const pendingFingerprints: Array<[string, ToolFingerprint]> = [];
+      let pendingPlanTitle: string | undefined;
+      let planTitleChanged = false;
 
       // Plan title: prefer the live phase (e.g. "Running tool: bash"), fall
       // back to the session title, then a generic "Working".
@@ -167,7 +188,8 @@ export function createStatusStreamDiffer(): StatusStreamDiffer {
         || `Working (${formatElapsedTime(startedAt)})`);
       if (planTitle !== lastPlanTitle) {
         chunks.push({ type: "plan_update", title: planTitle });
-        lastPlanTitle = planTitle;
+        pendingPlanTitle = planTitle;
+        planTitleChanged = true;
       }
 
       // Tools: emit a task_update for each tool whose fingerprint changed.
@@ -178,7 +200,7 @@ export function createStatusStreamDiffer(): StatusStreamDiffer {
         const fp = fingerprintTool(tool, workingPath);
         const prev = lastFingerprints.get(tool.id);
         if (prev && fingerprintsEqual(prev, fp)) continue;
-        lastFingerprints.set(tool.id, fp);
+        pendingFingerprints.push([tool.id, fp]);
         chunks.push({
           type: "task_update",
           id: tool.id,
@@ -189,7 +211,15 @@ export function createStatusStreamDiffer(): StatusStreamDiffer {
         });
       }
 
-      return chunks;
+      return {
+        chunks,
+        commit() {
+          if (planTitleChanged) lastPlanTitle = pendingPlanTitle;
+          for (const [id, fp] of pendingFingerprints) {
+            lastFingerprints.set(id, fp);
+          }
+        },
+      };
     },
 
     finalize({ state, startedAt }) {

--- a/packages/utils/test/status-stream.test.ts
+++ b/packages/utils/test/status-stream.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "bun:test";
+import { createStatusStreamDiffer } from "../status-stream";
+import type { SessionMessageState } from "../session-inspector";
+
+function baseState(overrides: Partial<SessionMessageState> = {}): SessionMessageState {
+  return {
+    sessionTitle: "Test",
+    phaseStatus: "Working",
+    currentText: "",
+    tools: [],
+    todos: [],
+    startedAt: Date.now(),
+    ...overrides,
+  };
+}
+
+const cwd = "/tmp/repo";
+
+describe("createStatusStreamDiffer", () => {
+  it("emits a plan_update for the initial phase title", () => {
+    const differ = createStatusStreamDiffer();
+    const { chunks, commit } = differ.diff({
+      state: baseState(),
+      workingPath: cwd,
+      startedAt: Date.now(),
+    });
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]).toEqual({ type: "plan_update", title: "Working" });
+    commit();
+  });
+
+  it("emits nothing on a second diff when nothing changed (after commit)", () => {
+    const differ = createStatusStreamDiffer();
+    const first = differ.diff({ state: baseState(), workingPath: cwd, startedAt: 0 });
+    first.commit();
+    const second = differ.diff({ state: baseState(), workingPath: cwd, startedAt: 0 });
+    expect(second.chunks).toHaveLength(0);
+  });
+
+  it("retries the same chunks on the next tick when commit() is skipped", () => {
+    // Regression: a transient appendStream failure used to leave the
+    // differ's fingerprint cache advanced anyway, so the next tick would
+    // emit no chunks and the failed update was permanently lost.
+    const differ = createStatusStreamDiffer();
+    const first = differ.diff({ state: baseState(), workingPath: cwd, startedAt: 0 });
+    expect(first.chunks).toHaveLength(1);
+    // Simulate appendStream throwing — caller does NOT invoke commit().
+    const second = differ.diff({ state: baseState(), workingPath: cwd, startedAt: 0 });
+    expect(second.chunks).toEqual(first.chunks);
+  });
+
+  it("emits a task_update when a tool appears, then nothing when unchanged", () => {
+    const differ = createStatusStreamDiffer();
+    const state = baseState({
+      tools: [{
+        id: "tool-1",
+        name: "bash",
+        status: "running",
+        input: { command: "git status" },
+      }],
+    });
+    const first = differ.diff({ state, workingPath: cwd, startedAt: 0 });
+    first.commit();
+    const taskChunk = first.chunks.find((c) => c.type === "task_update");
+    expect(taskChunk).toBeDefined();
+    if (taskChunk?.type === "task_update") {
+      expect(taskChunk.id).toBe("tool-1");
+      expect(taskChunk.status).toBe("in_progress");
+      expect(taskChunk.title).toContain("git status");
+    }
+
+    const second = differ.diff({ state, workingPath: cwd, startedAt: 0 });
+    expect(second.chunks).toHaveLength(0);
+  });
+
+  it("emits a follow-up task_update when a tool transitions to complete", () => {
+    const differ = createStatusStreamDiffer();
+    const running = baseState({
+      tools: [{
+        id: "tool-1",
+        name: "bash",
+        status: "running",
+        input: { command: "git status" },
+      }],
+    });
+    const completed = baseState({
+      tools: [{
+        id: "tool-1",
+        name: "bash",
+        status: "completed",
+        input: { command: "git status" },
+        output: "3 files modified",
+      }],
+    });
+    differ.diff({ state: running, workingPath: cwd, startedAt: 0 }).commit();
+    const { chunks, commit } = differ.diff({
+      state: completed,
+      workingPath: cwd,
+      startedAt: 0,
+    });
+    commit();
+    const transition = chunks.find((c) => c.type === "task_update");
+    expect(transition).toBeDefined();
+    if (transition?.type === "task_update") {
+      expect(transition.status).toBe("complete");
+      expect(transition.output).toBe("3 files modified");
+    }
+  });
+
+  it("emits a fresh plan_update when phaseStatus changes", () => {
+    const differ = createStatusStreamDiffer();
+    differ.diff({
+      state: baseState({ phaseStatus: "Working" }),
+      workingPath: cwd,
+      startedAt: 0,
+    }).commit();
+    const { chunks, commit } = differ.diff({
+      state: baseState({ phaseStatus: "Running tool: bash" }),
+      workingPath: cwd,
+      startedAt: 0,
+    });
+    commit();
+    expect(chunks).toContainEqual({ type: "plan_update", title: "Running tool: bash" });
+  });
+});

--- a/packages/web-ui/src/lib/local-setting/store.ts
+++ b/packages/web-ui/src/lib/local-setting/store.ts
@@ -25,6 +25,7 @@ export type CliCheckResult = {
 type LocalSettingState = {
   config: DashboardConfig;
   appVersion: string;
+  devEnabled: boolean;
   isLoading: boolean;
   isSaving: boolean;
   isSyncingSlack: boolean;
@@ -39,6 +40,7 @@ type LocalSettingState = {
 const initialState: LocalSettingState = {
   config: defaultDashboardConfig,
   appVersion: "",
+  devEnabled: false,
   isLoading: false,
   isSaving: false,
   isSyncingSlack: false,
@@ -218,6 +220,7 @@ async function loadConfig(): Promise<void> {
       ok?: boolean;
       error?: string;
       version?: string;
+      dev?: { enabled?: boolean };
       config?: DashboardConfig;
     };
     if (!response.ok || !payload.ok || !payload.config) {
@@ -227,6 +230,7 @@ async function loadConfig(): Promise<void> {
       ...state,
       config: normalizeConfig(payload.config as DashboardConfig),
       appVersion: typeof payload.version === "string" ? payload.version : state.appVersion,
+      devEnabled: payload.dev?.enabled === true,
       loaded: true,
       isLoading: false,
     }));
@@ -262,6 +266,7 @@ async function saveConfig(): Promise<void> {
       ok?: boolean;
       error?: string;
       version?: string;
+      dev?: { enabled?: boolean };
       config?: DashboardConfig;
     };
     if (!response.ok || !result.ok || !result.config) {
@@ -271,6 +276,7 @@ async function saveConfig(): Promise<void> {
       ...state,
       config: normalizeConfig(result.config as DashboardConfig),
       appVersion: typeof result.version === "string" ? result.version : state.appVersion,
+      devEnabled: result.dev?.enabled === true,
       isSaving: false,
       message: "Saved.",
     }));

--- a/packages/web-ui/src/routes/(settings)/+layout.svelte
+++ b/packages/web-ui/src/routes/(settings)/+layout.svelte
@@ -2,9 +2,9 @@
   import { goto } from "$app/navigation";
   import { page } from "$app/stores";
   import { onMount } from "svelte";
-  import { Building2, Github, Plus, Trash2 } from "lucide-svelte";
+  import { Building2, FlaskConical, Github, Plus, Trash2 } from "lucide-svelte";
   import ThemeToggle from "$lib/components/ThemeToggle.svelte";
-  import { Button, Card, Input, Label, Select } from "$lib/components/ui";
+  import { Button, Card, Input, Label, Select, Switch } from "$lib/components/ui";
   import { initLocale, locale, setLocalePreference, type Locale } from "$lib/i18n";
   import { localSettingStore } from "$lib/local-setting/store";
   import { getSelectedWorkspace, getWorkspacePath } from "$lib/local-setting/workspaces";
@@ -13,7 +13,7 @@
 
   const pathname = $derived($page.url.pathname);
   const normalizedPathname = $derived(pathname.endsWith("/") && pathname.length > 1 ? pathname.slice(0, -1) : pathname);
-  const activeSection = $derived.by<"general" | "agents" | "inbox" | "cronJobs" | "tasks" | "prTracker" | "workspace">(() =>
+  const activeSection = $derived.by<"general" | "agents" | "inbox" | "cronJobs" | "tasks" | "prTracker" | "dev" | "workspace">(() =>
     normalizedPathname === "/agents"
       ? "agents"
       : normalizedPathname === "/inbox"
@@ -24,6 +24,8 @@
         ? "tasks"
       : normalizedPathname === "/pr-tracker"
         ? "prTracker"
+      : normalizedPathname === "/dev"
+        ? "dev"
         : normalizedPathname.startsWith("/workspace")
           ? "workspace"
           : "general"
@@ -35,6 +37,7 @@
   let pendingLarkAppKey = $state("");
   let pendingLarkAppSecret = $state("");
   let isAddWorkspaceDialogOpen = $state(false);
+  let isDevMode = $state(false);
 
   const selectedWorkspace = $derived(getSelectedWorkspace($page.params.workspaceName ?? "", $localSettingStore.config.workspaces));
   const isBusy = $derived($localSettingStore.isLoading
@@ -108,6 +111,13 @@
     pendingLarkAppSecret = (event.currentTarget as HTMLInputElement).value;
   }
 
+  function setDevMode(enabled: boolean): void {
+    isDevMode = enabled;
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem("ode-dev-mode", enabled ? "1" : "0");
+    }
+  }
+
   async function removeWorkspace(workspaceId: string): Promise<void> {
     const workspaces = $localSettingStore.config.workspaces;
     const removingIndex = workspaces.findIndex((workspace) => workspace.id === workspaceId);
@@ -149,6 +159,7 @@
 
   onMount(() => {
     initLocale();
+    isDevMode = typeof window !== "undefined" && window.localStorage.getItem("ode-dev-mode") === "1";
     if (!$localSettingStore.loaded) {
       void localSettingStore.loadConfig();
     }
@@ -233,6 +244,26 @@
         >
           {t("PR Tracker", "PR 追踪")}
         </Button>
+        {#if isDevMode || activeSection === "dev"}
+          <Button
+            variant={activeSection === "dev" ? "default" : "secondary"}
+            className="w-full justify-start"
+            on:click={() => goto("/dev")}
+          >
+            <FlaskConical class="h-4 w-4" />
+            {t("Dev Tools", "开发工具")}
+          </Button>
+        {/if}
+      </div>
+    </Card>
+
+    <Card className="p-4">
+      <div class="flex items-center justify-between gap-3">
+        <div>
+          <h2 class="text-sm font-semibold">{t("Dev mode", "开发模式")}</h2>
+          <p class="text-xs text-[hsl(var(--muted-foreground))]">{t("Show local testing tools", "显示本地测试工具")}</p>
+        </div>
+        <Switch checked={isDevMode} ariaLabel={t("Toggle dev mode", "切换开发模式")} on:change={(event) => setDevMode(event.detail)} />
       </div>
     </Card>
 

--- a/packages/web-ui/src/routes/(settings)/+layout.svelte
+++ b/packages/web-ui/src/routes/(settings)/+layout.svelte
@@ -4,7 +4,7 @@
   import { onMount } from "svelte";
   import { Building2, FlaskConical, Github, Plus, Trash2 } from "lucide-svelte";
   import ThemeToggle from "$lib/components/ThemeToggle.svelte";
-  import { Button, Card, Input, Label, Select, Switch } from "$lib/components/ui";
+  import { Button, Card, Input, Label, Select } from "$lib/components/ui";
   import { initLocale, locale, setLocalePreference, type Locale } from "$lib/i18n";
   import { localSettingStore } from "$lib/local-setting/store";
   import { getSelectedWorkspace, getWorkspacePath } from "$lib/local-setting/workspaces";
@@ -37,7 +37,6 @@
   let pendingLarkAppKey = $state("");
   let pendingLarkAppSecret = $state("");
   let isAddWorkspaceDialogOpen = $state(false);
-  let isDevMode = $state(false);
 
   const selectedWorkspace = $derived(getSelectedWorkspace($page.params.workspaceName ?? "", $localSettingStore.config.workspaces));
   const isBusy = $derived($localSettingStore.isLoading
@@ -111,13 +110,6 @@
     pendingLarkAppSecret = (event.currentTarget as HTMLInputElement).value;
   }
 
-  function setDevMode(enabled: boolean): void {
-    isDevMode = enabled;
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem("ode-dev-mode", enabled ? "1" : "0");
-    }
-  }
-
   async function removeWorkspace(workspaceId: string): Promise<void> {
     const workspaces = $localSettingStore.config.workspaces;
     const removingIndex = workspaces.findIndex((workspace) => workspace.id === workspaceId);
@@ -159,7 +151,6 @@
 
   onMount(() => {
     initLocale();
-    isDevMode = typeof window !== "undefined" && window.localStorage.getItem("ode-dev-mode") === "1";
     if (!$localSettingStore.loaded) {
       void localSettingStore.loadConfig();
     }
@@ -244,7 +235,7 @@
         >
           {t("PR Tracker", "PR 追踪")}
         </Button>
-        {#if isDevMode || activeSection === "dev"}
+        {#if $localSettingStore.devEnabled}
           <Button
             variant={activeSection === "dev" ? "default" : "secondary"}
             className="w-full justify-start"
@@ -254,16 +245,6 @@
             {t("Dev Tools", "开发工具")}
           </Button>
         {/if}
-      </div>
-    </Card>
-
-    <Card className="p-4">
-      <div class="flex items-center justify-between gap-3">
-        <div>
-          <h2 class="text-sm font-semibold">{t("Dev mode", "开发模式")}</h2>
-          <p class="text-xs text-[hsl(var(--muted-foreground))]">{t("Show local testing tools", "显示本地测试工具")}</p>
-        </div>
-        <Switch checked={isDevMode} ariaLabel={t("Toggle dev mode", "切换开发模式")} on:change={(event) => setDevMode(event.detail)} />
       </div>
     </Card>
 

--- a/packages/web-ui/src/routes/(settings)/dev/+page.svelte
+++ b/packages/web-ui/src/routes/(settings)/dev/+page.svelte
@@ -1,0 +1,330 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { ExternalLink, Play, RefreshCw } from "lucide-svelte";
+  import { Badge, Button, Card, Input, Label, Select, Switch, Textarea } from "$lib/components/ui";
+  import { locale } from "$lib/i18n";
+  import { localSettingStore } from "$lib/local-setting/store";
+  import {
+    AGENT_PROVIDERS,
+    AGENT_PROVIDER_LABELS,
+  } from "@/shared/agent-provider";
+
+  type TaskPlatform = "slack" | "discord" | "lark";
+  type TaskStatus = "pending" | "running" | "success" | "failed" | "cancelled";
+
+  type TaskRecord = {
+    id: string;
+    title: string;
+    scheduledAt: number;
+    platform: TaskPlatform;
+    workspaceId: string | null;
+    workspaceName: string | null;
+    channelId: string;
+    channelName: string | null;
+    threadId: string | null;
+    messageText: string;
+    agent: string | null;
+    status: TaskStatus;
+    lastError: string | null;
+    triggeredAt: number | null;
+    completedAt: number | null;
+    createdAt: number;
+    updatedAt: number;
+  };
+
+  type TaskChannelOption = {
+    value: string;
+    platform: TaskPlatform;
+    workspaceId: string;
+    workspaceName: string;
+    channelId: string;
+    channelName: string;
+    label: string;
+  };
+
+  type TaskPayload = {
+    tasks: TaskRecord[];
+    channels: TaskChannelOption[];
+  };
+
+  type PresetId = "smoke" | "status" | "question";
+
+  const PRESETS: Record<PresetId, { title: string; prompt: string }> = {
+    smoke: {
+      title: "Dev smoke test",
+      prompt: "Inspect the current directory, create or update dev-smoke.txt with the current date and the dev run id, then reply with the file path.",
+    },
+    status: {
+      title: "Live status test",
+      prompt: "Run a visible multi-step coding-agent test: inspect the repository, read the README, create or update dev-live-status.txt with a short summary, and report what changed.",
+    },
+    question: {
+      title: "Question loop test",
+      prompt: "Before editing files, ask me one short multiple-choice question with two options about what note to write. After I answer in this thread, create or update dev-question-loop.txt with the chosen note and report the file path.",
+    },
+  };
+
+  let devModeEnabled = $state(false);
+  let channels = $state<TaskChannelOption[]>([]);
+  let tasks = $state<TaskRecord[]>([]);
+  let selectedChannel = $state("");
+  let selectedAgent = $state("");
+  let selectedPreset = $state<PresetId>("smoke");
+  let title = $state(PRESETS.smoke.title);
+  let prompt = $state(PRESETS.smoke.prompt);
+  let activeTaskId = $state<string | null>(null);
+  let activeRunMarker = $state("");
+  let message = $state("");
+  let isLoading = $state(false);
+  let isStarting = $state(false);
+
+  const activeTask = $derived(tasks.find((task) => task.id === activeTaskId) ?? null);
+  const enabledAgentProviders = $derived(
+    AGENT_PROVIDERS.filter((provider) => {
+      const agents = $localSettingStore.config.agents as Record<string, { enabled?: boolean }>;
+      return agents[provider]?.enabled === true;
+    })
+  );
+
+  function t(en: string, zh: string): string {
+    return $locale === "zh-CN" ? zh : en;
+  }
+
+  function getStatusVariant(status: TaskStatus): "secondary" | "success" | "destructive" | "outline" {
+    if (status === "success") return "success";
+    if (status === "failed") return "destructive";
+    if (status === "cancelled") return "outline";
+    return "secondary";
+  }
+
+  function formatTime(value: number | null | undefined): string {
+    if (!value || !Number.isFinite(value)) return "n/a";
+    return new Date(value).toLocaleString($locale === "zh-CN" ? "zh-CN" : "en-US");
+  }
+
+  function setDevMode(enabled: boolean): void {
+    devModeEnabled = enabled;
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem("ode-dev-mode", enabled ? "1" : "0");
+    }
+  }
+
+  function applyPreset(preset: PresetId): void {
+    selectedPreset = preset;
+    title = PRESETS[preset].title;
+    prompt = PRESETS[preset].prompt;
+  }
+
+  async function loadTasks(): Promise<void> {
+    isLoading = true;
+    try {
+      const response = await fetch("/api/tasks");
+      const payload = (await response.json()) as {
+        ok?: boolean;
+        error?: string;
+        result?: TaskPayload;
+      };
+      if (!response.ok || !payload.ok || !payload.result) {
+        throw new Error(payload.error || "Failed to load dev task data");
+      }
+      channels = payload.result.channels;
+      tasks = payload.result.tasks;
+      if (!selectedChannel && channels.length > 0) {
+        selectedChannel = channels[0]!.value;
+      }
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    } finally {
+      isLoading = false;
+    }
+  }
+
+  function buildRunPrompt(runMarker: string): string {
+    return `[${runMarker}]\n\n${prompt.trim()}`;
+  }
+
+  async function startRun(): Promise<void> {
+    if (!selectedChannel || !prompt.trim()) return;
+    isStarting = true;
+    message = "";
+    const runMarker = `ODE_DEV_RUN:${crypto.randomUUID()}`;
+    try {
+      const response = await fetch("/api/tasks", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          title: title.trim() || "Dev agent run",
+          scheduledAt: Date.now(),
+          channelId: selectedChannel,
+          threadId: null,
+          messageText: buildRunPrompt(runMarker),
+          agent: selectedAgent || null,
+          runImmediately: true,
+        }),
+      });
+      const payload = (await response.json()) as {
+        ok?: boolean;
+        error?: string;
+        result?: TaskPayload & { task?: TaskRecord };
+      };
+      if (!response.ok || !payload.ok || !payload.result?.task) {
+        throw new Error(payload.error || "Failed to start dev run");
+      }
+      activeTaskId = payload.result.task.id;
+      activeRunMarker = runMarker;
+      tasks = payload.result.tasks;
+      channels = payload.result.channels;
+      message = t("Dev run started.", "开发测试已启动。");
+    } catch (error) {
+      message = error instanceof Error ? error.message : String(error);
+    } finally {
+      isStarting = false;
+    }
+  }
+
+  onMount(() => {
+    devModeEnabled = typeof window !== "undefined" && window.localStorage.getItem("ode-dev-mode") === "1";
+    if (!$localSettingStore.loaded) {
+      void localSettingStore.loadConfig();
+    }
+    void loadTasks();
+    const timer = window.setInterval(() => {
+      if (activeTaskId) void loadTasks();
+    }, 2500);
+    return () => window.clearInterval(timer);
+  });
+</script>
+
+<Card className="p-5">
+  <div class="mb-5 flex flex-wrap items-center justify-between gap-3">
+    <div>
+      <h2 class="text-lg font-semibold">{t("Dev Tools", "开发工具")}</h2>
+      <p class="text-xs text-[hsl(var(--muted-foreground))]">{t("Agent live-message test runs", "Agent live message 测试")}</p>
+    </div>
+    <div class="flex items-center gap-3">
+      <Label for="dev-mode-toggle" className="text-sm">{t("Dev mode", "开发模式")}</Label>
+      <Switch id="dev-mode-toggle" checked={devModeEnabled} ariaLabel={t("Toggle dev mode", "切换开发模式")} on:change={(event) => setDevMode(event.detail)} />
+    </div>
+  </div>
+
+  {#if !devModeEnabled}
+    <div class="rounded-lg border border-dashed p-5 text-sm text-[hsl(var(--muted-foreground))]">
+      {t("Enable dev mode to run local agent tests.", "开启开发模式后运行本地 agent 测试。")}
+    </div>
+  {:else}
+    <div class="grid gap-5 lg:grid-cols-[minmax(0,1fr)_22rem]">
+      <div class="space-y-4">
+        <div class="grid gap-2">
+          <Label for="dev-channel">{t("Target channel", "目标频道")}</Label>
+          <Select id="dev-channel" bind:value={selectedChannel} disabled={isLoading || channels.length === 0}>
+            {#each channels as channel}
+              <option value={channel.value}>{channel.label}</option>
+            {/each}
+          </Select>
+        </div>
+
+        <div class="grid gap-2 sm:grid-cols-2">
+          <div class="grid gap-2">
+            <Label for="dev-agent">{t("Agent", "Agent")}</Label>
+            <Select id="dev-agent" bind:value={selectedAgent}>
+              <option value="">{t("Channel default", "频道默认")}</option>
+              {#each enabledAgentProviders as provider}
+                <option value={provider}>{AGENT_PROVIDER_LABELS[provider]}</option>
+              {/each}
+            </Select>
+          </div>
+
+          <div class="grid gap-2">
+            <Label for="dev-preset">{t("Preset", "预设")}</Label>
+            <Select
+              id="dev-preset"
+              bind:value={selectedPreset}
+              on:change={(event) => {
+                const value = (event.currentTarget as HTMLSelectElement).value;
+                if (value === "smoke" || value === "status" || value === "question") applyPreset(value);
+              }}
+            >
+              <option value="smoke">{t("Smoke", "基础")}</option>
+              <option value="status">{t("Live status", "动态状态")}</option>
+              <option value="question">{t("Question loop", "问题循环")}</option>
+            </Select>
+          </div>
+        </div>
+
+        <div class="grid gap-2">
+          <Label for="dev-title">{t("Title", "标题")}</Label>
+          <Input id="dev-title" bind:value={title} />
+        </div>
+
+        <div class="grid gap-2">
+          <Label for="dev-prompt">{t("Prompt", "Prompt")}</Label>
+          <Textarea id="dev-prompt" bind:value={prompt} className="min-h-44 font-mono text-sm" />
+        </div>
+
+        <div class="flex flex-wrap items-center gap-2">
+          <Button type="button" on:click={() => void startRun()} disabled={isStarting || !selectedChannel || !prompt.trim()}>
+            <Play class="h-4 w-4" />
+            {isStarting ? t("Starting...", "启动中...") : t("Start run", "开始测试")}
+          </Button>
+          <Button type="button" variant="outline" on:click={() => void loadTasks()} disabled={isLoading}>
+            <RefreshCw class="h-4 w-4" />
+            {t("Refresh", "刷新")}
+          </Button>
+          <a class="inline-flex h-10 items-center gap-2 rounded-md border px-3 text-sm hover:bg-[hsl(var(--muted)/0.45)]" href="/tasks">
+            <ExternalLink class="h-4 w-4" />
+            {t("Tasks", "一次性任务")}
+          </a>
+        </div>
+      </div>
+
+      <aside class="space-y-3">
+        <div class="rounded-lg border p-4">
+          <div class="mb-2 flex items-center justify-between gap-2">
+            <h3 class="text-sm font-semibold">{t("Active run", "当前测试")}</h3>
+            {#if activeTask}
+              <Badge variant={getStatusVariant(activeTask.status)}>{activeTask.status}</Badge>
+            {/if}
+          </div>
+          {#if activeTask}
+            <div class="space-y-2 text-sm">
+              <p class="break-all font-mono text-xs text-[hsl(var(--muted-foreground))]">{activeTask.id}</p>
+              <p>{activeTask.workspaceName || activeTask.workspaceId || "workspace"} / {activeTask.channelName || activeTask.channelId}</p>
+              <p class="text-xs text-[hsl(var(--muted-foreground))]">{t("Started", "开始")} {formatTime(activeTask.triggeredAt ?? activeTask.createdAt)}</p>
+              {#if activeRunMarker}
+                <p class="break-all rounded-md bg-[hsl(var(--muted)/0.55)] p-2 font-mono text-xs">{activeRunMarker}</p>
+              {/if}
+              {#if activeTask.lastError}
+                <p class="rounded-md border border-[hsl(var(--destructive))] bg-[hsl(var(--destructive)/0.08)] p-2 text-xs text-[hsl(var(--destructive))]">{activeTask.lastError}</p>
+              {/if}
+            </div>
+          {:else}
+            <p class="text-sm text-[hsl(var(--muted-foreground))]">{t("No active run", "暂无测试")}</p>
+          {/if}
+        </div>
+
+        {#if message}
+          <div class="rounded-lg border p-3 text-sm text-[hsl(var(--muted-foreground))]">{message}</div>
+        {/if}
+
+        <div class="rounded-lg border p-4">
+          <h3 class="mb-2 text-sm font-semibold">{t("Recent dev tasks", "最近测试任务")}</h3>
+          <div class="space-y-2">
+            {#each tasks.filter((task) => task.title.toLowerCase().includes("dev")).slice(0, 6) as task}
+              <button
+                type="button"
+                class="w-full rounded-md border px-3 py-2 text-left text-sm hover:bg-[hsl(var(--muted)/0.45)]"
+                onclick={() => activeTaskId = task.id}
+              >
+                <div class="flex items-center justify-between gap-2">
+                  <span class="truncate">{task.title}</span>
+                  <Badge variant={getStatusVariant(task.status)}>{task.status}</Badge>
+                </div>
+                <p class="mt-1 truncate text-xs text-[hsl(var(--muted-foreground))]">{task.channelName || task.channelId}</p>
+              </button>
+            {/each}
+          </div>
+        </div>
+      </aside>
+    </div>
+  {/if}
+</Card>

--- a/packages/web-ui/src/routes/(settings)/dev/+page.svelte
+++ b/packages/web-ui/src/routes/(settings)/dev/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { ExternalLink, Play, RefreshCw } from "lucide-svelte";
-  import { Badge, Button, Card, Input, Label, Select, Switch, Textarea } from "$lib/components/ui";
+  import { Badge, Button, Card, Input, Label, Select, Textarea } from "$lib/components/ui";
   import { locale } from "$lib/i18n";
   import { localSettingStore } from "$lib/local-setting/store";
   import {
@@ -64,7 +64,6 @@
     },
   };
 
-  let devModeEnabled = $state(false);
   let channels = $state<TaskChannelOption[]>([]);
   let tasks = $state<TaskRecord[]>([]);
   let selectedChannel = $state("");
@@ -102,13 +101,6 @@
     return new Date(value).toLocaleString($locale === "zh-CN" ? "zh-CN" : "en-US");
   }
 
-  function setDevMode(enabled: boolean): void {
-    devModeEnabled = enabled;
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem("ode-dev-mode", enabled ? "1" : "0");
-    }
-  }
-
   function applyPreset(preset: PresetId): void {
     selectedPreset = preset;
     title = PRESETS[preset].title;
@@ -144,7 +136,7 @@
   }
 
   async function startRun(): Promise<void> {
-    if (!selectedChannel || !prompt.trim()) return;
+    if (!$localSettingStore.devEnabled || !selectedChannel || !prompt.trim()) return;
     isStarting = true;
     message = "";
     const runMarker = `ODE_DEV_RUN:${crypto.randomUUID()}`;
@@ -183,35 +175,38 @@
   }
 
   onMount(() => {
-    devModeEnabled = typeof window !== "undefined" && window.localStorage.getItem("ode-dev-mode") === "1";
-    if (!$localSettingStore.loaded) {
-      void localSettingStore.loadConfig();
-    }
-    void loadTasks();
-    const timer = window.setInterval(() => {
-      if (activeTaskId) void loadTasks();
-    }, 2500);
-    return () => window.clearInterval(timer);
+    let timer: number | undefined;
+    void (async () => {
+      if (!$localSettingStore.loaded) {
+        await localSettingStore.loadConfig();
+      }
+      if (!$localSettingStore.devEnabled) return;
+      await loadTasks();
+      timer = window.setInterval(() => {
+        if (activeTaskId) void loadTasks();
+      }, 2500);
+    })();
+    return () => {
+      if (timer !== undefined) window.clearInterval(timer);
+    };
   });
 </script>
 
-<Card className="p-5">
-  <div class="mb-5 flex flex-wrap items-center justify-between gap-3">
-    <div>
+{#if !$localSettingStore.loaded || $localSettingStore.isLoading}
+  <Card className="p-5">
+    <p class="text-sm text-[hsl(var(--muted-foreground))]">{t("Loading...", "加载中...")}</p>
+  </Card>
+{:else if !$localSettingStore.devEnabled}
+  <Card className="p-5">
+    <h2 class="text-lg font-semibold">{t("Not found", "未找到")}</h2>
+  </Card>
+{:else}
+  <Card className="p-5">
+    <div class="mb-5">
       <h2 class="text-lg font-semibold">{t("Dev Tools", "开发工具")}</h2>
       <p class="text-xs text-[hsl(var(--muted-foreground))]">{t("Agent live-message test runs", "Agent live message 测试")}</p>
     </div>
-    <div class="flex items-center gap-3">
-      <Label for="dev-mode-toggle" className="text-sm">{t("Dev mode", "开发模式")}</Label>
-      <Switch id="dev-mode-toggle" checked={devModeEnabled} ariaLabel={t("Toggle dev mode", "切换开发模式")} on:change={(event) => setDevMode(event.detail)} />
-    </div>
-  </div>
 
-  {#if !devModeEnabled}
-    <div class="rounded-lg border border-dashed p-5 text-sm text-[hsl(var(--muted-foreground))]">
-      {t("Enable dev mode to run local agent tests.", "开启开发模式后运行本地 agent 测试。")}
-    </div>
-  {:else}
     <div class="grid gap-5 lg:grid-cols-[minmax(0,1fr)_22rem]">
       <div class="space-y-4">
         <div class="grid gap-2">
@@ -326,5 +321,5 @@
         </div>
       </aside>
     </div>
-  {/if}
-</Card>
+  </Card>
+{/if}

--- a/scripts/demo-stream-status.ts
+++ b/scripts/demo-stream-status.ts
@@ -1,0 +1,158 @@
+#!/usr/bin/env bun
+// Demo script: drive Slack's chat.startStream / appendStream / stopStream
+// directly against the current thread to show what task_update / plan_update
+// renders as. Bypasses Ode runtime entirely — pure API call sanity check.
+//
+// Usage:
+//   SLACK_BOT_TOKEN=xoxb-... SLACK_RECIPIENT_USER_ID=U... \
+//     SLACK_RECIPIENT_TEAM_ID=T... \
+//     bun run scripts/demo-stream-status.ts C0... 1779....
+//
+// Channel (non-DM) streams require recipient_user_id + recipient_team_id;
+// for a DM you can omit those. The stream is mode-locked to "chunks" at
+// startStream time — once locked you cannot mix in markdown_text on
+// appendStream/stopStream (returns cannot_provide_both_markdown_text_and_chunks
+// / streaming_mode_mismatch).
+
+const [channel, threadTs] = Bun.argv.slice(2);
+const token = process.env.SLACK_BOT_TOKEN;
+if (!channel || !threadTs || !token) {
+  console.error("Usage: SLACK_BOT_TOKEN=xoxb-... bun run scripts/demo-stream-status.ts <channelId> <threadTs>");
+  process.exit(1);
+}
+
+async function call(method: string, body: Record<string, unknown>): Promise<any> {
+  const res = await fetch(`https://slack.com/api/${method}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json; charset=utf-8",
+    },
+    body: JSON.stringify(body),
+  });
+  const json: any = await res.json();
+  if (!json.ok) {
+    console.error(`[${method}] FAILED`, json);
+    throw new Error(`${method}: ${json.error}`);
+  }
+  console.log(`[${method}] ok`, json.ts ? `ts=${json.ts}` : "");
+  return json;
+}
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+// Helper: an appendStream call with chunks only. The API treats
+// `markdown_text` and `chunks` as mutually exclusive (returns
+// `cannot_provide_both_markdown_text_and_chunks` if you send both), even
+// though the docs imply markdown_text is always required.
+function append(ts: string, chunks: unknown[]) {
+  return call("chat.appendStream", {
+    channel,
+    ts,
+    chunks,
+  });
+}
+
+async function main() {
+  // 1. Start the stream. task_display_mode "plan" groups everything into one
+  //    unified plan block instead of separate task_card messages.
+  //    Channel (non-DM) streams require recipient_user_id + recipient_team_id.
+  const recipientUserId = process.env.SLACK_RECIPIENT_USER_ID;
+  const recipientTeamId = process.env.SLACK_RECIPIENT_TEAM_ID;
+  if (!recipientUserId || !recipientTeamId) {
+    console.error("Set SLACK_RECIPIENT_USER_ID and SLACK_RECIPIENT_TEAM_ID for channel streams");
+    process.exit(1);
+  }
+  const started = await call("chat.startStream", {
+    channel,
+    thread_ts: threadTs,
+    task_display_mode: "plan",
+    recipient_user_id: recipientUserId,
+    recipient_team_id: recipientTeamId,
+    chunks: [{ type: "plan_update", title: "Thinking…" }],
+  });
+  const ts: string = started.ts;
+
+  // (plan_update was already sent in startStream above)
+  await sleep(900);
+
+  // 3. Start a task — pending.
+  await append(ts, [{
+    type: "task_update",
+    id: "tool-1",
+    title: "bash `git status`",
+    status: "pending",
+  }]);
+  await sleep(800);
+
+  // 4. Flip it to in_progress (spinner).
+  await append(ts, [{
+    type: "task_update",
+    id: "tool-1",
+    title: "bash `git status`",
+    status: "in_progress",
+    details: "Reading working tree",
+  }]);
+  await sleep(1400);
+
+  // 5. Complete + start another.
+  await append(ts, [
+    {
+      type: "task_update",
+      id: "tool-1",
+      title: "bash `git status`",
+      status: "complete",
+      output: "3 files modified",
+    },
+    {
+      type: "task_update",
+      id: "tool-2",
+      title: "read packages/ims/slack/client.ts",
+      status: "in_progress",
+    },
+  ]);
+  await sleep(1500);
+
+  // 6. Complete second, kick off a longer-looking third.
+  await append(ts, [
+    {
+      type: "task_update",
+      id: "tool-2",
+      title: "read packages/ims/slack/client.ts",
+      status: "complete",
+      output: "750 lines",
+    },
+    {
+      type: "task_update",
+      id: "tool-3",
+      title: "grep \"chat.update\" in packages/",
+      status: "in_progress",
+    },
+  ]);
+  await sleep(1800);
+
+  // 7. Rename the plan (phase change) + finish last task.
+  await append(ts, [
+    { type: "plan_update", title: "Drafting response" },
+    {
+      type: "task_update",
+      id: "tool-3",
+      title: "grep \"chat.update\" in packages/",
+      status: "complete",
+      output: "12 matches across 5 files",
+    },
+  ]);
+  await sleep(1200);
+
+  // 8. Stop the stream. Don't pass markdown_text here because we started in
+  //    chunks mode; the streaming-mode lock applies to stop too.
+  await call("chat.stopStream", {
+    channel,
+    ts,
+  });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Behind `ODE_SLACK_STATUS_STREAMING=1`, render the live agent status message via Slack's text-streaming API (`chat.startStream` / `chat.appendStream` / `chat.stopStream`, Feb/Apr 2026) instead of the repeated `chat.update` edits we do today.

Tool lifecycle events become `task_update` chunks inside a `plan` block — spinner on running tools, checkmark on complete, error pill on failure — matching the UI Slack's own AI agents use.

A live demo posting against the source thread is here: https://roombasehq.slack.com/archives/C0ATJJHRV5Y/p1779701209263979 (the "Drafting response" plan card with three completed task rows is the actual streaming-API output).

## Why

- `chat.appendStream` is **Tier 4 (100+/min)** vs `chat.update` Tier 3 (50+/min) — ~2× headroom against the same per-channel "1 msg/sec/channel" posting cap.
- Native Slack rendering: animated spinner, no flicker, no 4000-char text blob churn.
- Eliminates `streaming_state_conflict` / `edit_window_closed` failure modes `chat.update` is starting to hit on long-running sessions.
- Block-Kit `task_card` / `plan` blocks (new in Feb 2026) are now first-class — sources chips, rich-text output, etc.

## What changed

- `packages/utils/status-stream.ts` *(new)*: `SessionMessageState` → minimal `task_update` / `plan_update` chunks. Per-tool fingerprint cache so only deltas are sent (preserves the Tier-4 budget).
- `packages/ims/slack/api.ts`: `startSlackStream` / `appendSlackStream` / `stopSlackStream` helpers. Encodes the empirical quirks (mode-locking, `recipient_team_id` required, 256-char chunk caps).
- `packages/core/types.ts`: optional `startStatusStream` / `appendStatusStream` / `stopStatusStream` on `IMAdapter`. Discord/Lark unaffected — missing methods → kernel auto-fallback to `chat.update`.
- `packages/ims/slack/client.ts`: wire the three methods; resolve `recipient_team_id` from the channel's registered `WorkspaceAuth`.
- `packages/core/kernel/request-run.ts`: env-gated branch. Failure path sends a final `plan_update` with the error first, then stops the stream — avoids `streaming_state_conflict` on the cleanup `chat.update`.
- `scripts/demo-stream-status.ts` *(new)*: standalone smoke test that drives the raw Slack API end-to-end against a thread.

## Empirical quirks the docs miss (encoded in helpers)

- Channel (non-DM) streams **require both** `recipient_user_id` and `recipient_team_id`; omission → `missing_recipient_team_id`.
- The stream is **mode-locked** to text-mode or chunks-mode at `startStream`. Mixing `markdown_text` and `chunks` on `appendStream` returns `cannot_provide_both_markdown_text_and_chunks`; switching modes returns `streaming_mode_mismatch`.
- `chat.stopStream` cannot carry `markdown_text` on a chunks-mode stream, so the final summary line is sent as a `plan_update` chunk before stop.

## Rollout

- Off by default. Existing `chat.update` path remains the default and is untouched.
- Flip on for local dev: `ODE_SLACK_STATUS_STREAMING=1 bun run dev`.
- Flip on for the installed daemon: set the env var and respawn the runtime.
- Fallback is automatic: if `startStatusStream` is missing on the adapter (Discord/Lark), or if any stream call throws, the kernel logs a warning and the tick continues against the existing status TS via `chat.update`.

## Verification

- `bun run typecheck` clean.
- `bun test` — all 84 tests pass (no behavior change on default code path; streaming path is unit-coverable separately as a follow-up).
- Live API round-trip verified against `#ode` in Roombase (see permalink above and screenshot in the source thread).

## Follow-ups (not in this PR)

- Unit tests for `createStatusStreamDiffer` (fingerprint dedupe, edge cases around tool id reuse).
- A live-status-harness fixture so we can deterministically replay a captured run through the streaming renderer.
- Per-workspace / per-channel setting in Web UI instead of just the env var.
