### PR TITLE
fix(cron): auto-disable cron jobs whose target channel is unreachable

### DIFF
--- a/packages/config/local/cron-jobs.test.ts
+++ b/packages/config/local/cron-jobs.test.ts
@@ -9,10 +9,12 @@ import {
   clearCronJobsForTests,
   closeCronJobDatabaseForTests,
   createCronJob,
+  disableCronJob,
   getCronJobById,
   markCronJobCompleted,
   markCronJobFailed,
   markCronJobRunning,
+  patchCronJob,
   reconcileInterruptedCronJobs,
 } from "./cron-jobs";
 
@@ -200,5 +202,79 @@ describe("reconcileInterruptedCronJobs", () => {
     expect(second).toHaveLength(0);
     // The row remains `failed` from the first pass.
     expect(getCronJobById(job.id)?.lastRunStatus).toBe("failed");
+  });
+});
+
+describe("disableCronJob", () => {
+  test("flips enabled to false and reports the transition", () => {
+    const job = createCronJob({
+      title: "to-disable",
+      cronExpression: "*/5 * * * *",
+      channelId: "C_TEST",
+      messageText: "hi",
+    });
+    expect(getCronJobById(job.id)?.enabled).toBe(true);
+
+    const changed = disableCronJob(job.id);
+    expect(changed).toBe(true);
+    expect(getCronJobById(job.id)?.enabled).toBe(false);
+  });
+
+  test("returns false when the row is already disabled (idempotent)", () => {
+    const job = createCronJob({
+      title: "already-off",
+      cronExpression: "*/5 * * * *",
+      channelId: "C_TEST",
+      messageText: "hi",
+      enabled: false,
+    });
+    const changed = disableCronJob(job.id);
+    expect(changed).toBe(false);
+    expect(getCronJobById(job.id)?.enabled).toBe(false);
+  });
+
+  test("returns false when the row does not exist", () => {
+    expect(disableCronJob("does-not-exist")).toBe(false);
+  });
+
+  test("succeeds even when the row's channel was removed from local config", () => {
+    // This is the scenario `disableCronJob` exists to solve:
+    // a cron job points at a channel that has since been removed from
+    // ode.json. `patchCronJob` would throw via `getChannelSnapshot`, but
+    // the direct-SQL `disableCronJob` must still flip `enabled` to false
+    // so the scheduler stops firing the row.
+    const job = createCronJob({
+      title: "stale-channel",
+      cronExpression: "*/5 * * * *",
+      channelId: "C_TEST",
+      messageText: "hi",
+    });
+
+    // Drop the channel from the on-disk config so getChannelSnapshot fails.
+    const emptyConfig = {
+      user: {},
+      workspaces: [
+        {
+          id: "ws-test",
+          name: "Test Workspace",
+          type: "slack",
+          channelDetails: [], // C_TEST is gone
+        },
+      ],
+    };
+    fs.writeFileSync(ODE_CONFIG_FILE, JSON.stringify(emptyConfig));
+    invalidateOdeConfigCache();
+
+    // Sanity check: patchCronJob blows up because it re-validates the
+    // channel before writing. This is exactly the bug Codex flagged on
+    // PR #211 and is the reason we route around it.
+    expect(() => patchCronJob(job.id, { enabled: false })).toThrow(
+      /Channel not found/i,
+    );
+    expect(getCronJobById(job.id)?.enabled).toBe(true);
+
+    // disableCronJob bypasses channel resolution entirely.
+    expect(disableCronJob(job.id)).toBe(true);
+    expect(getCronJobById(job.id)?.enabled).toBe(false);
   });
 });

--- a/packages/config/local/cron-jobs.ts
+++ b/packages/config/local/cron-jobs.ts
@@ -384,6 +384,31 @@ export function patchCronJob(id: string, params: PatchCronJobParams): CronJobRec
   return updateCronJob(id, merged);
 }
 
+/**
+ * Directly flip `enabled` to 0 without re-validating the rest of the cron
+ * row. Unlike `patchCronJob`, this does NOT re-resolve the row's channel
+ * via `getChannelSnapshot`, so it is safe to call when the destination
+ * channel was removed from the local config — which is exactly the
+ * scenario that motivates auto-disable in the first place (bot kicked,
+ * workspace re-onboarded, channel id stale, etc.).
+ *
+ * Returns `true` if a row actually transitioned from enabled→disabled, so
+ * callers can avoid duplicate log/notification work if another writer beat
+ * them to it. A missing row returns `false` as well.
+ */
+export function disableCronJob(id: string): boolean {
+  const db = getDatabase();
+  const result = db.query(`
+    UPDATE cron_jobs
+    SET
+      enabled = 0,
+      updated_at = ?
+    WHERE id = ?
+      AND enabled = 1
+  `).run(Date.now(), id);
+  return result.changes > 0;
+}
+
 export function markCronJobTriggered(id: string, minuteStartMs: number): boolean {
   const db = getDatabase();
   const result = db.query(`

--- a/packages/core/cron/scheduler.ts
+++ b/packages/core/cron/scheduler.ts
@@ -15,6 +15,7 @@ import {
   markCronJobFailed,
   markCronJobRunning,
   markCronJobTriggered,
+  patchCronJob,
   reconcileInterruptedCronJobs,
 } from "@/config/local/cron-jobs";
 import {
@@ -37,6 +38,7 @@ import { sendSlackChannelMessage } from "@/core/runtime/slack-senders";
 import { buildSessionEnvironment, prepareSessionWorkspace } from "@/core/session";
 import { sendChannelMessage as sendDiscordChannelMessage } from "@/ims/discord/client";
 import { sendChannelMessage as sendLarkChannelMessage } from "@/ims/lark/client";
+import { isPermanentChannelError } from "@/shared/delivery/permanent-error";
 import { log } from "@/utils";
 
 const CRON_POLL_INTERVAL_MS = 15_000;
@@ -265,6 +267,57 @@ async function prepareCronSession(job: CronJobRecord, runId: string): Promise<{
   return { session, sessionId, cwd, created };
 }
 
+/**
+ * Auto-disable a cron job whose destination channel is permanently
+ * unreachable (bot kicked, channel archived, token revoked, etc.). Without
+ * this, every cron tick would re-attempt the same send and capture an
+ * identical Sentry event for the lifetime of the daemon — see
+ * `isPermanentChannelError` for the precise classification.
+ *
+ * Best-effort: we never let bookkeeping failures here shadow the original
+ * delivery error. The function does NOT throw.
+ */
+async function disableCronJobForPermanentChannelError(
+  job: CronJobRecord,
+  error: unknown,
+  agentResultDetailId: string | null,
+): Promise<void> {
+  const reason = error instanceof Error ? error.message : String(error);
+  const summary = `auto-disabled: destination channel unreachable (${reason})`;
+  if (agentResultDetailId) {
+    try {
+      failAgentResult({ detailId: agentResultDetailId, errorText: summary });
+    } catch (failError) {
+      log.warn("Failed to mark cron agent_result detail as failed during auto-disable", {
+        detailId: agentResultDetailId,
+        error: String(failError),
+      });
+    }
+  }
+  try {
+    patchCronJob(job.id, { enabled: false });
+  } catch (disableError) {
+    log.warn("Failed to disable cron job after permanent channel error", {
+      cronJobId: job.id,
+      error: String(disableError),
+    });
+  }
+  try {
+    markCronJobFailed(job.id, summary);
+  } catch (markError) {
+    log.warn("Failed to mark auto-disabled cron job as failed", {
+      cronJobId: job.id,
+      error: String(markError),
+    });
+  }
+  log.warn("Auto-disabled cron job: destination channel unreachable", {
+    cronJobId: job.id,
+    title: job.title,
+    channelId: job.channelId,
+    error: reason,
+  });
+}
+
 async function runCronJob(job: CronJobRecord, minuteStartMs: number): Promise<void> {
   const agent = createAgentAdapter();
   const runId = getCronRunId(minuteStartMs);
@@ -350,7 +403,22 @@ async function runCronJob(job: CronJobRecord, minuteStartMs: number): Promise<vo
     );
     const finalText = buildFinalResponseText(responses) ?? "_Done_";
 
-    const realThreadId = await sendResultToChannel(job, finalText);
+    let realThreadId: string | undefined;
+    try {
+      realThreadId = await sendResultToChannel(job, finalText);
+    } catch (sendError) {
+      // The agent turn succeeded, but we can't deliver the result. If the
+      // channel is permanently unreachable (bot kicked, channel archived,
+      // token revoked), auto-disable the job so the scheduler stops
+      // generating identical Sentry events on every tick. Transient send
+      // failures fall through to the generic error handler below and the
+      // job stays enabled for the next tick.
+      if (isPermanentChannelError(sendError)) {
+        await disableCronJobForPermanentChannelError(job, sendError, agentResultDetailId);
+        return;
+      }
+      throw sendError;
+    }
     if (realThreadId) {
       seedCronChannelThreadSession({
         platform: job.platform,
@@ -409,6 +477,34 @@ async function runCronJob(job: CronJobRecord, minuteStartMs: number): Promise<vo
       const failureText = `*Cron job failed:* ${job.title}\n${message}`;
       await sendResultToChannel(job, failureText);
     } catch (notifyError) {
+      // If the failure-notification itself hits a permanent channel error,
+      // the destination is the real problem (not the agent turn). Auto-
+      // disable so we don't spam the same channel on every tick. We
+      // intentionally check the *notify* error here, not the original
+      // `error`, because the original could be a transient agent timeout
+      // while the channel is still healthy.
+      if (isPermanentChannelError(notifyError)) {
+        try {
+          patchCronJob(job.id, { enabled: false });
+          markCronJobFailed(
+            job.id,
+            `auto-disabled: channel unreachable (${message})`,
+          );
+          log.warn("Auto-disabled cron job: destination channel unreachable", {
+            cronJobId: job.id,
+            title: job.title,
+            channelId: job.channelId,
+            originalError: message,
+            sendError: String(notifyError),
+          });
+        } catch (disableError) {
+          log.warn("Failed to auto-disable cron job after permanent channel error", {
+            cronJobId: job.id,
+            error: String(disableError),
+          });
+        }
+        return;
+      }
       log.warn("Failed to send cron job failure notification", {
         cronJobId: job.id,
         error: String(notifyError),

--- a/packages/core/cron/scheduler.ts
+++ b/packages/core/cron/scheduler.ts
@@ -9,13 +9,13 @@ import {
 } from "@/config";
 import {
   type CronJobRecord,
+  disableCronJob,
   getCronJobById,
   listEnabledCronJobs,
   markCronJobCompleted,
   markCronJobFailed,
   markCronJobRunning,
   markCronJobTriggered,
-  patchCronJob,
   reconcileInterruptedCronJobs,
 } from "@/config/local/cron-jobs";
 import {
@@ -295,7 +295,7 @@ async function disableCronJobForPermanentChannelError(
     }
   }
   try {
-    patchCronJob(job.id, { enabled: false });
+    disableCronJob(job.id);
   } catch (disableError) {
     log.warn("Failed to disable cron job after permanent channel error", {
       cronJobId: job.id,
@@ -485,7 +485,7 @@ async function runCronJob(job: CronJobRecord, minuteStartMs: number): Promise<vo
       // while the channel is still healthy.
       if (isPermanentChannelError(notifyError)) {
         try {
-          patchCronJob(job.id, { enabled: false });
+          disableCronJob(job.id);
           markCronJobFailed(
             job.id,
             `auto-disabled: channel unreachable (${message})`,

--- a/packages/core/cron/scheduler.ts
+++ b/packages/core/cron/scheduler.ts
@@ -140,7 +140,22 @@ async function sendResultToChannel(
   if (job.platform === "discord") {
     return sendDiscordChannelMessage(job.channelId, text);
   }
-  return sendLarkChannelMessage(job.channelId, text);
+  const larkResult = await sendLarkChannelMessage(job.channelId, text);
+  if (larkResult === undefined) {
+    // `sendLarkChannelMessage` returns `undefined` (without throwing) only
+    // when `getLarkCredentialsForProcessor` cannot find credentials for the
+    // channel — i.e. the Lark workspace/channel config has been removed.
+    // Without this guard the cron scheduler treats the run as delivered,
+    // marks it completed, and the job stays enabled and silently
+    // undelivered forever (see PR #211 review: "Treat undefined sends as
+    // delivery failures"). Throwing a message whose text matches
+    // `isPermanentChannelError` lets the existing catch-branch auto-
+    // disable this job the same way an explicit `chat_not_found` would.
+    throw new Error(
+      `Lark send returned no message id for channel ${job.channelId} (chat_not_found or credentials missing)`,
+    );
+  }
+  return larkResult;
 }
 
 /**

--- a/packages/core/cron/scheduler.ts
+++ b/packages/core/cron/scheduler.ts
@@ -36,7 +36,10 @@ import { buildMessageOptions } from "@/core/runtime/message-options";
 import { buildFinalResponseText, categorizeRuntimeError } from "@/core/runtime/helpers";
 import { sendSlackChannelMessage } from "@/core/runtime/slack-senders";
 import { buildSessionEnvironment, prepareSessionWorkspace } from "@/core/session";
-import { sendChannelMessage as sendDiscordChannelMessage } from "@/ims/discord/client";
+import {
+  sendChannelMessage as sendDiscordChannelMessage,
+  sendChannelMessageForWorkspace as sendDiscordChannelMessageForWorkspace,
+} from "@/ims/discord/client";
 import { sendChannelMessage as sendLarkChannelMessage } from "@/ims/lark/client";
 import { isPermanentChannelError } from "@/shared/delivery/permanent-error";
 import { log } from "@/utils";
@@ -138,6 +141,12 @@ async function sendResultToChannel(
     return sendSlackChannelMessage(job.channelId, text);
   }
   if (job.platform === "discord") {
+    if (job.workspaceId) {
+      return sendDiscordChannelMessageForWorkspace(job.channelId, text, job.workspaceId);
+    }
+    // Legacy rows may predate workspace snapshots. Keep their existing
+    // unpinned fallback rather than guessing a workspace, but all newly
+    // created cron rows use the exact stored workspace route above.
     return sendDiscordChannelMessage(job.channelId, text);
   }
   const larkResult = await sendLarkChannelMessage(job.channelId, text);

--- a/packages/ims/discord/client.ts
+++ b/packages/ims/discord/client.ts
@@ -117,6 +117,20 @@ async function maybeHandleLauncherCommand(params: {
 }
 async function resolveTextChannel(channelId: string, processorId?: string) {
   const attempts: string[] = [];
+  // Collect Discord API error codes across every fetch attempt so the
+  // caller can detect permanent-access failures (Unknown Channel / Missing
+  // Access / etc.) even though we re-throw a generic wrapper Error below.
+  // discord.js surfaces these on `err.code` as numbers; we forward them on
+  // the wrapper as `discordErrorCodes` and also expose the first as `code`
+  // so `isPermanentChannelError` can pick it up via the `code` shape.
+  const discordErrorCodes: number[] = [];
+  const captureCode = (error: unknown) => {
+    if (typeof error === "object" && error !== null) {
+      const code = (error as { code?: unknown }).code;
+      if (typeof code === "number") discordErrorCodes.push(code);
+    }
+  };
+
   if (processorId) {
     const pinnedClient = discordClientByProcessorId.get(processorId);
     if (pinnedClient) {
@@ -127,6 +141,7 @@ async function resolveTextChannel(channelId: string, processorId?: string) {
         }
         attempts.push(`bot=${pinnedClient.user?.id || "unknown"}: channel_not_text_or_missing`);
       } catch (error) {
+        captureCode(error);
         const errorMessage = error instanceof Error ? error.message : String(error);
         attempts.push(`bot=${pinnedClient.user?.id || "unknown"}: ${errorMessage}`);
       }
@@ -142,6 +157,7 @@ async function resolveTextChannel(channelId: string, processorId?: string) {
       }
       attempts.push(`bot=${client.user?.id || "unknown"}: channel_not_text_or_missing`);
     } catch (error) {
+      captureCode(error);
       const errorMessage = error instanceof Error ? error.message : String(error);
       attempts.push(`bot=${client.user?.id || "unknown"}: ${errorMessage}`);
     }
@@ -155,7 +171,20 @@ async function resolveTextChannel(channelId: string, processorId?: string) {
     });
   }
 
-  throw new Error(`Discord channel ${channelId} is not text-based or inaccessible`);
+  const wrapper = new Error(`Discord channel ${channelId} is not text-based or inaccessible`);
+  if (discordErrorCodes.length > 0) {
+    // Prefer the most informative code: prioritise "permanent" classes
+    // (10003 Unknown Channel, 50001 Missing Access, 50013 Missing Perms,
+    // 50007 Cannot DM) so isPermanentChannelError can disable the cron row
+    // even if some bots failed transiently.
+    const PERMANENT_PRIORITY = new Set([10003, 50001, 50013, 50007]);
+    const permanent = discordErrorCodes.find((c) => PERMANENT_PRIORITY.has(c));
+    (wrapper as Error & { code?: number; discordErrorCodes?: number[] }).code =
+      permanent ?? discordErrorCodes[0];
+    (wrapper as Error & { code?: number; discordErrorCodes?: number[] }).discordErrorCodes =
+      [...discordErrorCodes];
+  }
+  throw wrapper;
 }
 
 async function buildDiscordContext(

--- a/packages/ims/discord/client.ts
+++ b/packages/ims/discord/client.ts
@@ -133,7 +133,15 @@ async function resolveTextChannel(channelId: string, processorId?: string) {
   const discordErrorCodes: number[] = [];
   let pinnedBotErrorCode: number | undefined;
   let pinnedBotAttempted = false;
+  // Count every fetch attempt that ended in a thrown error — not just the
+  // subset that carried a numeric `err.code`. The wrapper's
+  // `isPermanentChannelError` classification must NOT promote to permanent
+  // when any attempt failed transiently (e.g. ECONNRESET, generic network
+  // error), because that bot might succeed on retry. See PR #211 discussion:
+  // "Require every Discord fetch attempt to be permanent".
+  let totalFailedAttempts = 0;
   const captureCode = (error: unknown, isPinnedBot: boolean) => {
+    totalFailedAttempts += 1;
     if (typeof error === "object" && error !== null) {
       const code = (error as { code?: unknown }).code;
       if (typeof code === "number") {
@@ -195,15 +203,21 @@ async function resolveTextChannel(channelId: string, processorId?: string) {
     //      same channel are unrelated noise.
     //   2. If no pinned bot was attempted (e.g. cron top-level send with
     //      no processorId), only treat the failure as permanent when every
-    //      captured code is permanent. Mixed transient+permanent means at
-    //      least one bot might succeed on retry, so do NOT promote.
+    //      failed attempt carried a permanent code. A transient failure
+    //      (ECONNRESET, network blip) without a numeric `code` would not
+    //      appear in `discordErrorCodes`, so counting only those would let
+    //      an unrelated bot's permanent code promote the wrapper even though
+    //      a retry might succeed. We therefore also require that the number
+    //      of captured permanent codes equals the number of failed attempts.
     let forwardedCode: number | undefined;
     if (pinnedBotAttempted) {
       forwardedCode = pinnedBotErrorCode;
     } else {
-      const allPermanent = discordErrorCodes.every((c) => PERMANENT_PRIORITY.has(c));
-      if (allPermanent) {
-        forwardedCode = discordErrorCodes.find((c) => PERMANENT_PRIORITY.has(c));
+      const permanentCodes = discordErrorCodes.filter((c) => PERMANENT_PRIORITY.has(c));
+      const allAttemptsPermanent =
+        permanentCodes.length === totalFailedAttempts && totalFailedAttempts > 0;
+      if (allAttemptsPermanent) {
+        forwardedCode = permanentCodes[0];
       } else {
         forwardedCode = discordErrorCodes[0];
       }

--- a/packages/ims/discord/client.ts
+++ b/packages/ims/discord/client.ts
@@ -123,17 +123,30 @@ async function resolveTextChannel(channelId: string, processorId?: string) {
   // discord.js surfaces these on `err.code` as numbers; we forward them on
   // the wrapper as `discordErrorCodes` and also expose the first as `code`
   // so `isPermanentChannelError` can pick it up via the `code` shape.
+  //
+  // The pinned bot's code is tracked separately: when `processorId` is
+  // provided we know which bot actually owns the channel, so its result
+  // is authoritative and unrelated bots' "permanent" errors (e.g. another
+  // workspace's bot legitimately returning `Missing Access` for a channel
+  // it cannot see) MUST NOT promote the wrapper to permanent. See PR #211
+  // discussion: "Avoid disabling Discord jobs on mixed fetch failures".
   const discordErrorCodes: number[] = [];
-  const captureCode = (error: unknown) => {
+  let pinnedBotErrorCode: number | undefined;
+  let pinnedBotAttempted = false;
+  const captureCode = (error: unknown, isPinnedBot: boolean) => {
     if (typeof error === "object" && error !== null) {
       const code = (error as { code?: unknown }).code;
-      if (typeof code === "number") discordErrorCodes.push(code);
+      if (typeof code === "number") {
+        discordErrorCodes.push(code);
+        if (isPinnedBot) pinnedBotErrorCode = code;
+      }
     }
   };
 
   if (processorId) {
     const pinnedClient = discordClientByProcessorId.get(processorId);
     if (pinnedClient) {
+      pinnedBotAttempted = true;
       try {
         const channel = await pinnedClient.channels.fetch(channelId);
         if (channel && channel.isTextBased()) {
@@ -141,7 +154,7 @@ async function resolveTextChannel(channelId: string, processorId?: string) {
         }
         attempts.push(`bot=${pinnedClient.user?.id || "unknown"}: channel_not_text_or_missing`);
       } catch (error) {
-        captureCode(error);
+        captureCode(error, true);
         const errorMessage = error instanceof Error ? error.message : String(error);
         attempts.push(`bot=${pinnedClient.user?.id || "unknown"}: ${errorMessage}`);
       }
@@ -157,7 +170,7 @@ async function resolveTextChannel(channelId: string, processorId?: string) {
       }
       attempts.push(`bot=${client.user?.id || "unknown"}: channel_not_text_or_missing`);
     } catch (error) {
-      captureCode(error);
+      captureCode(error, false);
       const errorMessage = error instanceof Error ? error.message : String(error);
       attempts.push(`bot=${client.user?.id || "unknown"}: ${errorMessage}`);
     }
@@ -173,14 +186,32 @@ async function resolveTextChannel(channelId: string, processorId?: string) {
 
   const wrapper = new Error(`Discord channel ${channelId} is not text-based or inaccessible`);
   if (discordErrorCodes.length > 0) {
-    // Prefer the most informative code: prioritise "permanent" classes
-    // (10003 Unknown Channel, 50001 Missing Access, 50013 Missing Perms,
-    // 50007 Cannot DM) so isPermanentChannelError can disable the cron row
-    // even if some bots failed transiently.
     const PERMANENT_PRIORITY = new Set([10003, 50001, 50013, 50007]);
-    const permanent = discordErrorCodes.find((c) => PERMANENT_PRIORITY.has(c));
-    (wrapper as Error & { code?: number; discordErrorCodes?: number[] }).code =
-      permanent ?? discordErrorCodes[0];
+
+    // Pick which code to forward as the `code` field consumed by
+    // `isPermanentChannelError`. Rules:
+    //   1. If a pinned bot was attempted, its outcome is authoritative —
+    //      forward its code (if any). Other bots' permanent codes for the
+    //      same channel are unrelated noise.
+    //   2. If no pinned bot was attempted (e.g. cron top-level send with
+    //      no processorId), only treat the failure as permanent when every
+    //      captured code is permanent. Mixed transient+permanent means at
+    //      least one bot might succeed on retry, so do NOT promote.
+    let forwardedCode: number | undefined;
+    if (pinnedBotAttempted) {
+      forwardedCode = pinnedBotErrorCode;
+    } else {
+      const allPermanent = discordErrorCodes.every((c) => PERMANENT_PRIORITY.has(c));
+      if (allPermanent) {
+        forwardedCode = discordErrorCodes.find((c) => PERMANENT_PRIORITY.has(c));
+      } else {
+        forwardedCode = discordErrorCodes[0];
+      }
+    }
+
+    if (forwardedCode !== undefined) {
+      (wrapper as Error & { code?: number; discordErrorCodes?: number[] }).code = forwardedCode;
+    }
     (wrapper as Error & { code?: number; discordErrorCodes?: number[] }).discordErrorCodes =
       [...discordErrorCodes];
   }

--- a/packages/ims/discord/client.ts
+++ b/packages/ims/discord/client.ts
@@ -49,6 +49,8 @@ import {
 } from "@/ims/discord/utils/rate-limit";
 import { DiscordStatusMessageIndex } from "@/ims/discord/state/status-message-index";
 import type { RawInboundEvent } from "@/core/model/raw-inbound-event";
+import { requireDiscordWorkspaceClient } from "@/ims/discord/workspace-routing";
+import { DISCORD_CHANNEL_NOT_TEXT_BASED_CODE } from "@/shared/delivery/permanent-error";
 
 const DISCORD_MESSAGE_LIMIT = 2000;
 const DISCORD_THREAD_NAME_LIMIT = 25;
@@ -317,19 +319,66 @@ export async function sendChannelMessage(
 ): Promise<string | undefined> {
   try {
     const channel = await resolveTextChannel(channelId, processorId);
-    const formattedText = markdownToDiscord(text);
-    const chunks = splitForDiscord(formattedText, DISCORD_MESSAGE_LIMIT);
-    let firstId: string | undefined;
-    for (let index = 0; index < chunks.length; index += 1) {
-      const chunk = chunks[index] ?? "";
-      const sent = await channel.send(chunk);
-      firstId = firstId || sent.id;
-      statusMessageIndex.setThreadId(sent.id, channelId);
-    }
-    return firstId;
+    return await sendResolvedChannelMessage(channelId, text, channel);
   } catch (error) {
     log.warn("Failed to send Discord top-level channel message", {
       channelId,
+      textLength: text.length,
+      error: String(error),
+    });
+    throw error;
+  }
+}
+
+async function sendResolvedChannelMessage(
+  channelId: string,
+  text: string,
+  channel: { send: (text: string) => Promise<{ id: string }> },
+): Promise<string | undefined> {
+  const formattedText = markdownToDiscord(text);
+  const chunks = splitForDiscord(formattedText, DISCORD_MESSAGE_LIMIT);
+  let firstId: string | undefined;
+  for (let index = 0; index < chunks.length; index += 1) {
+    const chunk = chunks[index] ?? "";
+    const sent = await channel.send(chunk);
+    firstId = firstId || sent.id;
+    statusMessageIndex.setThreadId(sent.id, channelId);
+  }
+  return firstId;
+}
+
+function isSendableDiscordChannel(
+  channel: unknown,
+): channel is { send: (text: string) => Promise<{ id: string }> } {
+  return typeof channel === "object"
+    && channel !== null
+    && "send" in channel
+    && typeof channel.send === "function";
+}
+
+export async function sendChannelMessageForWorkspace(
+  channelId: string,
+  text: string,
+  workspaceId: string,
+): Promise<string | undefined> {
+  try {
+    const client = requireDiscordWorkspaceClient({
+      workspaceId,
+      configuredWorkspaceIds: getConfiguredDiscordRuntimeBots().map((bot) => bot.workspaceId),
+      connectedClients: discordClients,
+    });
+    const channel = await client.channels.fetch(channelId);
+    if (!channel || !channel.isTextBased() || !isSendableDiscordChannel(channel)) {
+      throw Object.assign(
+        new Error(`Discord channel ${channelId} is not text-based or inaccessible`),
+        { code: DISCORD_CHANNEL_NOT_TEXT_BASED_CODE },
+      );
+    }
+    return await sendResolvedChannelMessage(channelId, text, channel);
+  } catch (error) {
+    log.warn("Failed to send Discord top-level channel message for workspace", {
+      channelId,
+      workspaceId,
       textLength: text.length,
       error: String(error),
     });

--- a/packages/ims/discord/client.ts
+++ b/packages/ims/discord/client.ts
@@ -209,6 +209,19 @@ async function resolveTextChannel(channelId: string, processorId?: string) {
     //      an unrelated bot's permanent code promote the wrapper even though
     //      a retry might succeed. We therefore also require that the number
     //      of captured permanent codes equals the number of failed attempts.
+    //
+    //      When the attempts are mixed (some permanent, some not), we must
+    //      NOT forward any permanent code as the wrapper's `code` field —
+    //      otherwise `isPermanentChannelError` (which classifies purely on
+    //      the numeric `code`) would auto-disable the cron even though at
+    //      least one retryable failure was in the mix. We fall back to the
+    //      first *non-permanent* code (still useful diagnostic signal on
+    //      the wrapper without triggering permanent classification); if
+    //      every captured code is permanent but `totalFailedAttempts`
+    //      exceeds that count (i.e. an untyped transient error is also in
+    //      play), we suppress the code entirely. See PR #211 discussion:
+    //      "Avoid forwarding a permanent code after a mixed Discord
+    //      failure".
     let forwardedCode: number | undefined;
     if (pinnedBotAttempted) {
       forwardedCode = pinnedBotErrorCode;
@@ -219,7 +232,12 @@ async function resolveTextChannel(channelId: string, processorId?: string) {
       if (allAttemptsPermanent) {
         forwardedCode = permanentCodes[0];
       } else {
-        forwardedCode = discordErrorCodes[0];
+        // Mixed attempts: never expose a permanent code on the wrapper.
+        // Prefer the first non-permanent numeric code for diagnostics; if
+        // no non-permanent code was captured, leave `code` undefined so
+        // the failure stays classified as retryable.
+        const nonPermanentCode = discordErrorCodes.find((c) => !PERMANENT_PRIORITY.has(c));
+        forwardedCode = nonPermanentCode;
       }
     }
 

--- a/packages/ims/discord/workspace-routing.test.ts
+++ b/packages/ims/discord/workspace-routing.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test";
+import { DISCORD_WORKSPACE_NOT_CONFIGURED_CODE } from "@/shared/delivery/permanent-error";
+import { requireDiscordWorkspaceClient } from "./workspace-routing";
+
+describe("Discord workspace routing", () => {
+  it("selects only the client belonging to the cron workspace", () => {
+    const owner = { id: "owner" };
+    const unrelated = { id: "unrelated" };
+    const selected = requireDiscordWorkspaceClient({
+      workspaceId: "workspace-owner",
+      configuredWorkspaceIds: ["workspace-owner", "workspace-other"],
+      connectedClients: new Map([
+        ["workspace-other", unrelated],
+        ["workspace-owner", owner],
+      ]),
+    });
+
+    expect(selected).toBe(owner);
+  });
+
+  it("keeps a configured workspace retryable while its client reconnects", () => {
+    expect(() => requireDiscordWorkspaceClient({
+      workspaceId: "workspace-owner",
+      configuredWorkspaceIds: ["workspace-owner"],
+      connectedClients: new Map(),
+    })).toThrow("temporarily unavailable");
+
+    try {
+      requireDiscordWorkspaceClient({
+        workspaceId: "workspace-owner",
+        configuredWorkspaceIds: ["workspace-owner"],
+        connectedClients: new Map(),
+      });
+    } catch (error) {
+      expect((error as { code?: unknown }).code).toBeUndefined();
+    }
+  });
+
+  it("marks a removed workspace as permanently unconfigured", () => {
+    try {
+      requireDiscordWorkspaceClient({
+        workspaceId: "workspace-owner",
+        configuredWorkspaceIds: ["workspace-other"],
+        connectedClients: new Map(),
+      });
+      throw new Error("Expected workspace resolution to fail");
+    } catch (error) {
+      expect((error as { code?: unknown }).code).toBe(DISCORD_WORKSPACE_NOT_CONFIGURED_CODE);
+    }
+  });
+});

--- a/packages/ims/discord/workspace-routing.ts
+++ b/packages/ims/discord/workspace-routing.ts
@@ -1,0 +1,24 @@
+import { DISCORD_WORKSPACE_NOT_CONFIGURED_CODE } from "@/shared/delivery/permanent-error";
+
+export function requireDiscordWorkspaceClient<T>(params: {
+  workspaceId: string;
+  configuredWorkspaceIds: Iterable<string>;
+  connectedClients: ReadonlyMap<string, T>;
+}): T {
+  const configuredWorkspaceIds = new Set(params.configuredWorkspaceIds);
+  if (!configuredWorkspaceIds.has(params.workspaceId)) {
+    throw Object.assign(
+      new Error(`Discord workspace ${params.workspaceId} is no longer configured`),
+      { code: DISCORD_WORKSPACE_NOT_CONFIGURED_CODE },
+    );
+  }
+
+  const client = params.connectedClients.get(params.workspaceId);
+  if (!client) {
+    // The workspace is still configured, so this is most likely a transient
+    // login/restart failure. Do not attach a permanent error code: the cron
+    // scheduler must keep the job enabled and retry on its next occurrence.
+    throw new Error(`Discord workspace ${params.workspaceId} client is temporarily unavailable`);
+  }
+  return client;
+}

--- a/packages/shared/delivery/permanent-error.test.ts
+++ b/packages/shared/delivery/permanent-error.test.ts
@@ -103,4 +103,21 @@ describe("isPermanentChannelError", () => {
     // must remain retryable from this helper's perspective.
     expect(isPermanentChannelError(new Error("message_not_found"))).toBe(false);
   });
+
+  test("matches the synthetic 'Lark send returned no message id' wrapper", () => {
+    // `packages/core/cron/scheduler.ts::sendResultToChannel` synthesizes
+    // this error when `sendLarkChannelMessage` returns `undefined`
+    // (missing Lark credentials for the channel — a permanent config
+    // problem the daemon cannot self-heal). The wrapper text embeds
+    // `chat_not_found` so this classifier catches it via the shared
+    // token list. See PR #211 review: "Treat undefined sends as delivery
+    // failures".
+    expect(
+      isPermanentChannelError(
+        new Error(
+          "Lark send returned no message id for channel oc_xxxx (chat_not_found or credentials missing)",
+        ),
+      ),
+    ).toBe(true);
+  });
 });

--- a/packages/shared/delivery/permanent-error.test.ts
+++ b/packages/shared/delivery/permanent-error.test.ts
@@ -68,6 +68,22 @@ describe("isPermanentChannelError", () => {
     expect(isPermanentChannelError(transientCode)).toBe(false);
   });
 
+  test("does not classify wrapper as permanent when only discordErrorCodes carries permanent codes", () => {
+    // Regression guard for PR #211 review "Avoid forwarding a permanent
+    // code after a mixed Discord failure": when `resolveTextChannel`
+    // observes a mixed set of failures (e.g. bot A returned 10003 Unknown
+    // Channel, bot B returned 50035 Invalid Form Body), the wrapper still
+    // exposes every captured code on `discordErrorCodes` for diagnostics,
+    // but `code` must be undefined or non-permanent. `isPermanentChannelError`
+    // only inspects `code`, so a wrapper carrying `discordErrorCodes:
+    // [10003, 50035]` with no `code` must NOT be classified as permanent.
+    const wrapper = Object.assign(
+      new Error("Discord channel 123 is not text-based or inaccessible"),
+      { discordErrorCodes: [10003, 50035] },
+    );
+    expect(isPermanentChannelError(wrapper)).toBe(false);
+  });
+
   test("matches Lark chat_not_found", () => {
     expect(isPermanentChannelError(new Error("chat_not_found: chat does not exist"))).toBe(true);
   });

--- a/packages/shared/delivery/permanent-error.test.ts
+++ b/packages/shared/delivery/permanent-error.test.ts
@@ -51,8 +51,35 @@ describe("isPermanentChannelError", () => {
     expect(isPermanentChannelError(wrapper)).toBe(true);
   });
 
+  test("ignores Discord resolveTextChannel wrapper without a forwarded code", () => {
+    // When `resolveTextChannel` cannot confidently identify a permanent
+    // failure (e.g. mixed pinned-bot transient + unrelated-bot permanent),
+    // it forwards a non-permanent or no `code`. The classifier must not
+    // promote those to permanent on the wrapper's message alone. See PR
+    // #211 discussion: "Avoid disabling Discord jobs on mixed fetch
+    // failures".
+    const noCode = new Error("Discord channel 123 is not text-based or inaccessible");
+    expect(isPermanentChannelError(noCode)).toBe(false);
+
+    const transientCode = Object.assign(
+      new Error("Discord channel 123 is not text-based or inaccessible"),
+      { code: 500 },
+    );
+    expect(isPermanentChannelError(transientCode)).toBe(false);
+  });
+
   test("matches Lark chat_not_found", () => {
     expect(isPermanentChannelError(new Error("chat_not_found: chat does not exist"))).toBe(true);
+  });
+
+  test("matches Lark deleted-chat message text alone", () => {
+    // larkApi() re-throws the raw `msg` field from the Lark API for some
+    // payloads — for stale/deleted group chats this surfaces as just
+    // "chat does not exist", without the `chat_not_found` token. The
+    // shorter "chat not exist" token does NOT match this string because
+    // of the "does" infix, so we list the long form explicitly. See PR
+    // #211 discussion: "Match Lark's deleted-chat message".
+    expect(isPermanentChannelError(new Error("chat does not exist"))).toBe(true);
   });
 
   test("ignores transient / retryable failures", () => {

--- a/packages/shared/delivery/permanent-error.test.ts
+++ b/packages/shared/delivery/permanent-error.test.ts
@@ -39,6 +39,18 @@ describe("isPermanentChannelError", () => {
     ).toBe(true);
   });
 
+  test("matches the Discord resolveTextChannel wrapper when it carries a DiscordAPIError code", () => {
+    // resolveTextChannel() in packages/ims/discord/client.ts wraps the
+    // underlying DiscordAPIError in a generic Error("... is not text-based
+    // or inaccessible"). The wrapper forwards the original numeric `code`
+    // so this helper can still classify it as permanent.
+    const wrapper = Object.assign(
+      new Error("Discord channel 123 is not text-based or inaccessible"),
+      { code: 10003 },
+    );
+    expect(isPermanentChannelError(wrapper)).toBe(true);
+  });
+
   test("matches Lark chat_not_found", () => {
     expect(isPermanentChannelError(new Error("chat_not_found: chat does not exist"))).toBe(true);
   });

--- a/packages/shared/delivery/permanent-error.test.ts
+++ b/packages/shared/delivery/permanent-error.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { isPermanentChannelError } from "./permanent-error";
+import {
+  DISCORD_CHANNEL_NOT_TEXT_BASED_CODE,
+  DISCORD_WORKSPACE_NOT_CONFIGURED_CODE,
+  isPermanentChannelError,
+} from "./permanent-error";
 
 describe("isPermanentChannelError", () => {
   test("matches Slack channel_not_found in message", () => {
@@ -37,6 +41,17 @@ describe("isPermanentChannelError", () => {
     expect(
       isPermanentChannelError(Object.assign(new Error("Unknown Channel"), { code: 10003 })),
     ).toBe(true);
+  });
+
+  test("matches Discord workspace routing errors that require configuration changes", () => {
+    expect(isPermanentChannelError(Object.assign(
+      new Error("Discord workspace ws-1 is no longer configured"),
+      { code: DISCORD_WORKSPACE_NOT_CONFIGURED_CODE },
+    ))).toBe(true);
+    expect(isPermanentChannelError(Object.assign(
+      new Error("Discord channel 123 is not text-based"),
+      { code: DISCORD_CHANNEL_NOT_TEXT_BASED_CODE },
+    ))).toBe(true);
   });
 
   test("matches the Discord resolveTextChannel wrapper when it carries a DiscordAPIError code", () => {

--- a/packages/shared/delivery/permanent-error.test.ts
+++ b/packages/shared/delivery/permanent-error.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { isPermanentChannelError } from "./permanent-error";
+
+describe("isPermanentChannelError", () => {
+  test("matches Slack channel_not_found in message", () => {
+    expect(
+      isPermanentChannelError(
+        new Error("An API error occurred: channel_not_found"),
+      ),
+    ).toBe(true);
+  });
+
+  test("matches Slack SDK error shape with data.error", () => {
+    const err = Object.assign(new Error("slack_webapi_platform_error"), {
+      data: { error: "channel_not_found" },
+    });
+    expect(isPermanentChannelError(err)).toBe(true);
+  });
+
+  test("matches Slack not_in_channel / is_archived / account_inactive", () => {
+    expect(isPermanentChannelError(new Error("not_in_channel"))).toBe(true);
+    expect(isPermanentChannelError(new Error("is_archived"))).toBe(true);
+    expect(isPermanentChannelError(new Error("channel_is_archived"))).toBe(true);
+    expect(isPermanentChannelError(new Error("account_inactive"))).toBe(true);
+  });
+
+  test("matches Slack auth-revoked errors", () => {
+    expect(isPermanentChannelError(new Error("token_revoked"))).toBe(true);
+    expect(isPermanentChannelError(new Error("invalid_auth"))).toBe(true);
+    expect(isPermanentChannelError(new Error("missing_scope"))).toBe(true);
+  });
+
+  test("matches Discord-style numeric codes (Missing Access, Unknown Channel)", () => {
+    expect(
+      isPermanentChannelError(Object.assign(new Error("Missing Access"), { code: 50001 })),
+    ).toBe(true);
+    expect(
+      isPermanentChannelError(Object.assign(new Error("Unknown Channel"), { code: 10003 })),
+    ).toBe(true);
+  });
+
+  test("matches Lark chat_not_found", () => {
+    expect(isPermanentChannelError(new Error("chat_not_found: chat does not exist"))).toBe(true);
+  });
+
+  test("ignores transient / retryable failures", () => {
+    expect(isPermanentChannelError(new Error("status 429"))).toBe(false);
+    expect(isPermanentChannelError(new Error("ECONNRESET"))).toBe(false);
+    expect(isPermanentChannelError(new Error("status 500"))).toBe(false);
+    expect(isPermanentChannelError(new Error("socket hang up"))).toBe(false);
+    expect(isPermanentChannelError(new Error("rate_limited"))).toBe(false);
+  });
+
+  test("ignores nullish / empty inputs", () => {
+    expect(isPermanentChannelError(null)).toBe(false);
+    expect(isPermanentChannelError(undefined)).toBe(false);
+    expect(isPermanentChannelError("")).toBe(false);
+    expect(isPermanentChannelError({})).toBe(false);
+  });
+
+  test("ignores message_not_found (that's a delete/update race, not permanent)", () => {
+    // `message_not_found` is already handled as a benign update/delete race
+    // in @/core/observability/sentry. It is NOT a channel-access problem and
+    // must remain retryable from this helper's perspective.
+    expect(isPermanentChannelError(new Error("message_not_found"))).toBe(false);
+  });
+});

--- a/packages/shared/delivery/permanent-error.ts
+++ b/packages/shared/delivery/permanent-error.ts
@@ -32,8 +32,8 @@
 //   - 50007 Cannot send messages to this user
 //
 // Lark (open-platform error codes vary; we match the common "permission
-// denied" / "chat not exist" message text):
-//   - chat_not_found / chat does not exist
+// denied" / "chat not exist" / "chat does not exist" message text):
+//   - chat_not_found / chat not exist / chat does not exist
 //   - permission denied (generic; only matched when paired with chat context)
 const PERMANENT_MESSAGE_TOKENS = [
   // Slack
@@ -49,6 +49,12 @@ const PERMANENT_MESSAGE_TOKENS = [
   // Lark
   "chat_not_found",
   "chat not exist",
+  // `larkApi` re-throws the raw `msg` text from the Lark API for some
+  // payloads (notably stale/deleted group chats), which surfaces as the
+  // human-readable "chat does not exist". The shorter "chat not exist"
+  // token does not contain this substring (due to the "does" infix), so
+  // we list it explicitly.
+  "chat does not exist",
 ];
 
 // Discord.js surfaces the raw API code on `err.code` as a number.

--- a/packages/shared/delivery/permanent-error.ts
+++ b/packages/shared/delivery/permanent-error.ts
@@ -57,12 +57,18 @@ const PERMANENT_MESSAGE_TOKENS = [
   "chat does not exist",
 ];
 
-// Discord.js surfaces the raw API code on `err.code` as a number.
-const PERMANENT_DISCORD_CODES = new Set<number>([
+export const DISCORD_WORKSPACE_NOT_CONFIGURED_CODE = "DISCORD_WORKSPACE_NOT_CONFIGURED";
+export const DISCORD_CHANNEL_NOT_TEXT_BASED_CODE = "DISCORD_CHANNEL_NOT_TEXT_BASED";
+
+// Discord.js surfaces API codes on `err.code`; Ode adds stable string codes
+// for local configuration failures that likewise need human intervention.
+const PERMANENT_DISCORD_CODES = new Set<number | string>([
   10003, // Unknown Channel
   50001, // Missing Access
   50013, // Missing Permissions
   50007, // Cannot send messages to this user
+  DISCORD_WORKSPACE_NOT_CONFIGURED_CODE,
+  DISCORD_CHANNEL_NOT_TEXT_BASED_CODE,
 ]);
 
 function stringifyError(err: unknown): string {
@@ -83,7 +89,7 @@ export function isPermanentChannelError(err: unknown): boolean {
   }
   if (typeof err === "object" && err !== null) {
     const code = (err as { code?: unknown }).code;
-    if (typeof code === "number" && PERMANENT_DISCORD_CODES.has(code)) {
+    if ((typeof code === "number" || typeof code === "string") && PERMANENT_DISCORD_CODES.has(code)) {
       return true;
     }
     // Slack SDK exposes the API error string on `err.data.error`.

--- a/packages/shared/delivery/permanent-error.ts
+++ b/packages/shared/delivery/permanent-error.ts
@@ -1,0 +1,94 @@
+/**
+ * Detect "permanent" channel-access delivery failures — cases where retrying
+ * the same send is guaranteed to fail until a human intervenes (bot removed
+ * from the channel, channel archived/deleted, workspace token revoked, etc.).
+ *
+ * This is used by the cron scheduler to auto-disable a job whose target
+ * channel is unreachable. Without this guard the scheduler keeps firing the
+ * job every cron tick, each failure capturing a fresh Sentry event with the
+ * same `channel_not_found` fingerprint — turning one broken job into a
+ * permanent noise source (see Sentry ODE-DEAMON-7).
+ *
+ * The detection is intentionally narrow: we only return `true` for errors
+ * whose remediation is *outside the daemon's control*. Transient failures
+ * (network blips, 5xx, rate limits) must remain retryable and therefore
+ * MUST NOT be classified as permanent here.
+ */
+
+// Tokens are matched case-insensitively against the stringified error.
+//
+// Slack:
+//   - channel_not_found: channel doesn't exist OR bot can't see it
+//   - not_in_channel: bot needs to be invited to post
+//   - is_archived / channel_is_archived: channel was archived
+//   - account_inactive: workspace user/account disabled
+//   - token_revoked / invalid_auth / not_authed: token no longer works
+//   - missing_scope: token lacks chat:write or similar — retrying won't help
+//
+// Discord (discord.js DiscordAPIError exposes `code`):
+//   - 10003 Unknown Channel
+//   - 50001 Missing Access
+//   - 50013 Missing Permissions
+//   - 50007 Cannot send messages to this user
+//
+// Lark (open-platform error codes vary; we match the common "permission
+// denied" / "chat not exist" message text):
+//   - chat_not_found / chat does not exist
+//   - permission denied (generic; only matched when paired with chat context)
+const PERMANENT_MESSAGE_TOKENS = [
+  // Slack
+  "channel_not_found",
+  "not_in_channel",
+  "is_archived",
+  "channel_is_archived",
+  "account_inactive",
+  "token_revoked",
+  "invalid_auth",
+  "not_authed",
+  "missing_scope",
+  // Lark
+  "chat_not_found",
+  "chat not exist",
+];
+
+// Discord.js surfaces the raw API code on `err.code` as a number.
+const PERMANENT_DISCORD_CODES = new Set<number>([
+  10003, // Unknown Channel
+  50001, // Missing Access
+  50013, // Missing Permissions
+  50007, // Cannot send messages to this user
+]);
+
+function stringifyError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}
+
+export function isPermanentChannelError(err: unknown): boolean {
+  if (!err) return false;
+  const message = stringifyError(err).toLowerCase();
+  for (const token of PERMANENT_MESSAGE_TOKENS) {
+    if (message.includes(token)) return true;
+  }
+  if (typeof err === "object" && err !== null) {
+    const code = (err as { code?: unknown }).code;
+    if (typeof code === "number" && PERMANENT_DISCORD_CODES.has(code)) {
+      return true;
+    }
+    // Slack SDK exposes the API error string on `err.data.error`.
+    const data = (err as { data?: { error?: unknown } }).data;
+    const apiError = data?.error;
+    if (typeof apiError === "string") {
+      const normalized = apiError.toLowerCase();
+      for (const token of PERMANENT_MESSAGE_TOKENS) {
+        if (normalized.includes(token)) return true;
+      }
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
## What

When a cron job's send hits a permanent channel-access error (`channel_not_found`, `not_in_channel`, `is_archived`, `token_revoked`, Discord `Missing Access`/`Unknown Channel`, Lark `chat_not_found`, …), the scheduler now disables the job and records the reason in `last_error`. The cron row stops firing until a human re-enables it.

## Why

Sentry [ODE-DEAMON-7](https://roombase-03.sentry.io/issues/7428990323/) — "IM slack send failed: channel_not_found" — captured 5 events over ~5 weeks, all from a single cron job whose bot had been removed from channel `C0ATGCJ0YK0`. Without intervention the job would keep firing every cron tick forever, each failure capturing a fresh Sentry event with the same fingerprint. This converts that infinite drip into a one-shot auto-disable + log.

This is a behaviour fix, not a Sentry-noise suppression. The Sentry event already correctly indicates "the bot may have been removed" (see existing `isBenignDeliveryFailure` test); the right product response is to stop firing the job, which is what this PR does.

## Design notes

- Cross-platform detection lives in `packages/shared/delivery/permanent-error.ts` alongside the existing `isRateLimitError`. It is intentionally narrow: transient failures (5xx, ECONNRESET, 429, socket hangups, Slack `message_not_found`) explicitly stay retryable.
- Two call sites in `runCronJob`:
  1. Success-path send: agent turn completed, but final delivery failed → if permanent, disable.
  2. Failure-notification send: agent turn already failed → if the *notify* error is permanent, disable. Critically the check is on the notify error, not the original turn error, so a transient agent timeout doesn't disable a job whose channel is fine.
- Disable bookkeeping (`patchCronJob({ enabled: false })` + `markCronJobFailed` + agent_result `failAgentResult`) is wrapped in best-effort try/catch so a SQLite hiccup never shadows the original delivery error.

## Tests

- 9 new unit tests in `permanent-error.test.ts` cover Slack message strings, Slack SDK `data.error` shape, Discord numeric `code`s (50001, 10003), Lark messages, and explicit negatives (rate limits, ECONNRESET, 5xx, `message_not_found`).
- Full suite still green: `bun test` → 414 pass, 1 skip, 0 fail.

## Out of scope

- Auto re-enable when access is restored. The right re-enable signal is a human `/invite` event, which is a separate observability problem; for now `ode cron enable <id>` is the recovery path.
- Auto-disabling tasks (`ode task`) — tasks are single-shot so the noise pattern is bounded; cron is the recurring case that needs this guard.