### PR TITLE
Remove hard agent-turn timeout from cron/task schedulers

### DIFF
--- a/packages/core/cron/scheduler.ts
+++ b/packages/core/cron/scheduler.ts
@@ -54,15 +54,16 @@ const CRON_PREPARE_TIMEOUT_MS = parsePositiveIntEnv(
   2 * 60_000
 );
 
-/**
- * Hard upper bound for the actual agent turn (`agent.sendMessage`). OpenCode
- * sessions can wedge waiting on approvals or remote provider calls; we bound
- * the run so a stuck turn doesn't permanently lock out the job.
- */
-const CRON_AGENT_TIMEOUT_MS = parsePositiveIntEnv(
-  process.env.ODE_CRON_AGENT_TIMEOUT_MS,
-  2 * 60 * 60_000
-);
+// NOTE: There is intentionally no hard upper bound on the agent turn itself
+// (`agent.sendMessage`) anymore. Cron jobs that drive long agent workflows
+// (Sentry triage, board grooming, multi-PR sweeps) routinely exceeded the
+// previous 2h bound and surfaced as `Request timed out` failures even though
+// the underlying agent was making progress. We rely on:
+//   * the prepare-step timeout above to guarantee the in-process
+//     `runningJobIds` lock can't be wedged by a hung session/worktree setup;
+//   * the agent adapter's own per-request handling for genuinely stuck turns.
+// If a turn really hangs forever, the daemon restart path
+// (`reconcileInterruptedCronJobs`) will still surface and retry it.
 
 function parsePositiveIntEnv(raw: string | undefined, fallback: number): number {
   if (!raw) return fallback;
@@ -336,17 +337,13 @@ async function runCronJob(job: CronJobRecord, minuteStartMs: number): Promise<vo
       });
     }
 
-    const responses = await withTimeout(
-      agent.sendMessage(
-        job.channelId,
-        sessionId,
-        job.messageText,
-        cwd,
-        options,
-        buildCronAgentContext(job, runId)
-      ),
-      CRON_AGENT_TIMEOUT_MS,
-      "Cron agent turn"
+    const responses = await agent.sendMessage(
+      job.channelId,
+      sessionId,
+      job.messageText,
+      cwd,
+      options,
+      buildCronAgentContext(job, runId)
     );
     const finalText = buildFinalResponseText(responses) ?? "_Done_";
 

--- a/packages/core/tasks/scheduler.ts
+++ b/packages/core/tasks/scheduler.ts
@@ -70,18 +70,14 @@ const TASK_PREPARE_TIMEOUT_MS = parsePositiveIntEnv(
   2 * 60_000,
 );
 
-/**
- * Hard upper bound for the actual agent turn (`agent.sendMessage`). OpenCode
- * sessions can wedge waiting on approvals or remote provider calls; we bound
- * the run so a stuck turn doesn't permanently lock out the task row. Matches
- * the cron default (2h) — tasks tend to be heavier since they often do
- * scripted long-running work, but anything longer than 2h should really be
- * split into multiple scheduled runs.
- */
-const TASK_AGENT_TIMEOUT_MS = parsePositiveIntEnv(
-  process.env.ODE_TASK_AGENT_TIMEOUT_MS,
-  2 * 60 * 60_000,
-);
+// NOTE: There is intentionally no hard upper bound on the agent turn itself
+// (`agent.sendMessage`) anymore. Tasks often drive long-running scripted
+// work (deploys, batch fixes, scheduled audits) that legitimately runs for
+// hours, and the previous 2h cap was surfacing as `Request timed out` even
+// when the agent was making progress. Hung sessions are still bounded by:
+//   * the prepare-step timeout above (covers session/worktree setup);
+//   * the agent adapter's own per-request handling;
+//   * `reconcileInterruptedTasks` on daemon restart.
 
 function parsePositiveIntEnv(raw: string | undefined, fallback: number): number {
   if (!raw) return fallback;
@@ -415,17 +411,13 @@ async function runTask(task: TaskRecord): Promise<void> {
       });
     }
 
-    const responses = await withTimeout(
-      agent.sendMessage(
-        task.channelId,
-        sessionId,
-        task.messageText,
-        cwd,
-        options,
-        buildTaskAgentContext(task),
-      ),
-      TASK_AGENT_TIMEOUT_MS,
-      "Task agent turn",
+    const responses = await agent.sendMessage(
+      task.channelId,
+      sessionId,
+      task.messageText,
+      cwd,
+      options,
+      buildTaskAgentContext(task),
     );
     const finalText = buildFinalResponseText(responses) ?? "_Done_";
 


### PR DESCRIPTION
## Why

The cron scheduler (`packages/core/cron/scheduler.ts`) and one-time task scheduler (`packages/core/tasks/scheduler.ts`) both wrapped `agent.sendMessage` in a 2h hard timeout via `withTimeout` (configurable via `ODE_CRON_AGENT_TIMEOUT_MS` / `ODE_TASK_AGENT_TIMEOUT_MS`).

This bound was tripping on legitimate long-running agent workflows — Sentry triage, Linear board grooming, multi-PR sweeps, scheduled audits — and surfacing in Slack as:

> *Cron job failed:* <title>
> Request timed out

even though the underlying agent was making progress. Verified on this machine: two recent runs of \`Sentry检查\` and \`PM推进\` both failed with \`CronStepTimeoutError: Cron agent turn timed out after 7200000ms\` (= exactly the 2h default).

## What

- Drop the \`withTimeout\` wrap around \`agent.sendMessage\` in both schedulers.
- Remove the \`CRON_AGENT_TIMEOUT_MS\` / \`TASK_AGENT_TIMEOUT_MS\` constants and the corresponding \`ODE_CRON_AGENT_TIMEOUT_MS\` / \`ODE_TASK_AGENT_TIMEOUT_MS\` env vars.
- Leave a comment explaining the decision and the remaining safety nets.

## What we keep

- \`CRON_PREPARE_TIMEOUT_MS\` / \`TASK_PREPARE_TIMEOUT_MS\` (2 min): still wraps session creation + worktree setup so a wedged \`getOrCreateSession\` / \`git worktree add\` can't hold the in-process \`runningJobIds\` / \`runningTaskIds\` lock indefinitely (which would otherwise make manual "Run now" return 409 forever).
- \`reconcileInterruptedCronJobs\` / \`reconcileInterruptedTasks\`: still recovers stuck runs on daemon restart.
- The agent adapter's own per-request error handling.

## Verification

- \`bun run typecheck\` clean.
- \`bun test packages/core/test\` → 78 pass / 1 skip / 0 fail.