### PR TITLE
[codex] Improve Slack AI card status layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ode",
-  "version": "0.1.46",
+  "version": "0.1.47",
   "description": "Coding anywhere with your coding agents connected",
   "module": "packages/core/index.ts",
   "type": "module",

--- a/packages/core/kernel/request-run.ts
+++ b/packages/core/kernel/request-run.ts
@@ -94,6 +94,36 @@ function buildFinalResultStreamChunk(text: string): StatusStreamChunk | undefine
   };
 }
 
+const STREAM_STATUS_HEARTBEAT_MS = 1_000;
+
+function migrateLiveStatusMessageKey(params: {
+  liveEventHistory: Map<string, SessionEvent[]>;
+  liveParsedState: Map<string, SessionMessageState>;
+  oldKey: string;
+  newKey: string;
+  eventHistory?: SessionEvent[];
+}): void {
+  const { liveEventHistory, liveParsedState, oldKey, newKey, eventHistory } = params;
+  if (newKey === oldKey) return;
+
+  const history = eventHistory ?? liveEventHistory.get(oldKey);
+  if (history) {
+    liveEventHistory.delete(oldKey);
+    liveEventHistory.set(newKey, history);
+  }
+
+  const parsed = liveParsedState.get(oldKey);
+  if (parsed) {
+    liveParsedState.delete(oldKey);
+    liveParsedState.set(newKey, parsed);
+  }
+}
+
+function isNonRecoverableStreamStateError(error: unknown): boolean {
+  const message = String(error);
+  return /message_not_in_streaming_state|streaming_state_conflict/i.test(message);
+}
+
 type RunnerDeps = {
   im: IMAdapter;
   agent: AgentAdapter;
@@ -133,6 +163,7 @@ export type RunTrackedRequestParams = {
   onComplete: () => void;
   onFail: (message: string) => void;
   publishFinalText: (text: string) => Promise<void>;
+  progressIntervalMs?: number;
   /**
    * Optional. When the runner used the streaming API for live status, the
    * failure path needs to stop the stream before chat.update would 409 with
@@ -258,12 +289,13 @@ async function startKernelEventStreamWatcher(params: {
    * object as before — only the Map keys move.
    */
   function migrateMessageKey(newKey: string): void {
-    if (newKey === messageKey) return;
-    liveEventHistory.delete(messageKey);
-    liveEventHistory.set(newKey, eventHistory);
-    const parsed = liveParsedState.get(messageKey);
-    liveParsedState.delete(messageKey);
-    if (parsed) liveParsedState.set(newKey, parsed);
+    migrateLiveStatusMessageKey({
+      liveEventHistory,
+      liveParsedState,
+      oldKey: messageKey,
+      newKey,
+      eventHistory,
+    });
     messageKey = newKey;
   }
 
@@ -723,16 +755,19 @@ export async function runOpenRequest(
     },
   });
 
-  const progressIntervalMs = getMessageUpdateIntervalMs();
+  const legacyProgressIntervalMs = getMessageUpdateIntervalMs();
+  const progressIntervalMs = useStreaming ? STREAM_STATUS_HEARTBEAT_MS : legacyProgressIntervalMs;
   let lastHeartbeat = Date.now();
+  let lastLegacyStatusUpdateAt = useStreaming ? Date.now() : 0;
   const resolvedModel = options?.model?.providerID && options.model.modelID
     ? `${options.model.providerID}/${options.model.modelID}`
     : null;
   const providerId = deps.agent.getProviderForSession(sessionId);
+  const runMode = options?.agent === "plan" ? "plan mode" : "build mode";
 
   // One differ instance per run; keeps last-seen fingerprints so we only
   // send chunks for tools whose shape actually changed.
-  const streamDiffer: StatusStreamDiffer | null = useStreaming ? createStatusStreamDiffer() : null;
+  let streamDiffer: StatusStreamDiffer | null = useStreaming ? createStatusStreamDiffer() : null;
 
   async function stopTrackedStatusStream(reason: string, appendChunks?: StatusStreamChunk[]): Promise<void> {
     const streamTs = streamingStatusTs ?? request.statusStreamTs;
@@ -771,6 +806,23 @@ export async function runOpenRequest(
         statusStreamTs: undefined,
       }, { immediate: true });
     } catch (err) {
+      if (isNonRecoverableStreamStateError(err)) {
+        useStreaming = false;
+        streamingStatusTs = undefined;
+        request.statusStreamActive = false;
+        request.statusStreamTs = undefined;
+        updateActiveRequest(context.channelId, context.threadId, {
+          statusStreamActive: false,
+          statusStreamTs: undefined,
+        }, { immediate: true });
+        log.warn("Slack status stream was already non-streaming; cleared active stream state", {
+          reason,
+          channelId: context.channelId,
+          statusTs: streamTs,
+          error: String(err),
+        });
+        return;
+      }
       useStreaming = true;
       streamingStatusTs = streamTs;
       request.statusStreamActive = true;
@@ -786,6 +838,186 @@ export async function runOpenRequest(
         error: String(err),
       });
     }
+  }
+
+  async function switchToLegacyStatusFromSnapshot(
+    currentState: SessionMessageState,
+    extra?: {
+      failedStreamTs?: string;
+      oldStatusTs?: string;
+      oldStreamTs?: string;
+    }
+  ): Promise<void> {
+    const oldStatusKey = getStatusMessageKey(request);
+    useStreaming = false;
+    streamingStatusTs = undefined;
+    streamDiffer = null;
+    request.statusStreamActive = false;
+    request.statusStreamTs = undefined;
+
+    const statusText = buildStatusMessageForAgent({
+      agent: deps.agent,
+      request,
+      workingPath: cwd,
+      state: currentState,
+      statusMessageFormat: getUserGeneralSettings().defaultStatusMessageFormat,
+    });
+    const legacyStatusTs = await deps.im.sendMessage(
+      context.channelId,
+      context.replyThreadId,
+      statusText
+    );
+    if (typeof legacyStatusTs === "string" && legacyStatusTs.length > 0) {
+      statusTs = legacyStatusTs;
+      request.statusMessageTs = legacyStatusTs;
+      lastLegacyStatusUpdateAt = Date.now();
+      migrateLiveStatusMessageKey({
+        liveEventHistory,
+        liveParsedState,
+        oldKey: oldStatusKey,
+        newKey: getStatusMessageKey(request),
+      });
+      updateActiveRequest(context.channelId, context.threadId, {
+        statusMessageTs: legacyStatusTs,
+        statusStreamActive: false,
+        statusStreamTs: undefined,
+      }, { immediate: true });
+      log.info("Switched Slack status to legacy message after stream recreation failed", {
+        channelId: context.channelId,
+        statusTs: legacyStatusTs,
+        ...extra,
+      });
+      return;
+    }
+
+    updateActiveRequest(context.channelId, context.threadId, {
+      statusStreamActive: false,
+      statusStreamTs: undefined,
+    }, { immediate: true });
+  }
+
+  async function recreateStatusStreamFromSnapshot(currentState: SessionMessageState): Promise<boolean> {
+    if (!streamingRequested || !deps.im.startStatusStream || !deps.im.appendStatusStream) return false;
+
+    const oldStatusTs = request.statusMessageTs;
+    const oldStreamTs = streamingStatusTs ?? request.statusStreamTs;
+    const oldStatusKey = getStatusMessageKey(request);
+
+    try {
+      await deps.im.deleteMessage(context.channelId, oldStatusTs);
+    } catch (err) {
+      log.warn("Failed to delete stale Slack AI status card before recreation", {
+        channelId: context.channelId,
+        statusTs: oldStatusTs,
+        error: String(err),
+      });
+    }
+
+    let nextStatusTs: string | undefined;
+    try {
+      nextStatusTs = await deps.im.startStatusStream(
+        context.channelId,
+        context.replyThreadId,
+        {
+          recipientUserId: context.userId,
+          seedPlanTitle: `${providerLabel} is running...`,
+        }
+      );
+    } catch (err) {
+      log.warn("Failed to start replacement Slack AI status card; falling back to legacy status updates", {
+        channelId: context.channelId,
+        oldStatusTs,
+        oldStreamTs,
+        error: String(err),
+      });
+      await switchToLegacyStatusFromSnapshot(currentState, { oldStatusTs, oldStreamTs });
+      return false;
+    }
+    if (!nextStatusTs) {
+      log.warn("Failed to recreate Slack AI status card; falling back to legacy status updates", {
+        channelId: context.channelId,
+        oldStatusTs,
+        oldStreamTs,
+      });
+      await switchToLegacyStatusFromSnapshot(currentState, { oldStatusTs, oldStreamTs });
+      return false;
+    }
+
+    const nextDiffer = createStatusStreamDiffer();
+    const { chunks, commit } = nextDiffer.diff({
+      state: currentState,
+      workingPath: cwd,
+      startedAt: request.startedAt,
+      runMode,
+    });
+    try {
+      if (chunks.length > 0) {
+        await deps.im.appendStatusStream(context.channelId, nextStatusTs, chunks);
+      }
+      commit();
+    } catch (err) {
+      log.warn("Failed to seed replacement Slack AI status card; falling back to legacy status updates", {
+        channelId: context.channelId,
+        oldStatusTs,
+        oldStreamTs,
+        newStatusTs: nextStatusTs,
+        error: String(err),
+      });
+      if (deps.im.stopStatusStream) {
+        try {
+          await deps.im.stopStatusStream(context.channelId, nextStatusTs);
+        } catch (stopErr) {
+          log.debug("Failed to stop unseeded replacement Slack AI status card", {
+            channelId: context.channelId,
+            statusTs: nextStatusTs,
+            error: String(stopErr),
+          });
+        }
+      }
+      try {
+        await deps.im.deleteMessage(context.channelId, nextStatusTs);
+      } catch (deleteErr) {
+        log.debug("Failed to delete unseeded replacement Slack AI status card", {
+          channelId: context.channelId,
+          statusTs: nextStatusTs,
+          error: String(deleteErr),
+        });
+      }
+      await switchToLegacyStatusFromSnapshot(currentState, {
+        failedStreamTs: nextStatusTs,
+        oldStatusTs,
+        oldStreamTs,
+      });
+      return false;
+    }
+
+    statusTs = nextStatusTs;
+    request.statusMessageTs = nextStatusTs;
+    request.statusStreamActive = true;
+    request.statusStreamTs = nextStatusTs;
+    useStreaming = true;
+    streamingStatusTs = nextStatusTs;
+    streamDiffer = nextDiffer;
+    migrateLiveStatusMessageKey({
+      liveEventHistory,
+      liveParsedState,
+      oldKey: oldStatusKey,
+      newKey: getStatusMessageKey(request),
+    });
+
+    updateActiveRequest(context.channelId, context.threadId, {
+      statusMessageTs: nextStatusTs,
+      statusStreamActive: true,
+      statusStreamTs: nextStatusTs,
+    }, { immediate: true });
+
+    log.info("Recreated Slack AI status card after stale stream state", {
+      channelId: context.channelId,
+      oldStatusTs,
+      newStatusTs: nextStatusTs,
+      oldStreamTs,
+    });
+    return true;
   }
 
   const result = await runTrackedRequest({
@@ -839,6 +1071,7 @@ export async function runOpenRequest(
           useStreaming = false;
           streamingStatusTs = undefined;
         }
+        lastLegacyStatusUpdateAt = now;
       }
 
       // Streaming path: diff state -> chunks -> chat.appendStream.
@@ -849,6 +1082,7 @@ export async function runOpenRequest(
           state: currentState,
           workingPath: cwd,
           startedAt: request.startedAt,
+          runMode,
         });
         if (chunks.length > 0) {
           try {
@@ -859,6 +1093,32 @@ export async function runOpenRequest(
             // (idempotent for Slack's task_update / plan_update).
             commit();
           } catch (err) {
+            if (isNonRecoverableStreamStateError(err)) {
+              log.warn("Slack AI status stream is no longer active; recreating card", {
+                channelId: context.channelId,
+                statusTs,
+                error: String(err),
+              });
+              try {
+                if (await recreateStatusStreamFromSnapshot(currentState) || !useStreaming) {
+                  return;
+                }
+              } catch (recreateErr) {
+                log.warn("Slack AI status card recreation failed; falling back to legacy status updates", {
+                  channelId: context.channelId,
+                  statusTs,
+                  error: String(recreateErr),
+                });
+                useStreaming = false;
+                streamingStatusTs = undefined;
+                request.statusStreamActive = false;
+                request.statusStreamTs = undefined;
+                updateActiveRequest(context.channelId, context.threadId, {
+                  statusStreamActive: false,
+                  statusStreamTs: undefined,
+                }, { immediate: true });
+              }
+            }
             // appendStream failed (rate limit, streaming_state_conflict,
             // network blip…). Don't crash the tick and don't commit() —
             // the next tick will re-emit the still-pending delta.
@@ -887,6 +1147,17 @@ export async function runOpenRequest(
         statusMessageFormat: getUserGeneralSettings().defaultStatusMessageFormat,
       });
       if (!request.statusFrozen) {
+        if (now - lastLegacyStatusUpdateAt < legacyProgressIntervalMs) {
+          updateActiveRequest(context.channelId, context.threadId, {
+            statusMessageTs: request.statusMessageTs,
+            currentText: request.currentText,
+            todos: request.todos,
+            statusFrozen: request.statusFrozen,
+          });
+          return;
+        }
+        lastLegacyStatusUpdateAt = now;
+
         const updatedStatusTs = await deps.im.updateMessage(context.channelId, statusTs, statusText);
         if (typeof updatedStatusTs === "string" && updatedStatusTs !== statusTs) {
           statusTs = updatedStatusTs;
@@ -917,6 +1188,7 @@ export async function runOpenRequest(
             if (typeof replacementStatusTs === "string" && replacementStatusTs.length > 0) {
               statusTs = replacementStatusTs;
               request.statusMessageTs = replacementStatusTs;
+              lastLegacyStatusUpdateAt = Date.now();
               // Persist the new statusTs immediately so a crash before the
               // next debounced save doesn't leave disk pointing at the old
               // rate-limited TS (which would mis-route recovery edits).
@@ -956,6 +1228,7 @@ export async function runOpenRequest(
     onFail: (failureMessage) => {
       failActiveRequest(context.channelId, context.threadId, failureMessage);
     },
+    progressIntervalMs,
     publishFinalText: async (text) => {
       // If we were rendering status via the streaming API, terminate the
       // stream first. This converts the live plan card to a static block
@@ -1067,6 +1340,7 @@ export async function runTrackedRequest(
     onComplete,
     onFail,
     publishFinalText,
+    progressIntervalMs: requestedProgressIntervalMs,
     failureLogLabel,
     agentResultDetailId,
     threadKey,
@@ -1075,7 +1349,7 @@ export async function runTrackedRequest(
     model,
   } = params;
 
-  const progressIntervalMs = getMessageUpdateIntervalMs();
+  const progressIntervalMs = requestedProgressIntervalMs ?? getMessageUpdateIntervalMs();
   let progressInFlight = false;
   let progressTimer: ReturnType<typeof setInterval> | null = null;
   let stopWatcher: (() => void) | null = null;

--- a/packages/core/test/runtime-resilience-e2e.test.ts
+++ b/packages/core/test/runtime-resilience-e2e.test.ts
@@ -40,14 +40,17 @@ async function waitFor(check: () => boolean, timeoutMs = 1500): Promise<void> {
   }
 }
 
-async function withFastMessageUpdates<T>(run: () => Promise<T>): Promise<T> {
+async function withMessageUpdateInterval<T>(
+  intervalMs: number,
+  run: () => Promise<T>
+): Promise<T> {
   const current = loadOdeConfig();
   const previousValue = current.user.IM_MESSAGE_UPDATE_INTERVAL_MS;
   updateOdeConfig((config) => ({
     ...config,
     user: {
       ...config.user,
-      IM_MESSAGE_UPDATE_INTERVAL_MS: 250,
+      IM_MESSAGE_UPDATE_INTERVAL_MS: intervalMs,
     },
   }));
 
@@ -62,6 +65,10 @@ async function withFastMessageUpdates<T>(run: () => Promise<T>): Promise<T> {
       },
     }));
   }
+}
+
+async function withFastMessageUpdates<T>(run: () => Promise<T>): Promise<T> {
+  return withMessageUpdateInterval(250, run);
 }
 
 function createFakeIm(logs: {
@@ -119,6 +126,7 @@ function createFakeAgent(params?: {
   delayMs?: number;
   responseText?: string;
   errorMessage?: string;
+  emitToolEvent?: boolean;
 }) {
   const sentPrompts: string[] = [];
   const supportsEventStream = Boolean(params?.supportsEventStream);
@@ -143,6 +151,25 @@ function createFakeAgent(params?: {
     subscribeToSession: (_sessionId, handler) => {
       if (supportsEventStream) {
         const delay = params?.streamStopAfterMs ?? 10;
+        if (params?.emitToolEvent) {
+          setTimeout(() => {
+            handler({
+              type: "message.part.updated",
+              properties: {
+                part: {
+                  id: "tool_1",
+                  sessionID: "session-resilience",
+                  type: "tool",
+                  tool: "Read",
+                  state: {
+                    status: "running",
+                    input: { filePath: "/tmp/repo/README.md" },
+                  },
+                },
+              },
+            });
+          }, 10);
+        }
         const timer = setTimeout(() => {
           handler({
             type: "message.part.updated",
@@ -484,6 +511,184 @@ describe("core runtime resilience e2e", () => {
 
     deleteSession(channelId, threadId);
   });
+
+  it("recreates the Slack AI card when append finds a stale stream", async () => {
+    process.env.ODE_SLACK_STATUS_STREAMING = "1";
+    const logs = {
+      sends: [] as Array<{ channelId: string; threadId: string; text: string; messageTs: string }>,
+      starts: [] as Array<{ channelId: string; threadId: string; messageTs: string }>,
+      appends: [] as Array<{ channelId: string; messageTs: string; chunks: unknown[] }>,
+      stops: [] as Array<{ channelId: string; messageTs: string }>,
+      deletes: [] as Array<{ channelId: string; messageTs: string }>,
+    };
+    let nextSendTs = 0;
+    let nextStreamTs = 0;
+    let failedFirstAppend = false;
+    const im: IMAdapter = {
+      sendMessage: async (channelId, threadId, text) => {
+        nextSendTs += 1;
+        const messageTs = `ts-${nextSendTs}`;
+        logs.sends.push({ channelId, threadId, text, messageTs });
+        return messageTs;
+      },
+      updateMessage: async () => {},
+      deleteMessage: async (channelId, messageTs) => {
+        logs.deletes.push({ channelId, messageTs });
+      },
+      fetchThreadHistory: async () => null,
+      buildAgentContext: async () => ({ slack: { channelId: "C", threadId: "T", userId: "U" } }),
+      startStatusStream: async (channelId, threadId) => {
+        nextStreamTs += 1;
+        const messageTs = `stream-${nextStreamTs}`;
+        logs.starts.push({ channelId, threadId, messageTs });
+        return messageTs;
+      },
+      appendStatusStream: async (channelId, messageTs, chunks) => {
+        if (!failedFirstAppend && messageTs === "stream-1") {
+          failedFirstAppend = true;
+          throw new Error("message_not_in_streaming_state");
+        }
+        logs.appends.push({ channelId, messageTs, chunks });
+      },
+      stopStatusStream: async (channelId, messageTs) => {
+        logs.stops.push({ channelId, messageTs });
+      },
+    };
+    const { agent } = createFakeAgent({
+      supportsEventStream: true,
+      emitToolEvent: true,
+      streamStopAfterMs: 2500,
+      delayMs: 2600,
+      responseText: "finished after stream recreation",
+    });
+    const runtime = createCoreRuntime({ platform: "slack", im, agent });
+    const channelId = uniqueId("CE2E-STREAM-STALE");
+    const threadId = uniqueId("TE2E-STREAM-STALE");
+
+    await runtime.handleInboundEvent(toInboundEvent({
+      channelId,
+      threadId,
+      userId: "UE2E-stream-stale",
+      messageId: uniqueId("ME2E-stream-stale"),
+      text: "trigger stale stream recovery",
+    }));
+
+    await waitFor(
+      () => logs.stops.some((entry) => entry.messageTs === "stream-2"),
+      5000
+    );
+
+    expect(logs.starts.map((entry) => entry.messageTs)).toEqual(["stream-1", "stream-2"]);
+    expect(logs.deletes).toContainEqual({ channelId, messageTs: "stream-1" });
+    expect(logs.appends.some((entry) => entry.messageTs === "stream-2")).toBe(true);
+    const stream2Chunks = logs.appends
+      .filter((entry) => entry.messageTs === "stream-2")
+      .flatMap((entry) => entry.chunks);
+    expect(stream2Chunks).toContainEqual(expect.objectContaining({
+      id: "result",
+      status: "complete",
+      title: "Result",
+      type: "task_update",
+    }));
+    expect(logs.stops).toContainEqual({ channelId, messageTs: "stream-2" });
+
+    deleteSession(channelId, threadId);
+  }, 10_000);
+
+  it("cleans up a replacement Slack AI card when seeding it fails", async () => {
+    await withMessageUpdateInterval(5_000, async () => {
+      process.env.ODE_SLACK_STATUS_STREAMING = "1";
+      const logs = {
+        sends: [] as Array<{ channelId: string; threadId: string; text: string; messageTs: string }>,
+        starts: [] as Array<{ channelId: string; threadId: string; messageTs: string }>,
+        appends: [] as Array<{ channelId: string; messageTs: string; chunks: unknown[] }>,
+        stops: [] as Array<{ channelId: string; messageTs: string }>,
+        deletes: [] as Array<{ channelId: string; messageTs: string }>,
+        updates: [] as Array<{ channelId: string; messageTs: string; text: string }>,
+      };
+      let nextSendTs = 0;
+      let nextStreamTs = 0;
+      let failedFirstAppend = false;
+      const im: IMAdapter = {
+        sendMessage: async (channelId, threadId, text) => {
+          nextSendTs += 1;
+          const messageTs = `ts-${nextSendTs}`;
+          logs.sends.push({ channelId, threadId, text, messageTs });
+          return messageTs;
+        },
+        updateMessage: async (channelId, messageTs, text) => {
+          logs.updates.push({ channelId, messageTs, text });
+        },
+        deleteMessage: async (channelId, messageTs) => {
+          logs.deletes.push({ channelId, messageTs });
+        },
+        fetchThreadHistory: async () => null,
+        buildAgentContext: async () => ({ slack: { channelId: "C", threadId: "T", userId: "U" } }),
+        startStatusStream: async (channelId, threadId) => {
+          nextStreamTs += 1;
+          const messageTs = `stream-${nextStreamTs}`;
+          logs.starts.push({ channelId, threadId, messageTs });
+          return messageTs;
+        },
+        appendStatusStream: async (channelId, messageTs, chunks) => {
+          if (!failedFirstAppend && messageTs === "stream-1") {
+            failedFirstAppend = true;
+            throw new Error("message_not_in_streaming_state");
+          }
+          if (messageTs === "stream-2") {
+            throw new Error("rate_limited while seeding replacement stream");
+          }
+          logs.appends.push({ channelId, messageTs, chunks });
+        },
+        stopStatusStream: async (channelId, messageTs) => {
+          logs.stops.push({ channelId, messageTs });
+        },
+      };
+      const { agent } = createFakeAgent({
+        supportsEventStream: true,
+        emitToolEvent: true,
+        streamStopAfterMs: 2500,
+        delayMs: 3800,
+        responseText: "finished after replacement fallback",
+      });
+      const runtime = createCoreRuntime({ platform: "slack", im, agent });
+      const channelId = uniqueId("CE2E-STREAM-SEED-FAIL");
+      const threadId = uniqueId("TE2E-STREAM-SEED-FAIL");
+
+      await runtime.handleInboundEvent(toInboundEvent({
+        channelId,
+        threadId,
+        userId: "UE2E-stream-seed-fail",
+        messageId: uniqueId("ME2E-stream-seed-fail"),
+        text: "trigger replacement stream seed failure",
+      }));
+
+      await waitFor(() => {
+        const savedRequest = loadSession(channelId, threadId)?.activeRequest;
+        return Boolean(
+          savedRequest?.statusStreamActive === false &&
+            savedRequest.statusMessageTs &&
+            logs.sends.some((entry) => entry.messageTs === savedRequest.statusMessageTs)
+        );
+      }, 12_000);
+
+      const savedRequest = loadSession(channelId, threadId)?.activeRequest;
+      const fallbackMessage = logs.sends.find(
+        (entry) => entry.messageTs === savedRequest?.statusMessageTs
+      );
+      await sleep(1_200);
+      expect(logs.starts.map((entry) => entry.messageTs)).toEqual(["stream-1", "stream-2"]);
+      expect(logs.deletes).toContainEqual({ channelId, messageTs: "stream-1" });
+      expect(logs.stops).toContainEqual({ channelId, messageTs: "stream-2" });
+      expect(logs.deletes).toContainEqual({ channelId, messageTs: "stream-2" });
+      expect(savedRequest?.statusStreamActive).toBe(false);
+      expect(savedRequest?.statusStreamTs).toBeUndefined();
+      expect(fallbackMessage).toBeDefined();
+      expect(logs.updates.some((entry) => entry.messageTs === fallbackMessage?.messageTs)).toBe(false);
+
+      deleteSession(channelId, threadId);
+    });
+  }, 20_000);
 
   it("does not crash when the initial status send throws", async () => {
     const logs = { sends: [], updates: [] } as {

--- a/packages/utils/status-stream.ts
+++ b/packages/utils/status-stream.ts
@@ -14,13 +14,11 @@
 //
 // Design notes:
 //   - We render one complete live-status card: run context, current phase,
-//     todo slots, and recent-tool slots all update in place inside the same
+//     tasks, and tool calling all update in place inside the same
 //     Slack plan card.
-//   - We use stable synthetic task_update ids (meta/context, todo:0, tool:0,
+//   - We use stable synthetic task_update ids (meta/context, group:tasks,
 //     etc.) instead of raw tool ids. Slack updates rows with the same id, so
 //     long runs stay compact instead of appending an unbounded tool log.
-//     Empirically, Slack may accumulate details/output text for repeated ids;
-//     reusable rows keep dynamic content in title/status only.
 //   - We only emit a chunk when a row's effective shape (title/status/output)
 //     actually changes — Slack drops near-duplicate appends but emitting them
 //     anyway wastes the Tier-4 budget (100/min).
@@ -84,13 +82,6 @@ function mapTodoStatus(status: string): TaskStatus {
   }
 }
 
-function normalizePhaseForTitle(phaseStatus?: string): string | undefined {
-  const phase = phaseStatus?.trim();
-  if (!phase) return undefined;
-  if (/^(running|finished)\s+tool:/i.test(phase)) return "Working";
-  return phase;
-}
-
 function formatCompactCount(value: number): string {
   if (!Number.isFinite(value)) return "0";
   const sign = value < 0 ? "-" : "";
@@ -139,38 +130,33 @@ function compactPath(path: string): string {
   return trimmed;
 }
 
-function buildPlanTitle(state: SessionMessageState): string {
+function buildPlanTitle(state: SessionMessageState, startedAt: number): string {
   const title = state.sessionTitle?.trim() || state.agent?.trim() || "Working";
-  const phase = normalizePhaseForTitle(state.phaseStatus) || "Working";
-  const totalTokens = state.tokenUsage?.total;
-  const tokenPart = typeof totalTokens === "number" && totalTokens > 0
-    ? `${formatCompactCount(totalTokens)} tokens`
-    : undefined;
-  return truncateField([title, phase, tokenPart].filter(Boolean).join(" · "), 160);
+  const elapsed = formatElapsedTime(startedAt);
+  return truncateField([title, state.agent?.trim(), state.model?.trim(), elapsed].filter(Boolean).join(" · "), 160);
 }
 
-function buildContextRow(state: SessionMessageState, workingPath: string): TaskRow {
-  const details = [
-    state.model?.trim(),
-    state.agent?.trim(),
-  ].filter(Boolean).join(" · ");
+function buildContextRow(runMode: string | undefined, workingPath: string): TaskRow {
+  const mode = runMode?.trim() || "build mode";
   return {
     id: "meta:context",
     title: "Run context",
     status: "complete",
-    ...(details ? { details } : {}),
+    details: mode,
     output: truncateField(compactPath(workingPath), 180),
   };
 }
 
-function buildPhaseRow(state: SessionMessageState): TaskRow {
+function buildCurrentStatusRow(state: SessionMessageState): TaskRow {
   const phase = state.phaseStatus?.trim() || "Working";
+  const detail = state.thinkingText?.trim() || state.currentText?.trim();
   const waitingForUser = /\b(waiting|question|approval|permission|confirm|choose|select|input)\b/i.test(phase);
   const finalizing = /\b(done|complete|completed|finalizing|finalized)\b/i.test(phase);
   return {
     id: "meta:phase",
-    title: truncateField(`Current phase: ${phase}`, 180),
+    title: "Current status",
     status: waitingForUser ? "in_progress" : finalizing ? "complete" : "in_progress",
+    details: truncateField(detail ? `${phase}: ${detail}` : phase, 220),
   };
 }
 
@@ -233,19 +219,6 @@ function buildTaskTitle(tool: SessionTool, workingPath: string): string {
   return title ? `${display} ${trimToolPath(title, workingPath)}` : display;
 }
 
-function fingerprintTool(tool: SessionTool, workingPath: string): RowFingerprint {
-  const status = mapToolStatus(tool.status);
-  const title = buildTaskTitle(tool, workingPath);
-  return { title, status };
-}
-
-function fingerprintTodo(todo: SessionTodo): RowFingerprint {
-  return {
-    title: truncateField(todo.content || "Task", 180),
-    status: mapTodoStatus(todo.status),
-  };
-}
-
 function fingerprintsEqual(a: RowFingerprint, b: RowFingerprint): boolean {
   return (
     a.title === b.title &&
@@ -260,35 +233,82 @@ function selectRecentTools(tools: SessionTool[]): SessionTool[] {
   return visible.slice(Math.max(0, visible.length - MAX_TOOL_ROWS));
 }
 
+function aggregateStatuses(statuses: TaskStatus[]): TaskStatus {
+  if (statuses.includes("error")) return "error";
+  if (statuses.includes("in_progress")) return "in_progress";
+  if (statuses.length > 0 && statuses.every((status) => status === "complete")) return "complete";
+  return "pending";
+}
+
+function formatTodoStatus(status: string): string {
+  switch (mapTodoStatus(status)) {
+    case "complete":
+      return "done";
+    case "in_progress":
+      return "in progress";
+    case "error":
+      return "error";
+    case "pending":
+    default:
+      return "pending";
+  }
+}
+
+function formatToolStatus(status: string): string {
+  switch (mapToolStatus(status)) {
+    case "complete":
+      return "done";
+    case "in_progress":
+      return "running";
+    case "error":
+      return "error";
+    case "pending":
+    default:
+      return "pending";
+  }
+}
+
+function buildTasksRow(todos: SessionTodo[]): TaskRow {
+  const visibleTodos = todos.slice(0, MAX_TODO_ROWS);
+  const details = visibleTodos.length > 0
+    ? visibleTodos.map((todo) => `- ${formatTodoStatus(todo.status)}: ${todo.content || "Task"}`).join("\n")
+    : "- pending: waiting for task updates";
+  return {
+    id: "group:tasks",
+    title: "Tasks",
+    status: aggregateStatuses(visibleTodos.map((todo) => mapTodoStatus(todo.status))),
+    details: truncateField(details, 220),
+  };
+}
+
+function buildToolsRow(tools: SessionTool[], workingPath: string): TaskRow {
+  const visibleTools = selectRecentTools(tools);
+  const details = visibleTools.length > 0
+    ? visibleTools.map((tool) => `- ${formatToolStatus(tool.status)}: ${buildTaskTitle(tool, workingPath)}`).join("\n")
+    : "- pending: no active tool call";
+  return {
+    id: "group:tools",
+    title: "Tool calling",
+    status: aggregateStatuses(visibleTools.map((tool) => mapToolStatus(tool.status))),
+    details: truncateField(details, 220),
+  };
+}
+
 function buildTaskRows(input: StatusStreamDiffInput): TaskRow[] {
-  const { state, workingPath } = input;
-  const rows: TaskRow[] = [
-    buildContextRow(state, workingPath),
-    buildPhaseRow(state),
+  const { state, workingPath, runMode } = input;
+  return [
+    buildContextRow(runMode, workingPath),
+    buildCurrentStatusRow(state),
+    buildTasksRow(state.todos),
+    buildToolsRow(state.tools, workingPath),
   ];
-
-  state.todos.slice(0, MAX_TODO_ROWS).forEach((todo, index) => {
-    rows.push({
-      id: `todo:${index}`,
-      ...fingerprintTodo(todo),
-    });
-  });
-
-  const selectedTools = selectRecentTools(state.tools);
-  selectedTools.forEach((tool, index) => {
-    rows.push({
-      id: `tool:${index}`,
-      ...fingerprintTool(tool, workingPath),
-    });
-  });
-
-  return rows;
 }
 
 export type StatusStreamDiffInput = {
   state: SessionMessageState;
   workingPath: string;
   startedAt: number;
+  runMode?: string;
 };
 
 export type StatusStreamDiffResult = {
@@ -326,7 +346,7 @@ export function createStatusStreamDiffer(): StatusStreamDiffer {
   let lastPlanTitle: string | undefined;
 
   return {
-    diff({ state, workingPath, startedAt }) {
+    diff({ state, workingPath, startedAt, runMode }) {
       const chunks: StatusStreamChunk[] = [];
       // Pending updates accumulated this tick. Only applied to
       // lastFingerprints / lastPlanTitle when commit() runs, so a network
@@ -336,14 +356,14 @@ export function createStatusStreamDiffer(): StatusStreamDiffer {
       let pendingPlanTitle: string | undefined;
       let planTitleChanged = false;
 
-      const planTitle = buildPlanTitle(state);
+      const planTitle = buildPlanTitle(state, startedAt);
       if (planTitle !== lastPlanTitle) {
         chunks.push({ type: "plan_update", title: planTitle });
         pendingPlanTitle = planTitle;
         planTitleChanged = true;
       }
 
-      for (const row of buildTaskRows({ state, workingPath, startedAt })) {
+      for (const row of buildTaskRows({ state, workingPath, startedAt, runMode })) {
         const { id, ...fp } = row;
         const prev = lastFingerprints.get(id);
         if (prev && fingerprintsEqual(prev, fp)) continue;

--- a/packages/utils/test/status-stream.test.ts
+++ b/packages/utils/test/status-stream.test.ts
@@ -24,19 +24,32 @@ describe("createStatusStreamDiffer", () => {
       workingPath: cwd,
       startedAt: Date.now(),
     });
-    expect(chunks).toHaveLength(3);
-    expect(chunks[0]).toEqual({ type: "plan_update", title: "Test · Working" });
+    expect(chunks).toHaveLength(5);
+    expect(chunks[0]).toMatchObject({ type: "plan_update" });
+    expect(chunks[0]?.type === "plan_update" ? chunks[0].title : "").toMatch(/^Test · \d+s$/);
     expect(chunks[1]).toMatchObject({
       type: "task_update",
       id: "meta:context",
       title: "Run context",
       status: "complete",
+      details: "build mode",
+      output: cwd,
     });
     expect(chunks[2]).toMatchObject({
       type: "task_update",
       id: "meta:phase",
-      title: "Current phase: Working",
+      title: "Current status",
       status: "in_progress",
+    });
+    expect(chunks[3]).toMatchObject({
+      type: "task_update",
+      id: "group:tasks",
+      title: "Tasks",
+    });
+    expect(chunks[4]).toMatchObject({
+      type: "task_update",
+      id: "group:tools",
+      title: "Tool calling",
     });
     commit();
   });
@@ -49,13 +62,31 @@ describe("createStatusStreamDiffer", () => {
     expect(second.chunks).toHaveLength(0);
   });
 
+  it("shows the requested run mode in the Run context row", () => {
+    const differ = createStatusStreamDiffer();
+    const { chunks } = differ.diff({
+      state: baseState(),
+      workingPath: cwd,
+      startedAt: 0,
+      runMode: "plan mode",
+    });
+    const contextChunk = chunks.find((chunk) => chunk.type === "task_update" && chunk.id === "meta:context");
+    expect(contextChunk).toMatchObject({
+      type: "task_update",
+      id: "meta:context",
+      title: "Run context",
+      details: "plan mode",
+      output: cwd,
+    });
+  });
+
   it("retries the same chunks on the next tick when commit() is skipped", () => {
     // Regression: a transient appendStream failure used to leave the
     // differ's fingerprint cache advanced anyway, so the next tick would
     // emit no chunks and the failed update was permanently lost.
     const differ = createStatusStreamDiffer();
     const first = differ.diff({ state: baseState(), workingPath: cwd, startedAt: 0 });
-    expect(first.chunks).toHaveLength(3);
+    expect(first.chunks).toHaveLength(5);
     // Simulate appendStream throwing — caller does NOT invoke commit().
     const second = differ.diff({ state: baseState(), workingPath: cwd, startedAt: 0 });
     expect(second.chunks).toEqual(first.chunks);
@@ -78,11 +109,12 @@ describe("createStatusStreamDiffer", () => {
     if (taskChunk?.type === "task_update") {
       expect(taskChunk.id).toBe("meta:context");
     }
-    const toolChunk = first.chunks.find((c) => c.type === "task_update" && c.id === "tool:0");
+    const toolChunk = first.chunks.find((c) => c.type === "task_update" && c.id === "group:tools");
     expect(toolChunk).toBeDefined();
     if (toolChunk?.type === "task_update") {
       expect(toolChunk.status).toBe("in_progress");
-      expect(toolChunk.title).toContain("git status");
+      expect(toolChunk.title).toBe("Tool calling");
+      expect(toolChunk.details).toContain("git status");
     }
 
     const second = differ.diff({ state, workingPath: cwd, startedAt: 0 });
@@ -115,11 +147,12 @@ describe("createStatusStreamDiffer", () => {
       startedAt: 0,
     });
     commit();
-    const transition = chunks.find((c) => c.type === "task_update" && c.id === "tool:0");
+    const transition = chunks.find((c) => c.type === "task_update" && c.id === "group:tools");
     expect(transition).toBeDefined();
     if (transition?.type === "task_update") {
       expect(transition.status).toBe("complete");
       expect(transition.output).toBeUndefined();
+      expect(transition.details).toContain("git status");
     }
   });
 
@@ -137,7 +170,7 @@ describe("createStatusStreamDiffer", () => {
     });
     commit();
     expect(chunks).not.toContainEqual({ type: "plan_update", title: "Running tool: bash" });
-    expect(chunks).toContainEqual({ type: "task_update", id: "meta:phase", title: "Current phase: Running tool: bash", status: "in_progress" });
+    expect(chunks).toContainEqual({ type: "task_update", id: "meta:phase", title: "Current status", status: "in_progress", details: "Running tool: bash" });
   });
 
   it("renders todos ahead of recent tool slots", () => {
@@ -162,10 +195,13 @@ describe("createStatusStreamDiffer", () => {
     const taskIds = chunks
       .filter((chunk) => chunk.type === "task_update")
       .map((chunk) => chunk.id);
-    expect(taskIds).toEqual(["meta:context", "meta:phase", "todo:0", "todo:1", "tool:0"]);
+    expect(taskIds).toEqual(["meta:context", "meta:phase", "group:tasks", "group:tools"]);
+    const taskChunk = chunks.find((chunk) => chunk.type === "task_update" && chunk.id === "group:tasks");
+    expect(taskChunk?.type === "task_update" ? taskChunk.details : "").toContain("Inspect current implementation");
+    expect(taskChunk?.type === "task_update" ? taskChunk.details : "").toContain("Patch Slack stream layout");
   });
 
-  it("uses fixed recent-tool slots instead of appending raw tool ids forever", () => {
+  it("keeps recent tools grouped in one stable row instead of appending raw tool ids forever", () => {
     const differ = createStatusStreamDiffer();
     const makeTools = (count: number) => Array.from({ length: count }, (_, index) => ({
       id: `tool-${index + 1}`,
@@ -183,9 +219,9 @@ describe("createStatusStreamDiffer", () => {
     first.commit();
     const firstToolIds = first.chunks
       .filter((chunk) => chunk.type === "task_update")
-      .filter((chunk) => chunk.id.startsWith("tool:"))
+      .filter((chunk) => chunk.id === "group:tools")
       .map((chunk) => chunk.id);
-    expect(firstToolIds).toEqual(["tool:0", "tool:1", "tool:2", "tool:3", "tool:4", "tool:5"]);
+    expect(firstToolIds).toEqual(["group:tools"]);
 
     const second = differ.diff({
       state: baseState({ tools: makeTools(7) }),
@@ -194,9 +230,9 @@ describe("createStatusStreamDiffer", () => {
     });
     const secondToolIds = second.chunks
       .filter((chunk) => chunk.type === "task_update")
-      .filter((chunk) => chunk.id.startsWith("tool:"))
+      .filter((chunk) => chunk.id === "group:tools")
       .map((chunk) => chunk.id);
-    expect(secondToolIds).toEqual(["tool:0", "tool:1", "tool:2", "tool:3", "tool:4", "tool:5"]);
+    expect(secondToolIds).toEqual(["group:tools"]);
   });
 
   it("builds a plain-text final title for Slack plan_update chunks", () => {


### PR DESCRIPTION
## Summary

- Reshape Slack AI cards around the tested layout: title + agent + model + elapsed time, then stable rows for Run context, Current status, Tasks, and Tool calling.
- Show build/plan mode and folder in Run context, and group task/tool details into stable secondary-list rows.
- Update Slack streaming status cadence to one-second heartbeats for AI cards, and recreate a stale card if Slack reports `message_not_in_streaming_state` or `streaming_state_conflict` while appending.
- Bump Ode version to `0.1.47`.

## Validation

- `bun run --bun tsc --noEmit`
- `bun test packages/utils/test/status-stream.test.ts packages/core/test/runtime-resilience-e2e.test.ts`
- `bun test`
- `git diff --check`
